### PR TITLE
fix(agents): include system paths in agent systemd services PATH

### DIFF
--- a/modules/os/agents/chrome.nix
+++ b/modules/os/agents/chrome.nix
@@ -26,9 +26,11 @@ in
       }
     ];
 
-    # Chromium package available system-wide for chrome agents
+    # Chromium and Node.js available system-wide for chrome agents.
+    # Node.js is required for the chrome-devtools-mcp server (stdio transport via npx/node).
     environment.systemPackages = [
       pkgs.chromium
+      pkgs.nodejs
     ];
 
     # Chromium as system services per chrome agent

--- a/modules/os/agents/home-manager.nix
+++ b/modules/os/agents/home-manager.nix
@@ -13,6 +13,7 @@ with lib;
 let
   agentsLib = import ./lib.nix { inherit lib config pkgs; };
   inherit (agentsLib) osCfg cfg topDomain agentPublicKey allKeysForAgent;
+  inherit (agentsLib) globalAgentChromeDebugPort;
 in
 {
   config = optionalAttrs (options ? home-manager) {
@@ -20,6 +21,10 @@ in
       users = mapAttrs' (name: agentCfg:
         let
           username = "agent-${name}";
+          # Capture NixOS system pkgs before they're shadowed by home-manager's pkgs
+          # argument. The keystone overlay is applied at the system level, so we use
+          # this to resolve keystone package store paths for MCP server commands.
+          sysPkgs = pkgs;
         in
         nameValuePair username ({ pkgs, ... }: {
           imports = [ ../../terminal/default.nix ];
@@ -102,6 +107,26 @@ in
                   esac
                 done
               '';
+            };
+            cliCodingAgents = {
+              enable = mkDefault true;
+              # Agents need to see ignored files (e.g. .agents submodule)
+              respectGitIgnore = mkDefault false;
+              mcpServers = {
+                deepwork = {
+                  command = "${sysPkgs.keystone.deepwork}/bin/deepwork";
+                  args = [ "serve" "--path" "." "--external-runner" "claude" "--platform" "claude" ];
+                };
+              } // optionalAttrs (agentCfg.chrome.enable && agentCfg.chrome.mcp.enable) {
+                chrome-devtools = {
+                  command = "${sysPkgs.keystone.chrome-devtools-mcp}/bin/chrome-devtools-mcp";
+                  args = [ "--browserUrl" "http://127.0.0.1:${toString (globalAgentChromeDebugPort name agentCfg)}" ];
+                };
+              } // mapAttrs (_: srv: {
+                inherit (srv) command args;
+              } // optionalAttrs (srv.env != {}) {
+                inherit (srv) env;
+              }) agentCfg.mcp.servers;
             };
           };
 

--- a/modules/os/agents/notes.nix
+++ b/modules/os/agents/notes.nix
@@ -76,7 +76,7 @@ in
             # bash, git, claude, himalaya, etc.). Nix and /run/current-system/sw/bin
             # are added as fallbacks for system tools not in the profile.
             environment = {
-              PATH = lib.mkForce "/etc/profiles/per-user/${username}/bin:${lib.makeBinPath [ pkgs.nix ]}:/run/current-system/sw/bin";
+              PATH = lib.mkForce "/etc/profiles/per-user/${username}/bin:/run/wrappers/bin:/run/current-system/sw/bin:${lib.makeBinPath [ pkgs.nix ]}";
               SSH_AUTH_SOCK = "/run/agent-${name}-ssh-agent/agent.sock";
               GIT_SSH_COMMAND = "${pkgs.openssh}/bin/ssh -o StrictHostKeyChecking=accept-new";
             };
@@ -97,7 +97,7 @@ in
           "agent-${name}-scheduler" = {
             description = "Daily scheduler for ${username}";
             unitConfig.ConditionUser = username;
-            environment.PATH = lib.mkForce "/etc/profiles/per-user/${username}/bin:${lib.makeBinPath [ pkgs.nix ]}:/run/current-system/sw/bin";
+            environment.PATH = lib.mkForce "/etc/profiles/per-user/${username}/bin:/run/wrappers/bin:/run/current-system/sw/bin:${lib.makeBinPath [ pkgs.nix ]}";
             serviceConfig = {
               Type = "oneshot";
               SyslogIdentifier = "agent-${name}-scheduler";

--- a/modules/os/agents/scripts/scheduler.sh
+++ b/modules/os/agents/scripts/scheduler.sh
@@ -4,6 +4,14 @@
 # Pure bash, no LLM.
 set -eo pipefail
 
+# Sanity check: Ensure required system utilities are available
+for cmd in bash tr systemctl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: Required command '$cmd' not found in PATH" >&2
+    exit 1
+  fi
+done
+
 # Config values substituted by NixOS module via pkgs.replaceVars
 NOTES_DIR="@notesDir@"
 AGENT_NAME="@agentName@"

--- a/modules/os/agents/scripts/task-loop.sh
+++ b/modules/os/agents/scripts/task-loop.sh
@@ -4,6 +4,14 @@
 # home-manager profile PATH set in notes.nix — no individual path resolution.
 set -eo pipefail
 
+# Sanity check: Ensure required system utilities are available
+for cmd in bash tr systemctl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: Required command '$cmd' not found in PATH" >&2
+    exit 1
+  fi
+done
+
 # Config values substituted by NixOS module via pkgs.replaceVars
 NOTES_DIR="@notesDir@"
 MAX_TASKS="@maxTasks@"

--- a/modules/terminal/cli-coding-agent-configs.nix
+++ b/modules/terminal/cli-coding-agent-configs.nix
@@ -1,0 +1,87 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.keystone.terminal.cliCodingAgents;
+  terminalCfg = config.keystone.terminal;
+in {
+  options.keystone.terminal.cliCodingAgents = {
+    enable = mkEnableOption "global configurations for AI coding agent CLIs";
+
+    mcpServers = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          command = mkOption {
+            type = types.str;
+            description = "The command to run the MCP server.";
+          };
+          args = mkOption {
+            type = types.listOf types.str;
+            default = [];
+            description = "Arguments to pass to the MCP server command.";
+          };
+          env = mkOption {
+            type = types.attrsOf types.str;
+            default = {};
+            description = ''
+              Environment variables for the MCP server.
+              WARNING: These values are stored in the Nix store in plain text and are world-readable.
+              DO NOT put secrets (API keys, tokens) here. Use agent-specific environment variables
+              or credential managers instead.
+            '';
+          };
+        };
+      });
+      default = {};
+      description = "MCP servers to configure globally across supported AI CLIs.";
+    };
+
+    respectGitIgnore = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether Gemini CLI should respect .gitignore files.
+        Setting this to false may leak ignored secrets into the AI context.
+      '';
+    };
+  };
+
+  config = mkIf (terminalCfg.enable && cfg.enable) {
+    home.file = {
+      # Gemini CLI
+      # Location: ~/.gemini/settings.json
+      ".gemini/settings.json".text = builtins.toJSON {
+        mcpServers = cfg.mcpServers;
+        context = {
+          fileFiltering = {
+            inherit (cfg) respectGitIgnore;
+          };
+        };
+      };
+
+      # Claude Code / Claude Desktop
+      # Location: ~/.claude.json
+      ".claude.json".text = builtins.toJSON {
+        mcpServers = cfg.mcpServers;
+      };
+
+      # OpenCode
+      # Location: ~/.config/opencode/opencode.json
+      ".config/opencode/opencode.json".text = builtins.toJSON {
+        mcp = mapAttrs (_: srv: {
+          type = "local";
+          command = [ srv.command ] ++ srv.args;
+          enabled = true;
+        } // optionalAttrs (srv.env != {}) {
+          inherit (srv) env;
+        }) cfg.mcpServers;
+      };
+
+      # TODO: Enable when codex supports global settings file
+      # ".codex/settings.json".text = builtins.toJSON {
+      #   mcpServers = cfg.mcpServers;
+      # };
+    };
+  };
+}

--- a/modules/terminal/default.nix
+++ b/modules/terminal/default.nix
@@ -30,6 +30,7 @@ in {
     ./ssh-auto-load.nix
     ./forgejo.nix
     ./projects.nix
+    ./cli-coding-agent-configs.nix
   ];
 
   options.keystone.terminal = {


### PR DESCRIPTION
This PR fixes pathing issues in autonomous agent services and introduces global tool configurations.

### Changes
- **Service Fixes**: Includes `/run/wrappers/bin` and `/run/current-system/sw/bin` in agent service `PATH`. This resolves issues where `systemctl`, `bash`, and `tr` were not found.
- **Sanity Checks**: Added explicit checks in agent scripts to fail early if required utilities are missing.
- **Node.js Integration**: Adds `pkgs.nodejs` to Chrome agents. This is **required** for the `chrome-devtools-mcp` server (standard `stdio` transport) which runs via `npx` or `node`.
- **Global Configs**: Introduces `keystone.terminal.cliCodingAgents` shared module to automatically generate `~/.gemini/settings.json`, `~/.claude.json`, and `~/.config/opencode/opencode.json`.
- **Security & Consistency**:
    - Uses camelCase for all options.
    - Adds security warnings about plain-text environment variables in the Nix store.
    - Allows host-level overrides via `mkDefault`.