### PR TITLE
feat(os): add PR review response convention and ingest handling

### DIFF
--- a/.deepwork/jobs/task_loop/steps/parse_sources.md
+++ b/.deepwork/jobs/task_loop/steps/parse_sources.md
@@ -63,6 +63,13 @@ Scheduled tasks (with `source: "schedule"`) are created by the `agent-scheduler`
 - **Reply emails**: Replies to agent-sent emails (e.g., replies to the daily status digest, replies to task confirmations) frequently contain NEW task requests from the human. When an email is a reply (`Re: ...`), focus on the new content above the quoted text — that is likely a new instruction, not a repeat of the original. Never dismiss a reply as "not actionable" just because it is part of an existing thread.
 - **GitHub Issues**: Open issues assigned to the agent or unassigned in watched repos are potential tasks. Closed issues are not.
 - **GitHub PRs**: PRs requesting review are tasks. PRs the agent authored that need updates are tasks. Merged/closed PRs are not.
+- **GitHub/Forgejo PR Reviews** (`github-pr-reviews`, `forgejo-pr-reviews`): Reviews on agent-authored PRs. These are high-priority — the agent's PR is blocked until feedback is addressed.
+  - Reviews with state `CHANGES_REQUESTED` (GitHub) or `REQUEST_CHANGES` (Forgejo) MUST always create a task.
+  - Reviews with state `COMMENTED` SHOULD create a task only if comments contain actionable feedback (not purely informational or approving).
+  - Use `source: "github-pr-review"` or `source: "forgejo-pr-review"`.
+  - Use `source_ref: "{pr_url}#reviews"` (keyed by PR URL to consolidate multiple reviews on the same PR into one task).
+  - The task `description` MUST include: repo name, PR number, branch name (`pr_branch`), reviewer name, review state, and a summary of each comment (file path + comment body). Preserve enough context for the executing agent to act without re-fetching.
+  - Example task name: `address-review-fix-login-bug-42`
 - **Deduplication**: Always check `source_ref` against existing tasks. If a task already exists for a source item, skip it even if the source data has changed.
 
 ## Output Format

--- a/conventions/archetypes.yaml
+++ b/conventions/archetypes.yaml
@@ -64,6 +64,7 @@ archetypes:
       - process.code-review-ownership
       - process.continuous-integration
       - process.copilot-agent
+      - process.pr-review-response
       - process.deepwork-job
       - process.feature-delivery
       - process.project-board

--- a/conventions/process.feature-delivery.md
+++ b/conventions/process.feature-delivery.md
@@ -44,7 +44,7 @@ This convention defines the end-to-end lifecycle of delivering features and fixe
 22. Reviewers MUST be assigned per the ownership matrix in `process.code-review-ownership`. On both GitHub and Forgejo, CODEOWNERS handles automatic reviewer assignment when a PR is created or undrafted, provided the repo has branch protection requiring code owner review enabled. If auto-request is not enabled, the authoring agent MUST manually request reviewers per the ownership matrix.
 23. On Forgejo, `tool.forgejo` rule 18 (repo owner as reviewer) is satisfied by including the repo owner in the CODEOWNERS file. Forgejo supports CODEOWNERS natively; no separate manual assignment is needed when CODEOWNERS is configured.
 24. Copilot SHOULD also be requested as a supplementary reviewer per `process.copilot-agent`.
-25. Review feedback MUST be addressed per `process.copilot-agent` conversation resolution rules (fix or explain every comment).
+25. Review feedback MUST be addressed per `process.copilot-agent` conversation resolution rules (fix or explain every comment). For human reviewer feedback, agents MUST also follow `process.pr-review-response` for the full response lifecycle (fetch comments, push fixes, reply, re-request review).
 26. PRs MUST be squash-merged per `process.pull-request`.
 
 ## Traceability

--- a/conventions/process.pr-review-response.md
+++ b/conventions/process.pr-review-response.md
@@ -1,0 +1,137 @@
+<!-- RFC 2119: MUST, MUST NOT, SHOULD, SHOULD NOT, MAY -->
+# Convention: PR Review Response (process.pr-review-response)
+
+This convention defines how an agent responds to reviewer feedback on PRs it has authored. It covers fetching review comments, addressing each one, pushing fixes, replying on the PR, and re-requesting review. It applies to both GitHub and Forgejo.
+
+**Platform** refers to the git hosting service (GitHub or Forgejo).
+
+## Fetching Review Comments
+
+1. Before acting on review feedback, agents MUST fetch the full review comments from the platform API. The task description is a summary and MAY not contain complete context.
+
+**GitHub:**
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/reviews --jq '[.[] | select(.state == "CHANGES_REQUESTED" or .state == "COMMENTED") | {id: .id, reviewer: .user.login, state: .state}]'
+
+# For each review, fetch line-level comments:
+gh api repos/{owner}/{repo}/pulls/{number}/reviews/{review_id}/comments --jq '[.[] | {id: .id, path: .path, body: .body, diff_hunk: .diff_hunk}]'
+```
+
+**Forgejo:**
+```bash
+curl -sf -H "Authorization: token $FORGEJO_TOKEN" \
+  "$FORGEJO_HOST/api/v1/repos/{owner}/{repo}/pulls/{number}/reviews" \
+  | jq '[.[] | select(.state == "REQUEST_CHANGES" or .state == "COMMENT") | {id: .id, reviewer: .user.login, state: .state}]'
+
+# For each review, fetch line-level comments:
+curl -sf -H "Authorization: token $FORGEJO_TOKEN" \
+  "$FORGEJO_HOST/api/v1/repos/{owner}/{repo}/pulls/{number}/reviews/{review_id}/comments" \
+  | jq '[.[] | {id: .id, path: .path, body: .body, diff_hunk: .diff_hunk}]'
+```
+
+## Checking Out the Branch
+
+2. Agents MUST check out the PR branch before making changes. If the repo is already cloned at `.repos/{owner}/{repo}`, agents MUST use a worktree:
+
+```bash
+cd .repos/{owner}/{repo}
+git fetch origin
+git worktree add .worktrees/{branch} origin/{branch}
+cd .worktrees/{branch}
+```
+
+3. If the PR branch has been deleted or the PR is merged/closed, agents MUST skip the task and mark it as `completed` with a note that the PR is no longer actionable.
+
+## Addressing Comments
+
+4. Agents MUST address every review comment — either by pushing a fix commit or by replying with an explanation of why the feedback was not applied.
+5. Fix commits MUST be regular commits (not force-pushes) that preserve review history.
+6. Each fix commit SHOULD reference the file and concern being addressed in the commit message (e.g., `fix(api): null check per review feedback on handler.ts:34`).
+7. `CHANGES_REQUESTED` reviews SHOULD be addressed before `COMMENTED` reviews.
+
+## Replying to Comments
+
+8. After addressing a comment, agents MUST reply to that review comment on the PR describing the fix applied or the reason the feedback was not applied.
+
+**GitHub:**
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
+  -f body="Fixed in <commit-sha>: added null check as suggested."
+```
+
+**Forgejo:**
+```bash
+curl -sf -X POST -H "Authorization: token $FORGEJO_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$FORGEJO_HOST/api/v1/repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies" \
+  -d '{"body": "Fixed in <commit-sha>: added null check as suggested."}'
+```
+
+9. Agents MUST NOT leave review comments unresolved — every comment MUST receive either a fix or an explanation.
+
+## Pushing and Re-requesting Review
+
+10. After all comments are addressed, agents MUST push the fix commits to the PR branch.
+11. Agents MUST re-request review from the original reviewer(s).
+
+**GitHub:**
+```bash
+git push origin {branch}
+gh pr edit {number} --repo {owner}/{repo} --add-reviewer {reviewer}
+```
+
+**Forgejo:**
+```bash
+git push origin {branch}
+# Re-request via API
+curl -sf -X POST -H "Authorization: token $FORGEJO_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$FORGEJO_HOST/api/v1/repos/{owner}/{repo}/pulls/{number}/requested_reviewers" \
+  -d '{"reviewers": ["{reviewer}"]}'
+```
+
+## Notification Hygiene
+
+12. After addressing all review comments on a PR, agents MUST mark the corresponding notification as read to prevent duplicate task creation in the next task loop run.
+
+**GitHub:**
+```bash
+# Find the notification thread ID
+THREAD_ID=$(gh api '/notifications?participating=true&all=true' \
+  --jq ".[] | select(.subject.url | endswith(\"pulls/{number}\")) | .id")
+gh api -X PATCH "/notifications/threads/$THREAD_ID"
+```
+
+**Forgejo:**
+```bash
+# Mark notification as read
+NOTIF_ID=$(curl -sf -H "Authorization: token $FORGEJO_TOKEN" \
+  "$FORGEJO_HOST/api/v1/notifications?limit=100" \
+  | jq -r ".[] | select(.subject.url | endswith(\"pulls/{number}\")) | .id")
+curl -sf -X PATCH -H "Authorization: token $FORGEJO_TOKEN" \
+  "$FORGEJO_HOST/api/v1/notifications/threads/$NOTIF_ID"
+```
+
+## Interaction with Existing Conventions
+
+13. This convention extends `process.feature-delivery` rule 25 for human reviewer feedback (not just Copilot).
+14. The comment resolution rules (fix or explain every comment) are consistent with `process.copilot-agent` rules 13-15.
+15. Agents operating in the `code-reviewer` role (reviewing others' PRs) follow `process.code-review-ownership` instead — this convention applies only to the **author** side.
+
+## Golden Example
+
+```
+1. Task loop discovers: github-pr-review on PR #42, reviewer=ncrmro,
+   state=CHANGES_REQUESTED, 2 comments (src/api.ts:34, src/api.ts:78)
+2. Ingest creates task: address-review-fix-login-42
+   source_ref: https://github.com/ncrmro/catalyst/pull/42#reviews
+3. Agent checks out branch:
+   cd .repos/ncrmro/catalyst
+   git worktree add .worktrees/fix/login-bug origin/fix/login-bug
+4. Agent fetches full review comments via gh api
+5. Agent reads src/api.ts, addresses both comments with fix commits
+6. Agent replies to both review comments on PR
+7. Agent pushes, re-requests review from ncrmro
+8. Agent marks notification as read
+9. Task marked completed
+```

--- a/conventions/process.pr-review-response.md
+++ b/conventions/process.pr-review-response.md
@@ -7,13 +7,13 @@ This convention defines how an agent responds to reviewer feedback on PRs it has
 
 ## Fetching Review Comments
 
-1. Before acting on review feedback, agents MUST fetch the full review comments from the platform API. The task description is a summary and MAY not contain complete context.
+1. Before acting on review feedback, agents MUST fetch the full review comments from the platform API. The task description is a summary and MAY not contain complete context. The fetch scripts intentionally omit bulky fields like `diff_hunk` to keep the ingest payload small — the executing agent MUST fetch these directly.
 
 **GitHub:**
 ```bash
 gh api repos/{owner}/{repo}/pulls/{number}/reviews --jq '[.[] | select(.state == "CHANGES_REQUESTED" or .state == "COMMENTED") | {id: .id, reviewer: .user.login, state: .state}]'
 
-# For each review, fetch line-level comments:
+# For each review, fetch line-level comments (includes diff_hunk for context):
 gh api repos/{owner}/{repo}/pulls/{number}/reviews/{review_id}/comments --jq '[.[] | {id: .id, path: .path, body: .body, diff_hunk: .diff_hunk}]'
 ```
 
@@ -23,7 +23,7 @@ curl -sf -H "Authorization: token $FORGEJO_TOKEN" \
   "$FORGEJO_HOST/api/v1/repos/{owner}/{repo}/pulls/{number}/reviews" \
   | jq '[.[] | select(.state == "REQUEST_CHANGES" or .state == "COMMENT") | {id: .id, reviewer: .user.login, state: .state}]'
 
-# For each review, fetch line-level comments:
+# For each review, fetch line-level comments (includes diff_hunk for context):
 curl -sf -H "Authorization: token $FORGEJO_TOKEN" \
   "$FORGEJO_HOST/api/v1/repos/{owner}/{repo}/pulls/{number}/reviews/{review_id}/comments" \
   | jq '[.[] | {id: .id, path: .path, body: .body, diff_hunk: .diff_hunk}]'

--- a/packages/fetch-forgejo-sources/bin/fetch-forgejo-sources
+++ b/packages/fetch-forgejo-sources/bin/fetch-forgejo-sources
@@ -108,7 +108,7 @@ while IFS= read -r row; do
       review_state=$(echo "$relevant" | jq -r ".[$review_idx].state")
 
       comments_raw=$(api_get "$API/repos/$owner/$name/pulls/$pr_number/reviews/$review_id/comments")
-      comments=$(echo "$comments_raw" | jq '[.[] | {id: .id, path: .path, body: .body, diff_hunk: .diff_hunk}]' 2>/dev/null || echo "[]")
+      comments=$(echo "$comments_raw" | jq '[.[] | {id: .id, path: .path, body: .body}]' 2>/dev/null || echo "[]")
 
       item=$(jq -n \
         --arg repo "$repo" \

--- a/packages/fetch-forgejo-sources/bin/fetch-forgejo-sources
+++ b/packages/fetch-forgejo-sources/bin/fetch-forgejo-sources
@@ -74,6 +74,7 @@ while IFS= read -r row; do
   pr_number=$(echo "$pr_raw" | jq -r '.number')
   pr_title=$(echo "$pr_raw" | jq -r '.title')
   pr_url=$(echo "$pr_raw" | jq -r '.html_url')
+  pr_branch=$(echo "$pr_raw" | jq -r '.head.ref')
 
   # PRs requesting review from agent (not authored by agent)
   if [ "$pr_author" != "$AGENT_USERNAME" ]; then
@@ -107,13 +108,14 @@ while IFS= read -r row; do
       review_state=$(echo "$relevant" | jq -r ".[$review_idx].state")
 
       comments_raw=$(api_get "$API/repos/$owner/$name/pulls/$pr_number/reviews/$review_id/comments")
-      comments=$(echo "$comments_raw" | jq '[.[] | {id: .id, path: .path, body: .body}]' 2>/dev/null || echo "[]")
+      comments=$(echo "$comments_raw" | jq '[.[] | {id: .id, path: .path, body: .body, diff_hunk: .diff_hunk}]' 2>/dev/null || echo "[]")
 
       item=$(jq -n \
         --arg repo "$repo" \
         --argjson pr_number "$pr_number" \
         --arg pr_title "$pr_title" \
         --arg pr_url "$pr_url" \
+        --arg pr_branch "$pr_branch" \
         --argjson review_id "$review_id" \
         --arg reviewer "$reviewer" \
         --arg review_state "$review_state" \
@@ -123,6 +125,7 @@ while IFS= read -r row; do
           pr_number: $pr_number,
           pr_title: $pr_title,
           pr_url: $pr_url,
+          pr_branch: $pr_branch,
           review_id: $review_id,
           reviewer: $reviewer,
           review_state: $review_state,

--- a/packages/fetch-github-sources/bin/fetch-github-sources
+++ b/packages/fetch-github-sources/bin/fetch-github-sources
@@ -88,7 +88,7 @@ while IFS= read -r row; do
     review_state=$(echo "$relevant" | jq -r ".[$review_idx].state")
 
     comments_raw=$(gh api "repos/$repo/pulls/$pr_number/reviews/$review_id/comments" 2>/dev/null || echo "[]")
-    comments=$(echo "$comments_raw" | jq '[.[] | {id: .id, path: .path, body: .body, diff_hunk: .diff_hunk}]' 2>/dev/null || echo "[]")
+    comments=$(echo "$comments_raw" | jq '[.[] | {id: .id, path: .path, body: .body}]' 2>/dev/null || echo "[]")
 
     item=$(jq -n \
       --arg repo "$repo" \

--- a/packages/fetch-github-sources/bin/fetch-github-sources
+++ b/packages/fetch-github-sources/bin/fetch-github-sources
@@ -70,10 +70,11 @@ while IFS= read -r row; do
   subject_url=$(echo "$row" | jq -r '.subject.url')
   repo=$(echo "$row" | jq -r '.repository.full_name')
 
-  pr_data=$(gh api "$subject_url" --jq '{number: .number, title: .title, html_url: .html_url}' 2>/dev/null) || continue
+  pr_data=$(gh api "$subject_url" --jq '{number: .number, title: .title, html_url: .html_url, head_ref: .head.ref}' 2>/dev/null) || continue
   pr_number=$(echo "$pr_data" | jq -r '.number')
   pr_title=$(echo "$pr_data" | jq -r '.title')
   pr_url=$(echo "$pr_data" | jq -r '.html_url')
+  pr_branch=$(echo "$pr_data" | jq -r '.head_ref')
 
   reviews_raw=$(gh api "repos/$repo/pulls/$pr_number/reviews" 2>/dev/null || echo "[]")
   relevant=$(echo "$reviews_raw" | jq --arg agent "$AGENT_USERNAME" \
@@ -87,13 +88,14 @@ while IFS= read -r row; do
     review_state=$(echo "$relevant" | jq -r ".[$review_idx].state")
 
     comments_raw=$(gh api "repos/$repo/pulls/$pr_number/reviews/$review_id/comments" 2>/dev/null || echo "[]")
-    comments=$(echo "$comments_raw" | jq '[.[] | {id: .id, path: .path, body: .body}]' 2>/dev/null || echo "[]")
+    comments=$(echo "$comments_raw" | jq '[.[] | {id: .id, path: .path, body: .body, diff_hunk: .diff_hunk}]' 2>/dev/null || echo "[]")
 
     item=$(jq -n \
       --arg repo "$repo" \
       --argjson pr_number "$pr_number" \
       --arg pr_title "$pr_title" \
       --arg pr_url "$pr_url" \
+      --arg pr_branch "$pr_branch" \
       --argjson review_id "$review_id" \
       --arg reviewer "$reviewer" \
       --arg review_state "$review_state" \
@@ -103,6 +105,7 @@ while IFS= read -r row; do
         pr_number: $pr_number,
         pr_title: $pr_title,
         pr_url: $pr_url,
+        pr_branch: $pr_branch,
         review_id: $review_id,
         reviewer: $reviewer,
         review_state: $review_state,

--- a/specs/REQ-024-pr-review-response/requirements.md
+++ b/specs/REQ-024-pr-review-response/requirements.md
@@ -91,7 +91,7 @@ intervention.
 
 **REQ-024.2** `fetch-forgejo-sources` MUST include the PR's `head.ref` (branch name) in each review entry as the `pr_branch` field.
 
-**REQ-024.3** Fetch scripts MUST include the `diff_hunk` field from each review comment alongside the existing `id`, `path`, and `body` fields, so the executing agent has line-level context.
+**REQ-024.3** Fetch scripts MUST NOT include bulky fields like `diff_hunk` in review comment output. The executing agent fetches full review context (including diff hunks) directly from the platform API at execution time.
 
 ### Ingest (parse_sources.md)
 

--- a/specs/REQ-024-pr-review-response/requirements.md
+++ b/specs/REQ-024-pr-review-response/requirements.md
@@ -1,0 +1,160 @@
+# REQ-024: PR Review Response
+
+Keystone agents author PRs as part of the `sweng` workflow, but currently lack
+a convention and ingest guidance for acting on reviewer feedback received on
+those PRs. The fetch scripts (`fetch-github-sources`, `fetch-forgejo-sources`)
+already discover review comments via the notifications API, and the task loop
+passes them to the ingest step. However, the ingest step has no explicit
+handling for `github-pr-reviews` / `forgejo-pr-reviews` data, so Haiku may
+create vague or missing tasks. There is also no convention telling the
+executing agent how to check out the branch, address each comment, push fixes,
+and reply on the PR.
+
+This spec closes the loop: reviews are ingested as first-class tasks, executed
+via a defined convention, and dismissed from the notifications queue to prevent
+duplicates.
+
+Key words: RFC 2119 (MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT,
+MAY, REQUIRED, OPTIONAL).
+
+## User Story
+
+As an OS agent that authors PRs, I want review feedback to be automatically
+ingested as actionable tasks with full comment context so that I can address
+each reviewer comment, push fixes, and re-request review without human
+intervention.
+
+## Architecture
+
+```
+                          GitHub / Forgejo
+                          ┌──────────────────────────────────┐
+                          │  PR #42 (agent-authored)         │
+                          │  ┌─────────────────────────────┐ │
+                          │  │ Review: CHANGES_REQUESTED   │ │
+                          │  │  comment: src/api.ts:34     │ │
+                          │  │  comment: src/api.ts:78     │ │
+                          │  └─────────────────────────────┘ │
+                          └──────────┬───────────────────────┘
+                                     │ notifications API
+                                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│  fetch-{github,forgejo}-sources                             │
+│  Phase 4: PR reviews on agent-authored PRs                  │
+│  Output: { "github-pr-reviews": [...] }                     │
+└──────────┬──────────────────────────────────────────────────┘
+           │ JSON
+           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  task-loop.sh → Step 2: Ingest (Haiku)                      │
+│  parse_sources.md                                           │
+│                                                             │
+│  NEW: Explicit pr-review handling                           │
+│  ┌────────────────────────────────────────────────────────┐ │
+│  │ source: "github-pr-review"                             │ │
+│  │ source_ref: "{pr_url}#review-{review_id}"              │ │
+│  │ description: includes repo, branch, file paths,        │ │
+│  │              comment bodies, review state               │ │
+│  │ workflow: "sweng/respond_review" (if available)         │ │
+│  └────────────────────────────────────────────────────────┘ │
+└──────────┬──────────────────────────────────────────────────┘
+           │ TASKS.yaml
+           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  task-loop.sh → Step 4: Execute                             │
+│                                                             │
+│  Convention: process.pr-review-response                     │
+│  1. Clone/checkout repo + branch                            │
+│  2. Fetch full review comments via API                      │
+│  3. Address each comment (fix or explain)                   │
+│  4. Push fix commits                                        │
+│  5. Reply to each review comment on PR                      │
+│  6. Re-request review                                       │
+│  7. Dismiss notification                                    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Affected Modules
+
+- `conventions/process.pr-review-response.md` — **new** convention for responding to PR review feedback
+- `.deepwork/jobs/task_loop/steps/parse_sources.md` — add explicit PR review ingest rules
+- `packages/fetch-github-sources/bin/fetch-github-sources` — add `pr_branch` field to review output
+- `packages/fetch-forgejo-sources/bin/fetch-forgejo-sources` — add `pr_branch` field to review output
+- `conventions/process.feature-delivery.md` — update rule 25 to reference `process.pr-review-response`
+- `conventions/archetypes.yaml` — wire `process.pr-review-response` into relevant archetypes
+
+## Requirements
+
+### Fetch Script Enrichment
+
+**REQ-024.1** `fetch-github-sources` MUST include the PR's `head.ref` (branch name) in each review entry as the `pr_branch` field.
+
+**REQ-024.2** `fetch-forgejo-sources` MUST include the PR's `head.ref` (branch name) in each review entry as the `pr_branch` field.
+
+**REQ-024.3** Fetch scripts MUST include the `diff_hunk` field from each review comment alongside the existing `id`, `path`, and `body` fields, so the executing agent has line-level context.
+
+### Ingest (parse_sources.md)
+
+**REQ-024.4** The ingest step MUST recognize `github-pr-reviews` and `forgejo-pr-reviews` as distinct source categories in the pre-fetched JSON.
+
+**REQ-024.5** For each PR review entry, the ingest step MUST create a task with:
+- `source`: `"github-pr-review"` or `"forgejo-pr-review"`
+- `source_ref`: `"{pr_url}#review-{review_id}"` (unique per review, enables deduplication)
+- `name`: kebab-case derived from the PR title (e.g., `address-review-fix-login-bug-42`)
+- `description`: MUST include the repo, PR number, branch name, reviewer, review state, and a summary of each comment (file path + body). The description MUST preserve enough context for the executing agent to act without re-fetching the review.
+
+**REQ-024.6** Reviews with state `CHANGES_REQUESTED` (GitHub) or `REQUEST_CHANGES` (Forgejo) MUST be ingested as tasks. Reviews with state `COMMENTED` SHOULD be ingested only if they contain actionable comments (not purely informational).
+
+**REQ-024.7** The ingest step MUST deduplicate PR reviews by `source_ref`. If a task already exists for a given `{pr_url}#review-{review_id}`, the review MUST NOT create a duplicate task.
+
+**REQ-024.8** When multiple reviews exist on the same PR, the ingest step SHOULD consolidate them into a single task per PR (keyed by `{pr_url}`) rather than one task per review, to avoid redundant branch checkouts. The `source_ref` for a consolidated task MUST use the PR URL (e.g., `"{pr_url}#reviews"`).
+
+### Convention: process.pr-review-response
+
+**REQ-024.9** A new convention `process.pr-review-response` MUST define the end-to-end flow for an agent responding to review feedback on its authored PRs.
+
+**REQ-024.10** The convention MUST require agents to address every review comment — either by pushing a fix commit or by replying with an explanation of why the feedback was not applied (consistent with `process.copilot-agent` rules 13-15).
+
+**REQ-024.11** The convention MUST require agents to fetch the full review comments from the platform API before acting, since the task description is a summary and MAY not contain complete context.
+
+**REQ-024.12** The convention MUST require agents to push fix commits (not force-pushes) that reference the review comment being addressed.
+
+**REQ-024.13** The convention MUST require agents to reply to each review comment on the PR with a description of the fix applied or the reason the feedback was not applied.
+
+**REQ-024.14** The convention MUST require agents to re-request review from the original reviewer after addressing all comments.
+
+**REQ-024.15** The convention MUST require agents to mark the notification as read after addressing the review, to prevent the next task loop run from creating a duplicate task.
+
+**REQ-024.16** The convention SHOULD specify that `CHANGES_REQUESTED` reviews take priority over `COMMENTED` reviews.
+
+**REQ-024.17** The convention MUST include platform-specific commands for both GitHub (`gh`) and Forgejo (`fj` / `curl`) for fetching comments, replying, re-requesting review, and dismissing notifications.
+
+### Integration
+
+**REQ-024.18** `process.feature-delivery` rule 25 MUST be updated to reference `process.pr-review-response` for human reviewer feedback, in addition to the existing `process.copilot-agent` reference for Copilot feedback.
+
+**REQ-024.19** `conventions/archetypes.yaml` MUST wire `process.pr-review-response` into the `engineer` archetype (and any other archetype that authors PRs) as a referenced convention.
+
+### Notification Hygiene
+
+**REQ-024.20** After an agent addresses all review comments on a PR, it MUST mark the corresponding GitHub notification as read via `gh api -X PATCH /notifications/threads/{thread_id}` (or the Forgejo equivalent).
+
+**REQ-024.21** The fetch scripts MUST NOT filter out already-read notifications in the current design (`all=true` parameter is intentional for discovery). Deduplication MUST happen at the ingest layer via `source_ref` matching.
+
+### Edge Cases
+
+**REQ-024.22** If the PR branch has been deleted or the PR is already merged/closed, the agent MUST skip the review task and mark it as `completed` with a note that the PR is no longer actionable.
+
+**REQ-024.23** If the agent cannot push to the PR branch (e.g., permission denied, branch protection), the task MUST be marked `blocked` with a description of the access issue.
+
+**REQ-024.24** If a reviewer leaves a review with no comments (body-only review), the agent MUST still create a task if the review state is `CHANGES_REQUESTED`.
+
+## References
+
+- `packages/fetch-github-sources/bin/fetch-github-sources` — Phase 4 (lines 68-115)
+- `packages/fetch-forgejo-sources/bin/fetch-forgejo-sources` — equivalent review discovery
+- `.deepwork/jobs/task_loop/steps/parse_sources.md` — ingest step instructions
+- `conventions/process.copilot-agent.md` — rules 10-15 (responding to Copilot feedback)
+- `conventions/process.code-review-ownership.md` — reviewer assignment via CODEOWNERS
+- `conventions/process.feature-delivery.md` — rule 25 (addressing review feedback)
+- `.deepwork/jobs/sweng/steps/review.md` — the reviewer-side flow (Step 7: fix loop)


### PR DESCRIPTION
## Summary

- Add REQ-024 spec for PR review response lifecycle
- Enrich `fetch-github-sources` and `fetch-forgejo-sources` with `pr_branch` and `diff_hunk` fields in review output
- Add explicit `github-pr-reviews` / `forgejo-pr-reviews` handling to task loop ingest step (`parse_sources.md`)
- Create `process.pr-review-response` convention covering the full author-side review response flow
- Wire convention into `process.feature-delivery` rule 25 and `engineer` archetype

## Test plan

- [ ] Verify fetch scripts output includes `pr_branch` and `diff_hunk` fields on a repo with PR reviews
- [ ] Verify ingest step creates tasks with `source: github-pr-review` when PR review data is present
- [ ] Verify convention is accessible via `engineer` archetype referenced conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)