### PR TITLE
fix(agent): default forgejo.username to agent name

### DIFF
--- a/modules/os/agents/notes.nix
+++ b/modules/os/agents/notes.nix
@@ -18,8 +18,8 @@ let
     let
       notesDir = agentCfg.notes.path;
       maxTasks = agentCfg.notes.taskLoop.maxTasks;
-      githubUsername = if agentCfg.github.username != null then agentCfg.github.username else "";
-      forgejoUsername = if agentCfg.forgejo.username != null then agentCfg.forgejo.username else "";
+      githubUsername = agentCfg.github.username;
+      forgejoUsername = agentCfg.forgejo.username;
     in
     pkgs.replaceVars ./scripts/task-loop.sh {
       notesDir = notesDir;

--- a/modules/os/agents/types.nix
+++ b/modules/os/agents/types.nix
@@ -145,19 +145,19 @@ in {
 
         github = {
           username = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            description = "GitHub username. When set, the task loop automatically fetches GitHub issues and PRs assigned to this user.";
+            type = types.str;
+            default = name;
+            description = "GitHub username. Defaults to the agent name. The task loop automatically fetches GitHub issues and PRs assigned to this user.";
             example = "octocat";
           };
         };
 
         forgejo = {
           username = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            description = "Forgejo username. When set, the task loop automatically fetches Forgejo issues and PRs assigned to this user.";
-            example = "agent-luce";
+            type = types.str;
+            default = name;
+            description = "Forgejo username. Defaults to the agent name. The task loop automatically fetches Forgejo issues and PRs assigned to this user.";
+            example = "luce";
           };
         };
 

--- a/tests/module/agent-evaluation.nix
+++ b/tests/module/agent-evaluation.nix
@@ -435,6 +435,7 @@ let
     ];
 
     # Agent with GitHub and Forgejo source usernames
+    # forgejo.username defaults to agent name; github.username must be set explicitly
     agent-source-usernames = eval "agent-source-usernames" [
       {
         keystone.os = {
@@ -443,19 +444,19 @@ let
             type = "ext4";
             devices = [ "/dev/vda" ];
           };
+          # Both set: github explicit, forgejo defaults to "luce"
           agents.luce = {
             fullName = "Luce";
             notes.repo = "git@example.com:luce/notes.git";
             github.username = "luce-gh";
-            forgejo.username = "luce";
           };
-          # Agent with only GitHub username (Forgejo left null)
+          # GitHub set, forgejo defaults to "solo"
           agents.solo = {
             fullName = "Solo";
             notes.repo = "git@example.com:solo/notes.git";
             github.username = "solo-gh";
           };
-          # Agent with no source usernames (both null, should still evaluate)
+          # No github username (null), forgejo defaults to "quiet"
           agents.quiet = {
             fullName = "Quiet";
             notes.repo = "git@example.com:quiet/notes.git";


### PR DESCRIPTION
## Goal

Both `github.username` and `forgejo.username` should default to the agent name, matching the existing `git.username` pattern. Only agents whose platform username differs need an explicit override.

Follow-up to #160.

## Changes

- `types.nix`: Change both `github.username` and `forgejo.username` from `types.nullOr types.str` (default `null`) to `types.str` (default `name`)
- `notes.nix`: Remove null checks — both usernames are always set
- `tests`: Update evaluation test comments to reflect the new defaults

## Usage

```nix
# Agent whose platform usernames match — zero config needed:
keystone.os.agents.alice = { fullName = "Alice"; };

# Agent whose GitHub username differs — only override what's needed:
keystone.os.agents.bob = {
  fullName = "Bob";
  github.username = "bob-gh";  # override, doesn't match agent name
  # forgejo.username defaults to "bob" — no config needed
};
```