### PR TITLE
feat(desktop): standardize demo/presentation recording and Slidev integration

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -5,7 +5,7 @@ agent: claude
 platform: github
 issue: 203
 task_type: implement
-status: ready
+status: assigned
 created: 2026-03-23
 ---
 

--- a/TASK.md
+++ b/TASK.md
@@ -1,57 +1,46 @@
 ---
 repo: ncrmro/keystone
-branch: feat/agentctl-sandbox-podman
+branch: feat/demo-presentations
 agent: claude
 platform: github
-issue: 123
-status: assigned
-created: 2026-03-19
+issue: 203
+task_type: implement
+status: ready
+created: 2026-03-23
 ---
 
-# Sandbox agentctl AI Tool Launches in Podman by Default
+# Standardize Demo/Presentation Recording and Slidev Integration
 
 ## Description
 
-AI tool subcommands in `agentctl` (claude, gemini, codex, opencode) currently
-run directly as the agent user. They must be wrapped in a Podman container by
-default to provide filesystem and network isolation. A `--nosandbox` flag opts
-out to the current direct-exec behavior.
+Create documentation and tooling for standardized demo/presentation workflows in keystone.
+There are four distinct use cases, each with different tools:
 
-Tech stack: Bash, NixOS, Podman, `podman-agent.sh` (existing sandbox backend).
-Modified files: `modules/os/agents/scripts/agentctl.sh`,
-`modules/os/agents/agentctl.nix`.
+1. **Quick PR/bug demos** — `keystone-screenrecord` (already exists)
+2. **Slide-based presentations** — Slidev (needs packaging/docs)
+3. **Long-form tutorials/streaming** — OBS (needs docs)
+4. **Video-to-Slidev post-processing** — `video-slidev` (needs docs)
+
+The primary deliverable is `docs/desktop/presentations.md` that describes each scenario
+and when to use each tool. Secondary deliverables are Slidev packaging and DeepWork
+workflows for presentation creation.
+
+Tech stack: NixOS modules, Nix overlays, home-manager, DeepWork jobs (YAML + markdown).
 
 ## Acceptance Criteria
 
-- [x] AI tool subcommands (claude, gemini, codex, opencode) launch via `podman-agent` by default
-- [x] Working directory (or worktree path when `--worktree` is set) is mounted read-write
-- [x] Parent `.git/` directory is mounted read-only inside the container
-- [x] Project context files (AGENT.md, CLAUDE.md, GEMINI.md) from `~/` are mounted read-only at `~/` in the container
-- [x] `--nosandbox` flag disables Podman and runs directly (current behavior preserved)
-- [x] Non-AI subcommands (shell, tasks, email, vnc, logs, etc.) are NOT sandboxed
-- [x] Sandbox uses existing `podman-agent` infrastructure (Nix store volume, SSH forwarding, cache volumes)
-- [x] `agentctl.nix` wires `PODMAN_AGENT` path variable into the script via `replaceVars`
-- [x] Existing tests pass (if any)
+- [ ] `docs/desktop/presentations.md` exists covering all four use case scenarios
+- [ ] Slidev is packaged or has a documented setup path
+- [ ] OBS usage is documented as an alternative for complex recordings
+- [ ] `video-slidev` pipeline is documented with usage examples
+- [ ] At least one DeepWork workflow for presentation creation exists
+- [ ] Existing evaluation passes (`nix flake check --no-build`)
 
 ## Key Files
 
-- `modules/os/agents/scripts/agentctl.sh` — main dispatch script; `claude|gemini|codex|opencode` branch needs sandboxing
-- `modules/os/agents/agentctl.nix` — Nix module; must expose `podman-agent` store path via `replaceVars`
-- `packages/podman-agent/podman-agent.sh` — existing sandbox backend; already handles mounts, SSH forwarding, cache volumes
-- `specs/REQ-012-agentctl-project-sessions/requirements.md` — REQ-012.8 through REQ-012.14
-
-## Agent Notes
-
-- `podman-agent` does not support extra `--volume` passthrough flags for additional mounts. Context file content (AGENTS.md, CLAUDE.md, GEMINI.md) is already embedded into the system prompt on the host side via `--append-system-prompt` / `--prompt-interactive` / `--instructions` before `podman-agent` is called. The acceptance criterion for mounting context files at `~/` is satisfied through this system prompt injection, which provides equivalent information access inside the container without requiring changes to `podman-agent`.
-- The `NOSANDBOX` variable is interpolated from the outer shell into the `bash -c` string using the `'"$NOSANDBOX"'` quoting pattern, consistent with how `$ROLE`, `$CMD`, and other outer variables are passed into the inner subshell throughout the existing code.
-- `podman-agent` uses `$(pwd)` as its `WORKDIR`; since `cd "$WORK_DIR"` runs first in the bash -c block, the container will mount the correct project or notes directory.
-
-## Results
-
-- Modified `modules/os/agents/scripts/agentctl.sh`:
-  - Added `PODMAN_AGENT="@podmanAgent@"` path substitution near the top
-  - Added `--nosandbox` to usage/help text under Flags
-  - Added `NOSANDBOX=""` and `--nosandbox) NOSANDBOX=1; shift ;;` in the flag-parsing section
-  - In the `claude|gemini|codex|opencode` case: branched on `$NOSANDBOX` — nosandbox path preserves original direct-exec behavior; default (sandbox) path execs `podman-agent CMD [SP_FLAGS...] [user-args...]`
-- Modified `modules/os/agents/agentctl.nix`:
-  - Added `podmanAgent = "${pkgs.keystone.podman-agent}/bin/podman-agent";` to the `replaceVars` attribute set
+- `docs/desktop/screen-recording.md` — existing recording docs (reference for style)
+- `docs/desktop/presentations.md` — new file to create
+- `modules/desktop/home/scripts/default.nix` — existing screenrecord script
+- `modules/desktop/nixos.nix` — desktop NixOS options
+- `overlays/default.nix` — overlay packages
+- `.deepwork/jobs/` — DeepWork job definitions

--- a/TASK.md
+++ b/TASK.md
@@ -29,11 +29,11 @@ Tech stack: NixOS modules, Nix overlays, home-manager, DeepWork jobs (YAML + mar
 
 ## Acceptance Criteria
 
-- [ ] `docs/desktop/presentations.md` exists covering all four use case scenarios
-- [ ] Slidev is packaged or has a documented setup path
-- [ ] OBS usage is documented as an alternative for complex recordings
-- [ ] `video-slidev` pipeline is documented with usage examples
-- [ ] At least one DeepWork workflow for presentation creation exists
+- [x] `docs/desktop/presentations.md` exists covering all four use case scenarios
+- [x] Slidev is packaged or has a documented setup path
+- [x] OBS usage is documented as an alternative for complex recordings
+- [x] `video-slidev` pipeline is documented with usage examples
+- [ ] At least one DeepWork workflow for presentation creation exists (deferred — outline posted on #203)
 - [ ] Existing evaluation passes (`nix flake check --no-build`)
 
 ## Key Files

--- a/docs/desktop/presentations.md
+++ b/docs/desktop/presentations.md
@@ -1,0 +1,221 @@
+---
+title: Demos & Presentations Guide
+description: Choosing the right tool for screen recordings, slide decks, and video post-processing
+---
+
+# Demos & Presentations Guide
+
+Keystone supports several approaches to creating demos and presentations. Each targets a different scenario — pick the one that fits your use case.
+
+## Decision Matrix
+
+| Scenario | Tool | Audio | Slides | Effort |
+|----------|------|-------|--------|--------|
+| Quick PR demo / bug report | `keystone-screenrecord` | Optional | No | ~1 min |
+| Slide-based presentation | Slidev | Built-in | Yes | Medium |
+| Complex multi-source recording | OBS Studio | Full mixer | Optional | High |
+| Convert existing video to slides | `video-slidev` | Preserves original | Generated | Medium |
+
+## Quick PR / Bug Demos (keystone-screenrecord)
+
+For short screen captures attached to PRs, issues, or Slack messages. This is the fastest path from "I need to show something" to a shareable video.
+
+**When to use:** Bug reproductions, feature demos under 5 minutes, code walkthroughs.
+
+```bash
+# Silent demo (most common for PRs)
+keystone-screenrecord
+
+# With voiceover narration
+keystone-screenrecord --with-microphone-audio
+
+# With app sounds + narration
+keystone-screenrecord --with-desktop-audio --with-microphone-audio
+```
+
+Click the red Waybar indicator to stop recording. Output lands in `~/Videos/`.
+
+For full details, see [Screen Recording User Guide](screen-recording.md).
+
+## Slide-Based Presentations (Slidev)
+
+[Slidev](https://sli.dev) is a markdown-powered slide framework built on Vue. It supports presenter notes, live coding, recording, and PDF/PNG export — all from markdown files.
+
+**When to use:** Conference talks, team presentations, project demos with structured narrative.
+
+### Setup
+
+Slidev runs via Node.js. Create a presentation in any project directory:
+
+```bash
+# Initialize a new presentation
+npm init slidev@latest my-presentation
+cd my-presentation
+
+# Or in an existing project, add slidev
+npm install @slidev/cli @slidev/theme-default
+```
+
+### Creating Slides
+
+Write slides in `slides.md`:
+
+```markdown
+---
+theme: default
+title: My Presentation
+---
+
+# Slide Title
+
+Content goes here.
+
+---
+
+# Second Slide
+
+- Bullet points
+- Code blocks work natively
+
+\`\`\`python
+def hello():
+    print("Hello from the presentation")
+\`\`\`
+
+---
+layout: presenter
+---
+
+# Live Demo
+
+Use presenter mode to show your screen alongside slides.
+```
+
+### Presenting and Recording
+
+```bash
+# Start dev server with hot reload
+npx slidev
+
+# Open presenter mode (separate window with notes + timer)
+# Navigate to http://localhost:3030/presenter
+
+# Record your presentation (screen + camera)
+npx slidev --record
+
+# Export to PDF
+npx slidev export
+
+# Export to PNG images
+npx slidev export --format png
+```
+
+Slidev's built-in recording captures both the slide view and presenter view simultaneously. The output is a WebM file saved to the project directory.
+
+### Presenter Mode
+
+Presenter mode (`/presenter` route) shows:
+- Current slide + next slide preview
+- Speaker notes
+- Timer and progress
+- Drawing tools
+
+This is useful for live presentations where you have a secondary display, or for recording where you want both the audience view and your notes captured.
+
+## Long-Form Tutorials / Streaming (OBS Studio)
+
+[OBS Studio](https://obsproject.com) is a full-featured recording and streaming application. Use it when you need scene switching, overlays, webcam compositing, or multi-source audio mixing.
+
+**When to use:** YouTube tutorials, live streams, multi-camera setups, recordings requiring post-production editing, picture-in-picture layouts.
+
+### Setup
+
+OBS is available in nixpkgs:
+
+```nix
+# In your NixOS or home-manager config
+environment.systemPackages = [ pkgs.obs-studio ];
+
+# Or run directly
+nix run nixpkgs#obs-studio
+```
+
+### Basic Recording Workflow
+
+1. **Add sources:** Display Capture (full screen), Window Capture (single app), or Video Capture Device (webcam)
+2. **Configure audio:** Desktop audio is captured automatically. Add your microphone as an Audio Input Capture source
+3. **Set output format:** Settings → Output → Recording → MP4 or MKV container, hardware encoder if available
+4. **Record:** Click "Start Recording" or use the hotkey (default: unset, configure in Settings → Hotkeys)
+
+### OBS vs keystone-screenrecord
+
+| Feature | keystone-screenrecord | OBS Studio |
+|---------|----------------------|------------|
+| Setup time | Zero (built-in) | Requires config |
+| Scene switching | No | Yes |
+| Webcam overlay | No | Yes |
+| Audio mixing | Basic (mic + desktop) | Full mixer |
+| Streaming | No | Yes (Twitch, YouTube, etc.) |
+| GPU encoding | Yes | Yes |
+| Wayland support | Native (portal) | Via PipeWire |
+
+**Rule of thumb:** If `keystone-screenrecord` can do it, use that. Reach for OBS when you need features it doesn't have.
+
+## Video-to-Slidev Post-Processing (video-slidev)
+
+The `video-slidev` tool converts an existing screen recording into a Slidev presentation by detecting scene changes and generating slides with timestamps.
+
+**When to use:** You already have a recording and want to create a navigable slide deck from it, or you want to add chapter markers and annotations after recording.
+
+### Setup
+
+The tool is located at `~/Downloads/video-slidev`. To use:
+
+```bash
+cd ~/Downloads/video-slidev
+npm install
+```
+
+### Usage
+
+```bash
+# Convert a recorded video to a Slidev project
+npx video-slidev convert ~/Videos/screenrecording-2026-03-23_14-30-45.mp4 \
+  --output ./my-presentation
+
+# This generates:
+# - slides.md with timestamps and auto-detected scene breaks
+# - Embedded video references for each slide
+# - A Slidev project you can edit and re-export
+```
+
+### Workflow
+
+1. Record your demo using `keystone-screenrecord` or OBS
+2. Run `video-slidev convert` on the recording
+3. Edit the generated `slides.md` — add titles, notes, clean up scene breaks
+4. Present or export with `npx slidev` / `npx slidev export`
+
+This is particularly useful for creating after-the-fact presentations from ad-hoc recordings, or for adding structure to long tutorial videos.
+
+## Choosing Your Workflow
+
+```
+Need to show something quickly?
+  └── keystone-screenrecord (+ attach to PR/issue)
+
+Giving a talk or structured presentation?
+  └── Slidev (write slides.md → present → export)
+
+Need webcam, scene switching, or streaming?
+  └── OBS Studio
+
+Already have a video, want slides from it?
+  └── video-slidev convert
+```
+
+## See Also
+
+- [Screen Recording User Guide](screen-recording.md) — full `keystone-screenrecord` reference
+- [Slidev Documentation](https://sli.dev) — upstream Slidev docs
+- [OBS Studio Wiki](https://obsproject.com/wiki/) — upstream OBS docs


### PR DESCRIPTION
# Goal

Standardize how users create demos and presentations across four distinct use cases with appropriate tooling for each.
Closes #203

# Tasks

- [ ] `docs/desktop/presentations.md` covering all use case scenarios
- [ ] Slidev packaged or documented setup path
- [ ] OBS usage documented
- [ ] `video-slidev` pipeline documented
- [ ] DeepWork workflow for presentation creation

# Changes

(to be filled during implementation)

# Demo

(to be filled before review)