### PR TITLE
docs(specs): add first-boot hardware pushback spec for Keystone TUI

### DIFF
--- a/packages/keystone-tui/specs/001-config-generation-contract.md
+++ b/packages/keystone-tui/specs/001-config-generation-contract.md
@@ -1,0 +1,155 @@
+# Spec: Config Generation Contract
+
+## Stories Covered
+- US-001: Define config generation output contract
+- US-002: Define template data model
+- US-003: Implement build validation test suite
+
+Derived from: REQ-001 (Config Generation), REQ-002 (Template Data Model), REQ-003 (Build Validation)
+
+## Affected Modules
+- `packages/keystone-tui/src/template.rs` — `GenerateConfig`, all generator functions
+- `packages/keystone-tui/tests/nix_build.rs` — `#[ignore]`d eval/build tests
+- `packages/keystone-tui/flake.nix` — must expose `checks.x86_64-linux.template-evaluation`
+- `packages/keystone-tui/checks/template-evaluation.nix` — new Nix derivation (to create)
+
+## Data Model
+
+### `GenerateConfig` (Rust struct — `src/template.rs`)
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| hostname | `String` | yes | Maps to `networking.hostName` |
+| host_id | `String` | yes | 8-char hex; generated randomly by TUI; maps to `networking.hostId` |
+| state_version | `String` | yes | Defaults to `"25.05"`; maps to `system.stateVersion` |
+| time_zone | `String` | yes | Defaults to `"UTC"`; maps to `time.timeZone` |
+| machine_type | `MachineType` | yes | Server \| Workstation \| Laptop |
+| storage | `StorageConfig` | yes | See below |
+| security | `SecurityConfig` | yes | See below |
+| users | `Vec<UserConfig>` | yes | At least one entry required |
+| github_username | `Option<String>` | no | For fetching SSH keys via GitHub API |
+
+### `StorageConfig`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| storage_type | `StorageType` (Zfs \| Ext4) | yes | Maps to `keystone.os.storage.type` |
+| devices | `Vec<String>` | yes | ≥1 entry; SHOULD be `/dev/disk/by-id/` paths |
+| mode | `StorageMode` | no | Single \| Mirror \| Stripe \| Raidz1 \| Raidz2 \| Raidz3; default `Single` |
+| swap_size | `Option<String>` | no | E.g. `"16G"`; defaults to `"16G"` |
+| hibernate | `bool` | no | Only valid when `storage_type = Ext4`; default `false` |
+
+### `SecurityConfig`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| secure_boot | `bool` | no | Maps to `keystone.os.secureBoot.enable`; default `true` |
+| tpm | `bool` | no | Maps to `keystone.os.tpm.enable`; default `true` |
+| remote_unlock | `RemoteUnlockConfig` | no | See below |
+
+### `RemoteUnlockConfig`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| enable | `bool` | yes | Maps to `keystone.os.remoteUnlock.enable` |
+| authorized_keys | `Vec<String>` | no | SSH public keys for initrd unlock |
+
+### `UserConfig`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| username | `String` | yes | Maps to `keystone.os.users.<name>` key |
+| full_name | `String` | yes | Maps to `fullName` |
+| email | `Option<String>` | no | Maps to `email`; defaults to `{username}@localhost` |
+| initial_password | `String` | yes | Maps to `initialPassword`; SHOULD warn user to change post-install |
+| authorized_keys | `Vec<String>` | no | SSH public keys |
+| extra_groups | `Vec<String>` | no | Default: `["wheel"]` for first user, `["wheel", "networkmanager", "video", "audio"]` for desktop |
+| terminal_enable | `bool` | no | Default `true` |
+| desktop_enable | `bool` | no | Default based on `MachineType` (false for Server, true for Workstation/Laptop) |
+
+## Generated File Contracts
+
+### `flake.nix`
+
+The generated flake.nix MUST:
+1. Declare `nixpkgs`, `keystone`, `home-manager`, and `disko` as inputs, with
+   `nixpkgs.follows = "nixpkgs"` on all derived inputs.
+2. Import `keystone.nixosModules.operating-system` in the modules list.
+3. Import `home-manager.nixosModules.home-manager` for any user with `terminal.enable` or `desktop.enable`.
+4. Import `keystone.nixosModules.desktop` when any user has `desktop.enable = true`.
+5. Expose exactly one `nixosConfigurations.<hostname>` output using the user-provided hostname.
+6. NOT contain any `TODO:` markers.
+
+### `configuration.nix`
+
+The generated configuration.nix MUST:
+1. Set `networking.hostName`, `networking.hostId`, `system.stateVersion`.
+2. Set `time.timeZone`.
+3. Set `keystone.os.enable = true`.
+4. Set `keystone.os.storage` with type, devices, mode, and swap.size.
+5. Set at least one `keystone.os.users.<username>` entry with fullName, email, extraGroups,
+   initialPassword, authorizedKeys, terminal.enable, and desktop.enable.
+6. NOT contain any `TODO:` markers.
+7. Use `__KEYSTONE_DISK__` as the disk placeholder when no device is provided (deferred selection).
+
+### `hardware.nix`
+
+The generated hardware.nix MUST:
+1. Be a minimal valid NixOS module: `{ ... }: { }` with an imports list pointing to
+   `(modulesPath + "/installer/scan/not-detected.nix")`.
+2. NOT configure any hardware — hardware.nix is populated post-installation by
+   `nixos-generate-config` or `nixos-anywhere`.
+
+## Behavioral Requirements
+
+### Config Generation
+
+1. The generator MUST produce `flake.nix`, `configuration.nix`, and `hardware.nix` from a
+   single `GenerateConfig` input.
+2. Generated files MUST pass `nix-instantiate --parse` without errors.
+3. Generated files SHOULD pass `nixfmt-rfc-style` formatting (no diff on re-format).
+4. The `hostId` field MUST be generated from `/dev/urandom` (8 hex chars); it MUST fall back
+   to a time-based seed if `/dev/urandom` is unavailable.
+5. String values embedded in Nix files MUST be escaped: `\` → `\\`, `"` → `\"`, `${` → `\${`,
+   `\n` → `\\n`.
+
+### Build Validation (Nix Check)
+
+6. A Nix derivation MUST be importable as `checks.x86_64-linux.template-evaluation` from the
+   keystone-tui `flake.nix`.
+7. The check MUST evaluate at least 4 configuration variants:
+   - Single-disk ZFS (Server)
+   - Multi-disk ZFS mirror (Server, 2 devices)
+   - Single-disk ext4 (Laptop)
+   - ZFS with desktop module (Workstation)
+8. Each variant MUST evaluate successfully via `nixpkgs.lib.nixosSystem` without errors.
+9. Each variant MUST force deep evaluation by serializing `users.users`, `users.groups`, and
+   `systemd.services` via `builtins.toJSON`.
+10. The derivation MUST write `$out/<config-name>.json` for each variant, containing at
+    minimum `users`, `groups`, and `services` keys.
+11. The check MUST be runnable via `nix build .#checks.x86_64-linux.template-evaluation`.
+
+### Data Model Validation
+
+12. The system MUST reject a `GenerateConfig` with zero storage devices.
+13. The system MUST reject a `GenerateConfig` with zero users.
+14. The system MUST reject a `hostId` that is not exactly 8 hexadecimal characters.
+15. The system MUST reject `storage.mode = Mirror` with fewer than 2 devices.
+16. The system MUST reject `storage.hibernate = true` when `storage_type = Zfs`.
+
+## Edge Cases
+
+- **Special characters in hostnames**: Hostnames containing `"`, `\`, or `${` MUST be escaped
+  in all generated files. The `escape_nix_string` function already handles this.
+- **Empty authorized_keys**: An empty `authorized_keys` list MUST produce `authorizedKeys = []`
+  (not a missing field).
+- **Deferred disk selection**: When `disk_device` is `None`, the placeholder `__KEYSTONE_DISK__`
+  MUST appear in generated config. The ISO installer replaces it at install time.
+- **Multiple users**: All users MUST appear in `keystone.os.users`. The first user gets
+  `extraGroups = ["wheel"]`; desktop users get networking/video/audio groups.
+- **nixfmt unavailability**: If `nixfmt-rfc-style` is not in PATH, formatting validation MUST
+  be skipped (not a build failure), but a warning SHOULD be logged.
+
+## Cross-References
+- Spec 004 (TUI App Framework): the `GenerateConfig` model is populated by the interactive form
+  in `create_config.rs` and by the JSON mode parser.

--- a/packages/keystone-tui/specs/002-nix-flake-parsing-modification.md
+++ b/packages/keystone-tui/specs/002-nix-flake-parsing-modification.md
@@ -1,0 +1,168 @@
+# Spec: Nix Flake Parsing and Modification
+
+## Stories Covered
+- US-005: Display all keystone hosts
+- US-009: Create new keystone host configurations
+
+## Affected Modules
+- `packages/keystone-tui/src/nix.rs` — flake.nix AST parser (read-only today; needs write support)
+- `packages/keystone-tui/src/screens/hosts.rs` — hosts dashboard
+- `packages/keystone-tui/src/screens/create_config.rs` — config creation form
+- `packages/keystone-tui/src/system.rs` — `HostStatus` struct
+- `modules/hosts.nix` — `keystone.hosts` NixOS option (already implemented)
+
+## Data Models
+
+### `HostInfo` (extended — `src/nix.rs`)
+
+Current fields:
+| Field | Type | Notes |
+|-------|------|-------|
+| name | `String` | Attribute key in `nixosConfigurations` |
+| system | `Option<String>` | Architecture, e.g. `"x86_64-linux"` |
+| keystone_modules | `Vec<String>` | Imported keystone modules |
+| config_files | `Vec<String>` | Local config file paths |
+
+Fields to add (from `keystone.hosts` evaluation):
+| Field | Type | Notes |
+|-------|------|-------|
+| hostname | `Option<String>` | From `keystone.hosts.<name>.hostname` |
+| ssh_target | `Option<String>` | Tailscale hostname or IP for deploys |
+| fallback_ip | `Option<String>` | LAN IP fallback |
+| build_on_remote | `bool` | Whether to use `--build-host` for deploys |
+| role | `Option<String>` | `"client"` \| `"server"` \| `"agent"` |
+| host_public_key | `Option<String>` | SSH host public key |
+
+### `HostsEvalResult` (new — `src/nix.rs`)
+
+JSON output of `nix eval --json .#nixosConfigurations` for `keystone.hosts`:
+
+```json
+{
+  "ocean": {
+    "hostname": "ocean",
+    "sshTarget": "ocean.mercury",
+    "fallbackIP": "192.168.1.10",
+    "buildOnRemote": true,
+    "role": "server",
+    "hostPublicKey": "ssh-ed25519 AAAAC3..."
+  }
+}
+```
+
+## Behavioral Requirements
+
+### Host Display (US-005)
+
+1. The hosts screen MUST display hostname, sshTarget, fallbackIP, and buildOnRemote for each
+   host defined in `keystone.hosts`.
+2. The TUI MUST read `keystone.hosts` by running:
+   `nix eval --json .#nixosConfigurations.<hostname>.config.keystone.hosts`
+   or by parsing `nix eval --json` output from the flake's hosts attribute.
+3. The hosts list MUST be navigable via arrow keys; pressing Enter on a host MUST open the
+   host detail screen.
+4. The host detail screen MUST display a summary of the selected host's configuration
+   including all `keystone.hosts` fields.
+5. The TUI MUST handle the case where `keystone.hosts` is empty (show an empty list with a
+   hint to add hosts).
+6. The TUI MUST handle flakes that do not import `keystone.nixosModules.hosts` gracefully
+   (fall back to displaying names from `nixosConfigurations` only, without metadata).
+7. The `HostsScreen` MUST NOT block the event loop during `nix eval` — evaluation MUST run
+   on a background tokio task and results MUST be delivered via channel.
+
+### New Host Creation (US-009)
+
+8. The TUI MUST support two distinct host creation modes:
+   - **New repo mode**: Creates a fresh directory with `flake.nix`, `configuration.nix`,
+     `hardware.nix` (existing `CreateConfigScreen` flow).
+   - **Add-to-existing mode**: Adds a new host to an already-open nixos-config flake.
+9. In add-to-existing mode, the TUI MUST modify `flake.nix` to add a new entry under
+   `nixosConfigurations.<hostname>`.
+10. In add-to-existing mode, the TUI MUST create a `hosts/<hostname>/` directory containing
+    `configuration.nix` and `hardware.nix`.
+11. In add-to-existing mode, the TUI MUST add the new host to `keystone.hosts` in the
+    existing `configuration.nix` (or a shared `hosts.nix` if present).
+12. `flake.nix` modification MUST use `rnix` AST manipulation — NOT string replacement.
+13. Before writing to `flake.nix`, the TUI MUST validate the modified AST parses without
+    errors via `rnix`.
+14. The TUI MUST create a git commit for the new host files before returning to the hosts
+    screen (leveraging the git operations in Spec 004).
+15. If `rnix` AST modification fails (unparseable flake), the TUI MUST display an error and
+    MUST NOT write partial changes to disk.
+
+## `rnix` Modification Contract
+
+The `nix.rs` module MUST expose a `add_nixos_configuration` function:
+
+```rust
+/// Add a new NixOS configuration entry to an existing flake.nix.
+/// Returns the modified flake.nix content as a String.
+pub fn add_nixos_configuration(
+    flake_content: &str,
+    hostname: &str,
+    config_path: &str,  // e.g., "./hosts/my-host/configuration.nix"
+) -> Result<String>
+```
+
+The function MUST:
+- Parse `flake_content` with `rnix`
+- Locate the `nixosConfigurations` attrset
+- Insert a new entry: `"<hostname>" = nixpkgs.lib.nixosSystem { system = "x86_64-linux"; modules = [ <config_path> ]; };`
+- Return the serialized (formatted) modified content
+- Return `Err` if the flake cannot be parsed or `nixosConfigurations` cannot be located
+
+## Edge Cases
+
+- **Quoted hostnames**: Hostnames with hyphens (e.g., `my-server`) MUST be quoted as
+  `"my-server"` in the Nix attrset. The `add_nixos_configuration` function MUST handle this.
+- **Duplicate hostname**: If `nixosConfigurations` already contains the target hostname, the
+  TUI MUST show an error ("Host already exists") and MUST NOT overwrite the existing entry.
+- **Nix eval timeout**: `nix eval` for `keystone.hosts` MUST time out after 30 seconds and
+  fall back to displaying `nixosConfigurations` names only (without metadata).
+- **Uncommitted changes**: When adding a host, if `flake.nix` has unstaged changes, the TUI
+  SHOULD warn the user before proceeding.
+- **Missing `hosts/` directory**: If `hosts/<hostname>/` already exists (prior partial run),
+  the TUI MUST NOT overwrite existing files — it MUST show an error.
+
+## UI Mockups
+
+### Hosts Screen
+
+```
+┌─ Keystone TUI ─── my-infra ─────────────────────────────────────────────┐
+│                                                                          │
+│  Hosts                                         System (local)            │
+│ ┌──────────────────────────────────┐  ┌───────────────────────────────┐  │
+│ │ > ocean         server   online  │  │ CPU  ████████░░░░  42%        │  │
+│ │   mercury       client  offline  │  │ MEM  █████░░░░░░  51%        │  │
+│ │   titan         agent    online  │  │ DISK ██░░░░░░░░░  21%        │  │
+│ │                                  │  │ TEMP 61°C                     │  │
+│ │                                  │  └───────────────────────────────┘  │
+│ │                                  │                                      │
+│ │  [n] New Host  [Enter] Details   │  Tailscale: 2/3 online              │
+│ └──────────────────────────────────┘                                      │
+│                                                                          │
+│  [q] Quit  [b] Build  [i] ISO  [?] Help                                  │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Host Detail Screen
+
+```
+┌─ Host Detail: ocean ─────────────────────────────────────────────────────┐
+│                                                                          │
+│  Identity                          Connection                            │
+│  Hostname:   ocean                 SSH Target:    ocean.mercury           │
+│  Role:       server                Fallback IP:   192.168.1.10           │
+│  Build mode: remote                                                      │
+│                                                                          │
+│  Modules: operating-system, hosts, secrets                               │
+│                                                                          │
+│  [b] Build  [d] Deploy  [Esc] Back                                       │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Cross-References
+- Spec 001 (Config Generation): `GenerateConfig` is used to generate files for the new host.
+- Spec 003 (ISO Pipeline): Deployment from host detail screen (US-008) references this spec.
+- Spec 004 (TUI App Framework): Screen routing and git commit integration.

--- a/packages/keystone-tui/specs/003-iso-pipeline.md
+++ b/packages/keystone-tui/specs/003-iso-pipeline.md
@@ -1,0 +1,182 @@
+# Spec: ISO Pipeline
+
+## Stories Covered
+- US-007: Build ISO installers with baked-in agenix secrets
+- US-008: Detect and deploy to Keystone ISO instances
+
+## Affected Modules
+- `packages/keystone-tui/src/screens/iso.rs` — ISO build + write to USB (phases exist)
+- `packages/keystone-tui/src/template.rs` — `generate_iso_flake_nix` (already implemented)
+- `packages/keystone-tui/src/app.rs` — new `AppScreen::Deploy` variant needed for US-008
+- `modules/iso-installer.nix` — `keystone.nixosModules.isoInstaller` (already implemented)
+- `packages/keystone-tui/Cargo.toml` — needs mDNS crate for ISO discovery
+
+## Existing State
+
+The `IsoScreen` already supports:
+- **Phase SelectTarget**: listing USB devices + ~/Downloads
+- **Phase Building**: runs `nix build .#iso` in the active repo
+- **Phase Writing**: `dd` to USB or `cp` to ~/Downloads
+- **Phase Done/Failed**
+
+The `generate_iso_flake_nix` function already produces a flake that:
+- Uses `keystone.nixosModules.isoInstaller`
+- Embeds target config files at `/etc/keystone/install-config/`
+- Accepts SSH keys via `keystone.installer.sshKeys`
+
+## Gaps to Implement
+
+### US-007: Agenix Secrets Baking
+
+The current ISO build does not include agenix secrets. The agenix-secrets integration requires:
+1. Determining the path to the user's secrets repo
+2. Copying or symlinking the secrets into the ISO build directory as `agenix-secrets/`
+3. Wiring the secrets path into the generated ISO flake
+
+### US-008: ISO Instance Discovery and Deployment
+
+No deployment flow exists yet. A new `Deploy` screen must be created.
+
+## Data Models
+
+### `IsoTarget` (existing — `src/screens/iso.rs`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| label | `String` | Display name |
+| path | `String` | Device path or file path |
+| is_usb | `bool` | USB vs file destination |
+| size | `String` | Human-readable size |
+
+### `AgenixSecretsConfig` (new — `src/template.rs` or new module)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| secrets_repo_path | `PathBuf` | Absolute path to the user's agenix-secrets repo |
+| secrets_subdir | `Option<String>` | Subdirectory within the secrets repo; defaults to root |
+
+### `IsoInstanceDiscovery` (new — `src/screens/deploy.rs`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| hostname | `String` | mDNS hostname or user-provided |
+| ip_address | `String` | Discovered or manually entered IP |
+| discovered_via | `DiscoveryMethod` | `Mdns` \| `Manual` |
+
+### `DeployTarget` (new — `src/screens/deploy.rs`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| instance | `IsoInstanceDiscovery` | The discovered ISO instance |
+| config_hostname | `String` | Target nixosConfigurations key |
+| ssh_key_path | `Option<PathBuf>` | SSH key to use for deployment |
+
+## Behavioral Requirements
+
+### ISO Build with Agenix Secrets (US-007)
+
+1. The ISO screen MUST offer a "secrets integration" option before building.
+2. When secrets integration is enabled, the TUI MUST prompt for the path to the agenix-secrets
+   repository (defaulting to `~/.keystone/secrets/` if it exists).
+3. The TUI MUST copy the secrets repository into the ISO build directory at `agenix-secrets/`
+   before triggering `nix build`.
+4. The generated ISO flake MUST reference the `agenix-secrets/` directory so the installer
+   can access secrets during installation.
+5. The TUI MUST verify that the secrets repo contains an `agenix.nix` or `secrets.nix` file
+   before proceeding — if absent, MUST warn the user but allow building without secrets.
+6. The built ISO MUST boot and install without requiring manual secret entry (end-to-end
+   requirement — verified via manual test during development).
+7. ISO build MUST work when initiated from macOS by delegating to a configured remote builder
+   (the TUI MUST detect if Nix remote build is available; if not, display a helpful message).
+
+### ISO Instance Discovery (US-008)
+
+8. The deploy screen MUST attempt mDNS discovery for Keystone ISO instances on the local
+   network by querying for `_keystone-iso._tcp.local` service records.
+9. mDNS discovery MUST run for a configurable timeout (default 10 seconds) before showing
+   results (discovered + manual entry option).
+10. If mDNS discovery finds no instances, the TUI MUST offer a manual IP address entry field.
+11. The TUI MUST support both discovered and manually entered targets simultaneously in the
+    same list.
+12. The TUI MUST display each discovered instance with: hostname, IP address, and discovery
+    method (mDNS \| Manual).
+
+### Deployment (US-008)
+
+13. The TUI MUST invoke `nixos-anywhere --flake .#<hostname> root@<ip>` to deploy to a
+    discovered ISO instance.
+14. Before invoking nixos-anywhere, the TUI MUST:
+    - Verify that `nixos-anywhere` is available in PATH.
+    - Verify SSH connectivity to the target IP (port 22).
+    - Confirm the selected nixos-config hostname matches the intended target.
+15. The TUI MUST display deployment progress by streaming nixos-anywhere stdout/stderr to a
+    scrollable output pane.
+16. The TUI MUST display a clear success or failure status after deployment completes.
+17. The TUI MUST auto-detect local SSH keys from `~/.ssh/*.pub` and offer them for deployment.
+18. Deployment MUST NOT proceed without explicit user confirmation ("Deploy to 192.168.1.42?").
+
+### Error Handling
+
+19. If `nix build` fails during ISO creation, the TUI MUST show the last 20 lines of stderr
+    and transition to `IsoPhase::Failed`.
+20. If nixos-anywhere exits non-zero, the TUI MUST show the error output and allow the user
+    to retry.
+21. If mDNS discovery crashes (e.g., no network interface), the TUI MUST fall back to manual
+    entry silently (no panic).
+
+## Edge Cases
+
+- **macOS build path**: `nixos-anywhere` is Linux-only. When running on macOS, the TUI MUST
+  detect this and use the nixos-anywhere `--build-on-remote` flag, delegating the build to
+  the target machine or a configured remote builder.
+- **Secrets repo not found**: If the provided secrets path doesn't exist, the TUI MUST show
+  an error before touching any build files.
+- **USB write permission**: `dd` requires root on Linux. The TUI MUST check `/dev/<device>`
+  write permissions before starting the write phase and advise `sudo` if needed.
+- **ISO instance behind firewall**: If mDNS is blocked, manual IP is the only path. The TUI
+  MUST make manual entry the prominent fallback, not a buried option.
+- **Multiple ISO instances**: If mDNS discovers multiple instances, the TUI MUST allow
+  selecting which one to deploy to.
+
+## UI Mockups
+
+### ISO Screen (SelectTarget phase, with secrets option)
+
+```
+┌─ Build ISO Installer ────────────────────────────────────────────────────┐
+│                                                                          │
+│  Configuration: ocean (x86_64-linux)                                     │
+│                                                                          │
+│  Secrets Integration                                                     │
+│  ○ No secrets — install without agenix secrets                           │
+│  ● Include secrets from: ~/.keystone/secrets/  [Browse...]               │
+│                                                                          │
+│  Write Destination                                                       │
+│  ○ /dev/sdb  USB3 Flash Drive  (32 GB)                                   │
+│  ● ~/Downloads/keystone-ocean.iso  (save to file)                        │
+│                                                                          │
+│  [Enter] Build ISO    [Esc] Back                                         │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Deploy Screen
+
+```
+┌─ Deploy to ISO Instance ─────────────────────────────────────────────────┐
+│                                                                          │
+│  Discovered Instances (mDNS)                                             │
+│ ┌──────────────────────────────────────────────────────────────────────┐ │
+│ │ > keystone-installer.local   192.168.1.42   mDNS                    │ │
+│ │   [+ Enter IP manually...]                                           │ │
+│ └──────────────────────────────────────────────────────────────────────┘ │
+│                                                                          │
+│  Configuration:  ocean                                                   │
+│  SSH Key:        ~/.ssh/id_ed25519.pub  [Change]                         │
+│                                                                          │
+│  [Enter] Deploy   [r] Refresh   [Esc] Back                               │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Cross-References
+- Spec 001 (Config Generation): `generate_iso_flake_nix` produces the ISO flake.
+- Spec 004 (TUI App Framework): `AppScreen::Iso` and new `AppScreen::Deploy` routing.

--- a/packages/keystone-tui/specs/004-tui-app-framework.md
+++ b/packages/keystone-tui/specs/004-tui-app-framework.md
@@ -1,0 +1,199 @@
+# Spec: TUI App Framework
+
+## Stories Covered
+- US-004: Build interactive TUI with cross-platform support
+- US-006: Implement git and GitHub publishing
+- US-010: Document TUI installation and usage
+- US-011: Define phased delivery plan
+
+Note: US-005 and US-008 overlap with this boundary but are detailed in Spec 002 and Spec 003.
+
+## Affected Modules
+- `packages/keystone-tui/src/main.rs` — entry point, mode detection, CLI args
+- `packages/keystone-tui/src/app.rs` — `AppScreen` enum, screen transitions
+- `packages/keystone-tui/src/input.rs` — key dispatch and action handling
+- `packages/keystone-tui/src/screens/create_config.rs` — config creation form
+- `packages/keystone-tui/src/github.rs` — SSH key fetching; needs repo creation
+- `packages/keystone-tui/src/repo.rs` — git clone/discover; needs init + commit + push
+- `packages/keystone-tui/Cargo.toml` — `clap` for CLI, `git2` for git ops
+
+## Existing Framework State
+
+The TUI is implemented in **Rust** using `ratatui` (v0.29) + `crossterm` (v0.28). This is
+the implementation language going forward. The Bubbletea (Go) mention in issue #132 US-004
+is stale — the architecture decision to use Rust was made when the existing `keystone-ha/tui`
+was chosen as the reference implementation. No Go code exists in this package.
+
+## Cross-Platform Support
+
+The TUI already compiles and runs on both Linux and macOS. The `crossterm` backend handles
+platform differences. No additional cross-platform work is needed for the core TUI loop.
+
+macOS-specific considerations:
+- `/dev/disk*` paths differ; disk detection uses `sysinfo` which is cross-platform.
+- `tailscale status --json` may not be available; the TUI already handles missing tailscale.
+- SSH key paths and `~/.ssh/` layout are consistent across platforms.
+
+## Data Models
+
+### `AppScreen` (extended — `src/app.rs`)
+
+Current variants:
+- `Welcome`, `CreateConfig`, `Hosts`, `HostDetail`, `Build`, `Iso`, `Install`, `FirstBoot`
+
+New variants to add:
+- `Deploy` — ISO instance discovery + nixos-anywhere deployment (US-008)
+- `Git` — diff preview, commit, push (US-006)
+
+### `JsonInputConfig` (new — `src/main.rs` or `src/json_input.rs`)
+
+For non-interactive `--json` mode. Mirrors `GenerateConfig` as a JSON-deserializable struct:
+
+```json
+{
+  "hostname": "my-server",
+  "state_version": "25.05",
+  "time_zone": "America/Chicago",
+  "machine_type": "server",
+  "storage": {
+    "type": "zfs",
+    "devices": ["/dev/disk/by-id/nvme-abc123"],
+    "mode": "single",
+    "swap_size": "16G"
+  },
+  "security": {
+    "secure_boot": true,
+    "tpm": true
+  },
+  "users": [
+    {
+      "username": "admin",
+      "full_name": "Admin User",
+      "initial_password": "changeme",
+      "authorized_keys": ["ssh-ed25519 AAAA..."],
+      "terminal_enable": true,
+      "desktop_enable": false
+    }
+  ],
+  "output_dir": "/tmp/my-config"
+}
+```
+
+## Behavioral Requirements
+
+### TUI Interaction (US-004)
+
+1. The TUI MUST use `ratatui` with `crossterm` as the terminal backend (not Bubbletea/Go).
+2. The TUI MUST restore terminal state on exit via the existing panic hook.
+3. The TUI MUST handle terminal resize events without crashing.
+4. The TUI SHOULD support mouse events for clicking list items.
+5. The TUI MUST auto-detect SSH public keys from `~/.ssh/*.pub` during the user configuration
+   form step (create-config flow) and offer them for selection.
+6. The TUI MUST detect connected hardware security keys:
+   - YubiKey: detected via `lsusb` output or `/dev/hidraw*` on Linux
+   - SoloKey: same detection path
+   - On macOS: detected via `system_profiler SPUSBDataType`
+   - When detected, offer to configure `keystone.os.hardwareKey` (FIDO2 SSH key enrollment
+     via `ssh-keygen -t ed25519-sk`)
+7. Input validation MUST reject:
+   - Blank hostname
+   - Hostname longer than 63 characters or containing invalid characters (`[^a-z0-9-]`)
+   - Zero storage devices
+   - Zero users
+   - Blank username
+8. The TUI MUST display inline validation errors next to the offending field, not on a
+   separate error screen.
+
+### Non-Interactive JSON Mode (US-004)
+
+9. The TUI MUST accept a `--json <path>` CLI flag (or `--json -` for stdin).
+10. In JSON mode, the TUI MUST skip all interactive screens and directly generate config files
+    to the `output_dir` specified in the JSON input.
+11. In JSON mode, the TUI MUST validate the `JsonInputConfig` against the same rules as the
+    interactive form (Behavioral Requirements §7 above).
+12. In JSON mode, the TUI MUST print a success or error message to stdout and exit with
+    code 0 (success) or 1 (failure). No TUI rendering MUST occur.
+13. In JSON mode, the TUI MUST write `flake.nix`, `configuration.nix`, and `hardware.nix`
+    to `output_dir`, creating the directory if it doesn't exist.
+
+### Git Operations (US-006)
+
+14. After generating a new config (both interactive and JSON modes), the TUI MUST offer to:
+    - Initialize a git repository in the output directory
+    - Create an initial commit with message `"chore: initial keystone config for <hostname>"`
+15. The TUI MUST NOT auto-commit without user confirmation ("Initialize git repo? [y/N]").
+16. The TUI MUST warn if any generated file appears to contain a plaintext password (heuristic:
+    `initialPassword` value is present in the file and is not a bcrypt/yescrypt hash).
+17. The TUI MUST offer to create a private GitHub repository via `gh repo create`:
+    - Requires `gh` to be available in PATH and authenticated
+    - Uses SSH URL format for the remote: `git@github.com:<user>/<repo>.git`
+    - If `gh` is unavailable, display instructions for manual setup
+18. The TUI MUST NOT commit any of the following (MUST warn and exclude):
+    - Files matching `*.pem`, `*.key`, `*.age`, `id_rsa`, `id_ecdsa` (private keys)
+    - Files matching `.env`, `*.secret`
+    - Age-encrypted secrets (`.age` extension) ARE allowed in commits
+19. The `GitScreen` MUST show a diff preview (using `git2::Diff`) before the user confirms
+    a commit.
+20. The TUI MUST NOT push to a remote without explicit user confirmation ("Push to origin/main?").
+
+### GitHub Repo Creation (US-006)
+
+21. The TUI MUST shell out to `gh repo create <name> --private --source=. --remote=origin`
+    rather than using the GitHub API directly.
+22. If `gh` is not authenticated (`gh auth status` fails), the TUI MUST display a message:
+    "Run `gh auth login` to enable GitHub integration."
+23. The repo name MUST default to the hostname value from the generated config.
+
+## Edge Cases
+
+- **SSH key detection on macOS**: `~/.ssh/` may contain `.pub` files with whitespace in
+  names (unlikely but MUST not crash). The TUI MUST skip non-standard filenames gracefully.
+- **Hardware key detection**: If USB probing fails (permission denied on `/dev/hidraw*`), the
+  TUI MUST skip detection silently — do not display an error for missing hardware keys.
+- **JSON mode invalid path**: If `output_dir` already contains a `flake.nix`, the TUI MUST
+  error ("Output directory already contains a flake.nix; use --force to overwrite") and
+  exit with code 1.
+- **git2 init on existing repo**: If `output_dir` already contains `.git/`, the TUI MUST
+  skip `git init` and proceed to the commit step.
+- **`gh` invocation failure**: If `gh repo create` fails (e.g., name conflict), the TUI MUST
+  display the error and allow the user to retry with a different name or skip.
+
+## Phased Delivery Plan (US-011)
+
+The implementation MUST follow these phases:
+
+### Phase 1 — Config Contract (prerequisite, no TUI code)
+- **Deliverables**: Spec 001 implemented — `disko` in generated flake.nix, data model
+  complete, Nix check at `checks.x86_64-linux.template-evaluation` with 4 variants.
+- **Exit criteria**: `nix flake check` passes; all 4 test configs evaluate.
+
+### Phase 2 — Interactive TUI + Publishing
+- **Deliverables**: SSH key auto-detection (US-004), hardware key detection (US-004),
+  JSON mode (US-004), host display with `keystone.hosts` metadata (US-005), new host
+  creation into existing flake (US-009), git init + commit (US-006), GitHub repo creation (US-006).
+- **Entry criteria**: Phase 1 complete.
+- **Exit criteria**: Interactive config creation + publishing flow works end-to-end on macOS
+  and Linux.
+
+### Phase 3 — ISO Build + Deployment
+- **Deliverables**: Agenix secrets baking into ISO (US-007), mDNS ISO discovery (US-008),
+  nixos-anywhere deployment (US-008).
+- **Entry criteria**: Phase 2 complete; user has a functioning nixos-config repo.
+- **Exit criteria**: Full flow from `keystone-tui` launch to deployed NixOS system works
+  without manual Nix commands.
+
+### Documentation
+- **Deliverables**: README covers install, quick-start, all screens, JSON mode, ISO workflow.
+- **Timing**: Updated alongside Phase 2 and Phase 3 feature work; finalized before milestone close.
+
+## PLAN.md Alignment
+
+The existing `packages/keystone-tui/PLAN.md` defines 7 implementation phases. These MUST be
+reconciled with the 3-phase delivery plan above before Phase 2 work begins. The recommended
+approach: replace the 7-phase plan in `PLAN.md` with the 3-phase structure from this spec,
+keeping the module structure section unchanged.
+
+## Cross-References
+- Spec 001 (Config Generation): JSON mode populates `GenerateConfig` from `JsonInputConfig`.
+- Spec 002 (Nix Flake): New host creation and hosts screen are driven from the app framework.
+- Spec 003 (ISO Pipeline): `AppScreen::Deploy` is added by this spec.


### PR DESCRIPTION
Adds the missing engineering handoff spec for the post-install hardware pushback story from milestone #132. This follow-up closes the gap in PR #137, which covered the original 11-story scope before the pushback story was added.\n\nRefs #132