### PR TITLE
feat(vm): add rootless desktop demo workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,10 @@ vms/*/*.socket
 # build-vm artifacts (nixos-rebuild build-vm)
 .build-vm/
 build-vm-*.pid
+build-vm-*.log
 keystone-buildvm-*.qcow2
 build-vm-*.qcow2
+artifacts/
 
 # VM configuration (keep .example files tracked)
 vms/*.conf

--- a/bin/build-vm
+++ b/bin/build-vm
@@ -2,117 +2,57 @@
 #
 # build-vm - Fast VM testing for Keystone configurations
 #
-# This script uses nixos-rebuild build-vm for rapid iteration on configurations
-# without the overhead of full deployment (no disko/encryption/secure boot).
-# VM configurations are defined in ./tests/flake.nix.
-#
-# Usage:
-#   ./bin/build-vm terminal          # Build and auto-SSH into terminal VM
-#   ./bin/build-vm desktop            # Build and open desktop VM console
-#   ./bin/build-vm terminal --clean   # Clean old artifacts first
-#   ./bin/build-vm terminal --build-only  # Build only, don't run
-#
-# The VMs:
-#   - Mount host Nix store via 9P (read-only, fast)
-#   - Create persistent qcow2 disk (survives reboots)
-#   - Much faster than full deployment for testing configs
-#   - Located at ./build-vm-{terminal,desktop}.qcow2
-#
-# Automatic connection:
-#   - terminal: Starts VM in background, automatically SSHs in
-#   - desktop: Opens graphical console for Hyprland
-#
-# Compare with ./bin/test-deployment:
-#   - test-deployment: Full stack (ZFS, encryption, secure boot, TPM)
-#   - build-vm: Fast iteration on configs (no encryption/secure boot)
+# Uses nixos-rebuild build-vm for rapid iteration on terminal and desktop
+# configurations without the overhead of full deployment.
 
 set -euo pipefail
 
-# ANSI colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 CYAN='\033[0;36m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
 print_usage() {
     cat <<EOF
 Usage: $0 <terminal|desktop> [OPTIONS]
 
-Build and automatically connect to VMs for fast testing of Keystone configurations.
-
 Configurations:
-  terminal    Terminal dev environment - auto-SSH into VM
-  desktop     Hyprland desktop - open graphical console
+  terminal    Terminal dev environment
+  desktop     Hyprland desktop
 
 Options:
-  --build-only    Build VM but don't run/connect
+  --build-only    Build the VM but do not run it
+  --background    Run the VM in the background
+  --ssh           Connect to the running VM over SSH
+  --status        Show VM status
+  --stop          Stop the background VM
   --clean         Remove old VM artifacts before building
   --help          Show this help message
 
 Examples:
-  $0 terminal                  # Build and SSH into terminal VM
-  $0 desktop                   # Build and open desktop console
-  $0 terminal --clean          # Clean, rebuild, and connect
-  $0 desktop --build-only      # Just build, don't open console
-
-VM Details:
-  - Mounts host Nix store via 9P (read-only)
-  - Creates persistent qcow2 disk
-  - User: testuser (automatic SSH key login)
-  - Root: root / Password: root
-
-Automatic Connection:
-  terminal: Starts VM in background, waits for SSH, then auto-connects
-            Uses SSH key authentication (no password needed)
-            Exit SSH with: 'exit' or Ctrl-D
-            VM continues running in background after disconnect
-
-  desktop:  Opens QEMU window with graphical display
-            Login: testuser / testpass
-            Stop with: 'poweroff' in VM or Ctrl-C
-
-Manual Access (if needed):
-  terminal VM:
-    SSH: ssh -p 2222 testuser@localhost
-    Console: ./result/bin/run-keystone-buildvm-terminal-vm
-
-  desktop VM:
-    Console: ./result/bin/run-keystone-buildvm-desktop-vm
-
-Files Created:
-  - VM script: ./result/bin/run-keystone-buildvm-{terminal,desktop}-vm
-  - Persistent disk: ./keystone-buildvm-{terminal,desktop}.qcow2
-  - VM PID file: ./build-vm-{terminal,desktop}.pid (terminal only)
-
-Compare workflows:
-  ./bin/test-deployment  Full testing (ZFS, encryption, secure boot, TPM)
-  ./bin/build-vm        Fast config testing (no encryption/secure boot)
+  $0 terminal
+  $0 terminal --background
+  $0 desktop --background
+  $0 desktop --ssh
+  $0 desktop --status
+  $0 desktop --stop
 EOF
 }
 
-print_step() {
-    echo -e "${BLUE}==>${NC} $1"
-}
+print_step() { echo -e "${BLUE}==>${NC} $1"; }
+print_success() { echo -e "${GREEN}✓${NC} $1"; }
+print_error() { echo -e "${RED}✗${NC} $1"; }
+print_warning() { echo -e "${YELLOW}⚠${NC} $1"; }
+print_info() { echo -e "${CYAN}ℹ${NC} $1"; }
 
-print_success() {
-    echo -e "${GREEN}✓${NC} $1"
-}
+ssh_opts=(
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -o LogLevel=ERROR
+)
 
-print_error() {
-    echo -e "${RED}✗${NC} $1"
-}
-
-print_warning() {
-    echo -e "${YELLOW}⚠${NC} $1"
-}
-
-print_info() {
-    echo -e "${CYAN}ℹ${NC} $1"
-}
-
-# Parse arguments
 if [ $# -eq 0 ]; then
     print_error "No configuration specified"
     echo
@@ -120,7 +60,6 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-# Check for help flag first
 if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     print_usage
     exit 0
@@ -130,18 +69,20 @@ CONFIG="$1"
 shift
 
 BUILD_ONLY=false
+BACKGROUND=false
+SSH_MODE=false
+STATUS_ONLY=false
+STOP_ONLY=false
 CLEAN=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --build-only)
-            BUILD_ONLY=true
-            shift
-            ;;
-        --clean)
-            CLEAN=true
-            shift
-            ;;
+        --build-only) BUILD_ONLY=true ;;
+        --background) BACKGROUND=true ;;
+        --ssh) SSH_MODE=true ;;
+        --status) STATUS_ONLY=true ;;
+        --stop) STOP_ONLY=true ;;
+        --clean) CLEAN=true ;;
         --help|-h)
             print_usage
             exit 0
@@ -153,27 +94,111 @@ while [ $# -gt 0 ]; do
             exit 1
             ;;
     esac
+    shift
 done
 
-# Validate configuration
 case "$CONFIG" in
-    terminal|desktop)
-        FLAKE_CONFIG="build-vm-$CONFIG"
-        # VM script and disk names are based on hostname from VM config
-        VM_HOSTNAME="keystone-buildvm-$CONFIG"
-        DISK_IMAGE="$VM_HOSTNAME.qcow2"
+    terminal)
+        FLAKE_CONFIG="build-vm-terminal"
+        VM_HOSTNAME="keystone-buildvm-terminal"
+        SSH_PORT=2222
+        ;;
+    desktop)
+        FLAKE_CONFIG="build-vm-desktop"
+        VM_HOSTNAME="keystone-buildvm-desktop"
+        SSH_PORT=2223
         ;;
     *)
         print_error "Invalid configuration: $CONFIG"
-        echo
-        print_usage
         exit 1
         ;;
 esac
 
-# Clean if requested
-if [ "$CLEAN" = true ]; then
+DISK_IMAGE="$VM_HOSTNAME.qcow2"
+VM_SCRIPT="./result/bin/run-$VM_HOSTNAME-vm"
+PID_FILE="./build-vm-$CONFIG.pid"
+LOG_FILE="./build-vm-$CONFIG.log"
+SSH_USER="testuser"
+
+pid_is_running() {
+    [ -f "$PID_FILE" ] || return 1
+    local pid
+    pid=$(cat "$PID_FILE")
+    [ -n "$pid" ] || return 1
+    kill -0 "$pid" 2>/dev/null
+}
+
+ssh_is_ready() {
+    ssh "${ssh_opts[@]}" -o ConnectTimeout=1 -p "$SSH_PORT" "$SSH_USER@localhost" "echo ready" >/dev/null 2>&1
+}
+
+wait_for_ssh() {
+    local seconds=${1:-90}
+    local i
+    for ((i = 0; i < seconds; i++)); do
+        if ssh_is_ready; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+cleanup_port() {
+    if ! ss -tln 2>/dev/null | grep -q ":$SSH_PORT "; then
+        return 0
+    fi
+
+    local port_pid
+    port_pid=$(ss -tlnp 2>/dev/null | grep ":$SSH_PORT " | grep -o "pid=[0-9]*" | head -1 | cut -d= -f2 || true)
+    if [ -n "$port_pid" ]; then
+        print_info "Killing process $port_pid using port $SSH_PORT..."
+        kill "$port_pid" 2>/dev/null || true
+        sleep 2
+    fi
+}
+
+stop_vm() {
+    if pid_is_running; then
+        local pid
+        pid=$(cat "$PID_FILE")
+        print_info "Stopping $CONFIG VM (PID $pid)..."
+        kill "$pid" 2>/dev/null || true
+
+        local i
+        for i in {1..20}; do
+            if ! kill -0 "$pid" 2>/dev/null; then
+                break
+            fi
+            sleep 1
+        done
+
+        if kill -0 "$pid" 2>/dev/null; then
+            print_warning "Force-killing $CONFIG VM (PID $pid)..."
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    fi
+
+    rm -f "$PID_FILE"
+    cleanup_port
+}
+
+show_status() {
+    if pid_is_running; then
+        print_success "$CONFIG VM is running"
+        print_info "PID:  $(cat "$PID_FILE")"
+    else
+        print_info "$CONFIG VM is not running"
+    fi
+
+    print_info "SSH:  ssh -p $SSH_PORT $SSH_USER@localhost"
+    print_info "Log:  $LOG_FILE"
+    print_info "Disk: $DISK_IMAGE"
+}
+
+clean_artifacts() {
     print_step "Cleaning old VM artifacts"
+    stop_vm
 
     if [ -f "$DISK_IMAGE" ]; then
         rm -f "$DISK_IMAGE"
@@ -184,127 +209,92 @@ if [ "$CLEAN" = true ]; then
         rm -f result
         print_success "Removed result symlink"
     fi
-fi
+}
 
-# Build VM (configurations are in ./tests/flake.nix)
-print_step "Building VM for configuration: $CONFIG"
-print_info "This may take a few minutes on first build..."
+build_vm() {
+    print_step "Building VM for configuration: $CONFIG"
+    print_info "This may take a few minutes on first build..."
 
-if nixos-rebuild build-vm --flake "./tests#$FLAKE_CONFIG"; then
-    print_success "VM built successfully"
-else
-    print_error "Failed to build VM"
-    exit 1
-fi
-
-# Show build information
-echo
-print_info "Configuration: $CONFIG"
-print_info "VM script:     ./result/bin/run-$VM_HOSTNAME-vm"
-print_info "Disk image:    $DISK_IMAGE"
-echo
-
-# If build-only, exit here
-if [ "$BUILD_ONLY" = true ]; then
-    print_info "Build complete. To run manually:"
-    echo "  ./result/bin/run-$VM_HOSTNAME-vm"
-    echo
-    if [ "$CONFIG" = "terminal" ]; then
-        print_info "Or use this script without --build-only to auto-connect"
-    fi
-    exit 0
-fi
-
-# Auto-connect logic
-if [ "$CONFIG" = "terminal" ]; then
-    # Terminal VM: Start in background and SSH in
-    print_step "Starting terminal VM in background..."
-
-    VM_SCRIPT="./result/bin/run-$VM_HOSTNAME-vm"
-    PID_FILE="./build-vm-terminal.pid"
-
-    # Clean up any existing VM
-    if [ -f "$PID_FILE" ]; then
-        OLD_PID=$(cat "$PID_FILE")
-        if kill -0 "$OLD_PID" 2>/dev/null; then
-            print_info "Stopping existing VM (PID $OLD_PID)..."
-            kill "$OLD_PID" 2>/dev/null || true
-            sleep 2
-        fi
-        rm -f "$PID_FILE"
-    fi
-
-    # Check if port 2222 is already in use (e.g., from crashed VM)
-    if ss -tln 2>/dev/null | grep -q ":2222 "; then
-        print_warning "Port 2222 is already in use"
-        # Try to find and kill the process using port 2222
-        PORT_PID=$(ss -tlnp 2>/dev/null | grep ":2222 " | grep -o "pid=[0-9]*" | head -1 | cut -d= -f2)
-        if [ -n "$PORT_PID" ]; then
-            print_info "Killing process $PORT_PID using port 2222..."
-            kill "$PORT_PID" 2>/dev/null || true
-            sleep 2
-        fi
-    fi
-
-    # Start VM in background
-    nohup "$VM_SCRIPT" </dev/null >/dev/null 2>&1 &
-    VM_PID=$!
-    echo "$VM_PID" > "$PID_FILE"
-
-    print_info "VM started (PID $VM_PID)"
-    print_info "Waiting for VM to boot and SSH to be ready..."
-
-    # Give VM a few seconds to start booting before checking SSH
-    sleep 5
-
-    # Wait for SSH to be available (max 60 seconds)
-    SSH_READY=false
-    for i in {1..60}; do
-        if ssh -o StrictHostKeyChecking=no \
-               -o UserKnownHostsFile=/dev/null \
-               -o ConnectTimeout=1 \
-               -o LogLevel=ERROR \
-               -p 2222 testuser@localhost "echo ready" >/dev/null 2>&1; then
-            SSH_READY=true
-            break
-        fi
-        sleep 1
-    done
-
-    if [ "$SSH_READY" = false ]; then
-        print_error "SSH did not become ready in time"
-        print_info "VM is still running in background (PID $VM_PID)"
-        print_info "Try manually: ssh -p 2222 testuser@localhost"
-        print_info "Or connect to console: $VM_SCRIPT"
+    if nixos-rebuild build-vm --flake "./tests#$FLAKE_CONFIG"; then
+        print_success "VM built successfully"
+    else
+        print_error "Failed to build VM"
         exit 1
     fi
 
-    print_success "VM is ready!"
-    echo
-    print_info "Connecting via SSH (automatic key authentication)..."
-    print_warning "VM will keep running in background after you exit SSH"
-    print_info "To stop VM: kill $VM_PID  or  kill \$(cat $PID_FILE)"
-    echo
+    print_info "VM script: $VM_SCRIPT"
+    print_info "Disk image: $DISK_IMAGE"
+}
 
-    # SSH into the VM (automatic key-based authentication)
-    ssh -o StrictHostKeyChecking=no \
-        -o UserKnownHostsFile=/dev/null \
-        -o LogLevel=ERROR \
-        -p 2222 testuser@localhost
+start_vm_background() {
+    if pid_is_running; then
+        print_info "$CONFIG VM is already running"
+        return 0
+    fi
 
-    # After SSH exits
-    echo
-    print_info "SSH session ended"
-    print_info "VM is still running in background (PID $VM_PID)"
-    print_info "To reconnect: ssh -p 2222 testuser@localhost"
-    print_info "To stop VM: kill $VM_PID"
+    if [ ! -x "$VM_SCRIPT" ]; then
+        print_error "VM script not found: $VM_SCRIPT"
+        exit 1
+    fi
 
-elif [ "$CONFIG" = "desktop" ]; then
-    # Desktop VM: Run with graphical console
-    print_step "Starting desktop VM with graphical console..."
-    print_info "Login with: testuser / testpass"
-    print_info "Press Ctrl-C or use 'poweroff' in VM to stop"
-    echo
+    cleanup_port
+    print_step "Starting $CONFIG VM in background..."
+    nohup "$VM_SCRIPT" >"$LOG_FILE" 2>&1 &
+    local vm_pid=$!
+    echo "$vm_pid" > "$PID_FILE"
+    print_info "VM started (PID $vm_pid)"
 
-    exec ./result/bin/run-$VM_HOSTNAME-vm
+    if wait_for_ssh; then
+        print_success "SSH is ready on localhost:$SSH_PORT"
+    else
+        print_error "SSH did not become ready in time"
+        print_info "Check the VM log: $LOG_FILE"
+        exit 1
+    fi
+}
+
+connect_ssh() {
+    print_info "Connecting to $CONFIG VM via SSH..."
+    exec ssh "${ssh_opts[@]}" -p "$SSH_PORT" "$SSH_USER@localhost"
+}
+
+if [ "$CLEAN" = true ]; then
+    clean_artifacts
 fi
+
+if [ "$STATUS_ONLY" = true ]; then
+    show_status
+    exit 0
+fi
+
+if [ "$STOP_ONLY" = true ]; then
+    stop_vm
+    print_success "$CONFIG VM stopped"
+    exit 0
+fi
+
+build_vm
+
+if [ "$BUILD_ONLY" = true ]; then
+    print_info "Build complete. To run manually:"
+    echo "  $VM_SCRIPT"
+    exit 0
+fi
+
+if [ "$CONFIG" = "terminal" ] || [ "$BACKGROUND" = true ] || [ "$SSH_MODE" = true ]; then
+    stop_vm
+    start_vm_background
+
+    if [ "$SSH_MODE" = true ] || [ "$CONFIG" = "terminal" ]; then
+        connect_ssh
+    fi
+
+    print_info "$CONFIG VM is running in the background"
+    print_info "To stop it: $0 $CONFIG --stop"
+    exit 0
+fi
+
+print_step "Starting desktop VM with graphical console..."
+print_info "Login with: testuser / testpass"
+print_info "Press Ctrl-C or use 'poweroff' in the VM to stop"
+exec "$VM_SCRIPT"

--- a/bin/demo-artifact-publish
+++ b/bin/demo-artifact-publish
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# demo-artifact-publish - Publish screenshot and demo artifacts to R2
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: $0 <file-or-directory>
+
+Required environment:
+  KEYSTONE_DEMO_R2_BUCKET         R2 bucket name
+  KEYSTONE_DEMO_PUBLIC_BASE_URL   Public base URL for uploaded objects
+
+Optional environment:
+  KEYSTONE_DEMO_PREFIX            Object key prefix override
+  KEYSTONE_DEMO_WRANGLER_CONFIG   Wrangler config file to use
+EOF
+}
+
+if [[ $# -ne 1 || "$1" == "--help" || "$1" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+source_path="$1"
+if [[ ! -e "$source_path" ]]; then
+    echo "Path not found: $source_path" >&2
+    exit 1
+fi
+
+: "${KEYSTONE_DEMO_R2_BUCKET:?KEYSTONE_DEMO_R2_BUCKET must be set}"
+: "${KEYSTONE_DEMO_PUBLIC_BASE_URL:?KEYSTONE_DEMO_PUBLIC_BASE_URL must be set}"
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+repo_name="$(basename "$repo_root")"
+git_rev="$(git -C "$repo_root" rev-parse HEAD)"
+git_branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD)"
+git_branch="${git_branch//\//-}"
+timestamp="$(date +'%Y-%m-%d_%H-%M-%S')"
+
+prefix="${KEYSTONE_DEMO_PREFIX:-keystone/$repo_name/$git_branch/$timestamp}"
+public_base="${KEYSTONE_DEMO_PUBLIC_BASE_URL%/}"
+
+wrangler_args=()
+if [[ -n "${KEYSTONE_DEMO_WRANGLER_CONFIG:-}" ]]; then
+    wrangler_args+=(--config "$KEYSTONE_DEMO_WRANGLER_CONFIG")
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+manifest_items="$tmpdir/manifest.ndjson"
+markdown_path=""
+
+if [[ -d "$source_path" ]]; then
+    artifact_root="$(cd "$source_path" && pwd -P)"
+    manifest_path="$artifact_root/published.json"
+    markdown_path="$artifact_root/published.md"
+    mapfile -t files < <(find "$artifact_root" -type f ! -name 'published.json' ! -name 'published.md' | sort)
+else
+    source_abs="$(cd "$(dirname "$source_path")" && pwd -P)/$(basename "$source_path")"
+    artifact_root="$(dirname "$source_abs")"
+    manifest_path="$artifact_root/$(basename "$source_abs").published.json"
+    markdown_path="$artifact_root/$(basename "$source_abs").published.md"
+    files=("$source_abs")
+fi
+
+if [[ ${#files[@]} -eq 0 ]]; then
+    echo "No files to upload under $source_path" >&2
+    exit 1
+fi
+
+for file in "${files[@]}"; do
+    rel_path="${file#"$artifact_root"/}"
+    if [[ "$file" == "$artifact_root" ]]; then
+        rel_path="$(basename "$file")"
+    fi
+    object_key="$prefix/$rel_path"
+
+    wrangler "${wrangler_args[@]}" r2 object put "$KEYSTONE_DEMO_R2_BUCKET/$object_key" --file "$file" >/dev/null
+
+    url="$public_base/$object_key"
+    jq -n \
+        --arg file "$file" \
+        --arg rel_path "$rel_path" \
+        --arg object_key "$object_key" \
+        --arg url "$url" \
+        '{file: $file, rel_path: $rel_path, object_key: $object_key, url: $url}' >> "$manifest_items"
+done
+
+jq -s \
+    --arg source_path "$source_path" \
+    --arg prefix "$prefix" \
+    --arg git_rev "$git_rev" \
+    --arg created_at "$(date -Iseconds)" \
+    '{
+      source_path: $source_path,
+      prefix: $prefix,
+      git_rev: $git_rev,
+      created_at: $created_at,
+      files: .
+    }' "$manifest_items" > "$manifest_path"
+
+{
+    echo "# Demo artifacts"
+    echo
+    while IFS= read -r item; do
+        rel_path="$(jq -r '.rel_path' <<<"$item")"
+        url="$(jq -r '.url' <<<"$item")"
+        case "$rel_path" in
+            *.png|*.jpg|*.jpeg|*.webp|*.gif)
+                echo "## $rel_path"
+                echo
+                echo "![${rel_path}](${url})"
+                echo
+                ;;
+            *)
+                echo "- [$rel_path]($url)"
+                ;;
+        esac
+    done < "$manifest_items"
+} > "$markdown_path"
+
+printf '%s\n%s\n' "$manifest_path" "$markdown_path"

--- a/bin/dev-vm-capture
+++ b/bin/dev-vm-capture
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# dev-vm-capture - Collect screenshots and terminal evidence from build-vm guests
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: $0 <screenshot|terminal|journal> [OPTIONS]
+
+Options:
+  --config <desktop|terminal>   VM configuration to target (default: desktop)
+  --output-dir <path>           Artifact directory (default: artifacts/demos/<timestamp>)
+  --command <cmd>               Remote fallback command for terminal/journal capture
+
+Examples:
+  $0 screenshot
+  $0 terminal --command "ls -la"
+  $0 journal --config desktop
+EOF
+}
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+subcommand="${1:-}"
+
+if [[ -z "$subcommand" || "$subcommand" == "--help" || "$subcommand" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+shift
+
+config="desktop"
+output_dir=""
+remote_command=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --config)
+            config="${2:?missing value for --config}"
+            shift 2
+            ;;
+        --output-dir)
+            output_dir="${2:?missing value for --output-dir}"
+            shift 2
+            ;;
+        --command)
+            remote_command="${2:?missing value for --command}"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+case "$config" in
+    desktop) ssh_port=2223 ;;
+    terminal) ssh_port=2222 ;;
+    *)
+        echo "Invalid config: $config" >&2
+        exit 1
+        ;;
+esac
+
+if [[ -z "$output_dir" ]]; then
+    output_dir="$repo_root/artifacts/demos/$(date +'%Y-%m-%d_%H-%M-%S')"
+fi
+
+mkdir -p "$output_dir"
+
+ssh_opts=(
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -o LogLevel=ERROR
+    -p "$ssh_port"
+)
+scp_opts=(
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+    -o LogLevel=ERROR
+    -P "$ssh_port"
+)
+
+ssh_ready() {
+    ssh "${ssh_opts[@]}" testuser@localhost "echo ready" >/dev/null 2>&1
+}
+
+if ! ssh_ready; then
+    echo "VM is not reachable on localhost:$ssh_port. Start it with ./bin/build-vm $config --background" >&2
+    exit 1
+fi
+
+write_metadata() {
+    local kind="$1"
+    local primary_path="$2"
+    local secondary_path="${3:-}"
+    local metadata_path="$output_dir/metadata.json"
+    local git_rev
+    git_rev="$(git -C "$repo_root" rev-parse HEAD)"
+
+    jq -n \
+        --arg kind "$kind" \
+        --arg config "$config" \
+        --arg primary_path "$primary_path" \
+        --arg secondary_path "$secondary_path" \
+        --arg git_rev "$git_rev" \
+        --arg created_at "$(date -Iseconds)" \
+        --arg command "$remote_command" \
+        '{
+          kind: $kind,
+          config: $config,
+          git_rev: $git_rev,
+          created_at: $created_at,
+          command: ($command | select(length > 0)),
+          primary_path: $primary_path,
+          secondary_path: ($secondary_path | select(length > 0))
+        }' > "$metadata_path"
+}
+
+render_terminal_png() {
+    local txt_path="$1"
+    local png_path="$2"
+
+    freeze \
+        --output "$png_path" \
+        --theme catppuccin-mocha \
+        --language txt \
+        --window=false \
+        --padding "10" \
+        --margin "0" \
+        --font.size 14 < "$txt_path"
+}
+
+capture_terminal_text() {
+    local txt_path="$1"
+    local fallback_cmd="${2:-journalctl --user -b --no-pager -n 120}"
+
+    # shellcheck disable=SC2029
+    ssh "${ssh_opts[@]}" testuser@localhost "bash -s -- $(printf '%q' "$fallback_cmd")" <<'EOF' > "$txt_path"
+set -euo pipefail
+fallback_cmd="$1"
+
+if command -v tmux >/dev/null 2>&1 && tmux list-sessions >/dev/null 2>&1; then
+  tmux capture-pane -p -S -200
+else
+  bash -lc "$fallback_cmd"
+fi
+EOF
+}
+
+case "$subcommand" in
+    screenshot)
+        screenshot_path="$output_dir/desktop.png"
+        remote_path="/tmp/keystone-vm-screenshot-$(date +%s).png"
+
+        # shellcheck disable=SC2029
+        ssh "${ssh_opts[@]}" testuser@localhost "bash -s -- $(printf '%q' "$remote_path")" <<'EOF' >/dev/null
+set -euo pipefail
+keystone-vm-screenshot "$1"
+EOF
+        scp "${scp_opts[@]}" "testuser@localhost:$remote_path" "$screenshot_path" >/dev/null
+        # shellcheck disable=SC2029
+        ssh "${ssh_opts[@]}" testuser@localhost "bash -s -- $(printf '%q' "$remote_path")" <<'EOF' >/dev/null
+set -euo pipefail
+rm -f "$1"
+EOF
+
+        write_metadata "screenshot" "$screenshot_path"
+        printf '%s\n' "$screenshot_path"
+        ;;
+    terminal)
+        txt_path="$output_dir/terminal.txt"
+        png_path="$output_dir/terminal.png"
+        capture_terminal_text "$txt_path" "${remote_command:-journalctl --user -b --no-pager -n 120}"
+        render_terminal_png "$txt_path" "$png_path"
+        write_metadata "terminal" "$txt_path" "$png_path"
+        printf '%s\n%s\n' "$txt_path" "$png_path"
+        ;;
+    journal)
+        txt_path="$output_dir/journal.txt"
+        # shellcheck disable=SC2029
+        ssh "${ssh_opts[@]}" testuser@localhost "bash -s -- $(printf '%q' "${remote_command:-sudo -n journalctl -b --no-pager -n 200}")" <<'EOF' > "$txt_path"
+set -euo pipefail
+bash -lc "$1"
+EOF
+        write_metadata "journal" "$txt_path"
+        printf '%s\n' "$txt_path"
+        ;;
+    *)
+        echo "Unknown subcommand: $subcommand" >&2
+        usage >&2
+        exit 1
+        ;;
+esac

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -42,6 +42,7 @@ The intended workflow is:
 ## Related docs
 
 - [Desktop Keybindings](desktop/keybindings.md)
+- [Desktop VM Development](desktop/vm-development.md)
 - [Walker](desktop/walker.md)
 - [Monitors](desktop/monitors.md)
 - [Fingerprint Unlock](desktop/fingerprint-unlock.md)

--- a/docs/desktop/vm-development.md
+++ b/docs/desktop/vm-development.md
@@ -1,0 +1,70 @@
+---
+title: Desktop VM development
+description: Rootless build-vm workflow for Keystone Desktop iteration, capture, and demo publishing
+---
+
+# Desktop VM development
+
+Use the rootless `build-vm` workflow for day-to-day Keystone Desktop work.
+
+## Standard loop
+
+Start the desktop VM in the background:
+
+```bash
+./bin/build-vm desktop --background
+```
+
+Open a shell into the guest:
+
+```bash
+./bin/build-vm desktop --ssh
+```
+
+Capture a desktop screenshot:
+
+```bash
+./bin/dev-vm-capture screenshot
+```
+
+Capture terminal evidence as text plus PNG:
+
+```bash
+./bin/dev-vm-capture terminal
+```
+
+Publish the artifact set to R2:
+
+```bash
+export KEYSTONE_DEMO_R2_BUCKET=keystone-demo
+export KEYSTONE_DEMO_PUBLIC_BASE_URL=https://demo-assets.example.com
+./bin/demo-artifact-publish artifacts/demos/2026-03-31_12-00-00
+```
+
+Stop the VM when finished:
+
+```bash
+./bin/build-vm desktop --stop
+```
+
+## Commands
+
+- `./bin/build-vm desktop --background` builds the VM, starts it as a background process, and waits for SSH on `localhost:2223`
+- `./bin/build-vm desktop --ssh` opens an SSH shell to the running guest
+- `./bin/build-vm desktop --status` prints PID, SSH target, log path, and disk path
+- `./bin/dev-vm-capture screenshot` saves `desktop.png` under `artifacts/demos/<timestamp>/`
+- `./bin/dev-vm-capture terminal` saves `terminal.txt`, `terminal.png`, and `metadata.json`
+- `./bin/demo-artifact-publish <path>` uploads a file or artifact directory with `wrangler`, then writes `published.json` and `published.md`
+
+## Why this path
+
+- `build-vm` works without sudo on the local host
+- It is fast enough for desktop iteration
+- Screenshot capture happens inside the guest via the active Wayland session, then copies back to the repo
+- Terminal evidence is reproducible because it is captured as text and rendered to PNG locally
+
+## Tradeoffs
+
+- Use microvm for TPM-focused Tier 1 testing, not for Keystone Desktop iteration
+- Use libvirt for full-fidelity manual testing when you need that stack specifically
+- Do not use Git LFS as the default artifact path for iterative demo evidence

--- a/modules/desktop/nixos.nix
+++ b/modules/desktop/nixos.nix
@@ -4,6 +4,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   keystoneInputs,
   ...
@@ -11,6 +12,7 @@
 with lib;
 let
   cfg = config.keystone.desktop;
+  hasElephant = options ? services.elephant;
 in
 {
   # nix-flatpak is imported via flake.nix nixosModules.desktop (hoisted to avoid
@@ -89,9 +91,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    services.elephant.enable = mkDefault true;
-
+  config = mkIf cfg.enable ({
     # Flatpak support (declarative via nix-flatpak)
     services.flatpak.enable = mkDefault true;
 
@@ -250,5 +250,7 @@ in
       docker.serviceConfig.OOMScoreAdjust = 1000;
       podman.serviceConfig.OOMScoreAdjust = 1000;
     };
-  };
+  } // optionalAttrs hasElephant {
+    services.elephant.enable = mkDefault true;
+  });
 }

--- a/vms/README.md
+++ b/vms/README.md
@@ -21,8 +21,9 @@ There are two types of VM testing workflows:
 # Terminal dev environment - auto-SSH into VM
 ./bin/build-vm terminal
 
-# Hyprland desktop - open graphical console
-./bin/build-vm desktop
+# Hyprland desktop - run in background, then SSH in
+./bin/build-vm desktop --background
+./bin/build-vm desktop --ssh
 
 # Build only, don't connect
 ./bin/build-vm terminal --build-only
@@ -31,13 +32,14 @@ There are two types of VM testing workflows:
 **Characteristics**:
 
 - Uses `nixos-rebuild build-vm`
-- **Automatic connection** - Terminal auto-SSHs, Desktop opens console
+- **Automatic connection** - Terminal auto-SSHs, Desktop supports background mode plus SSH
 - Mounts host Nix store via 9P (read-only)
 - No encryption, secure boot, or TPM
 - Fast iteration (~minutes)
 - Persistent qcow2 disk images
 - Direct QEMU execution (no libvirt)
 - Terminal: SSH forwarded to `localhost:2222`
+- Desktop: SSH forwarded to `localhost:2223`
 
 ### 2. Full Stack Testing with `test-deployment` (For Complete Testing)
 
@@ -190,8 +192,15 @@ nixos-rebuild build-vm --flake .#build-vm-desktop
 # Edit desktop configuration
 vim modules/client/desktop/hyprland.nix
 
-# Rebuild and auto-connect to graphical console
-./bin/build-vm desktop
+# Rebuild and keep the VM running in the background
+./bin/build-vm desktop --background
+
+# Open a shell in the guest
+./bin/build-vm desktop --ssh
+
+# Capture evidence
+./bin/dev-vm-capture screenshot
+./bin/dev-vm-capture terminal
 ```
 
 ### Quick Terminal Config Test
@@ -282,6 +291,8 @@ rm -f build-vm-*.qcow2
 ## See Also
 
 - [../bin/build-vm](../bin/build-vm) - Fast VM testing script
+- [../bin/dev-vm-capture](../bin/dev-vm-capture) - Screenshot and terminal capture
+- [../bin/demo-artifact-publish](../bin/demo-artifact-publish) - R2 publishing helper
 - [../bin/test-deployment](../bin/test-deployment) - Full deployment test script
 - [../bin/virtual-machine](../bin/virtual-machine) - Libvirt VM management
 - [../CLAUDE.md](../CLAUDE.md) - Full project documentation

--- a/vms/build-vm-desktop/configuration.nix
+++ b/vms/build-vm-desktop/configuration.nix
@@ -5,6 +5,35 @@
   keystone,
   ...
 }:
+let
+  vmScreenshot = pkgs.writeShellScriptBin "keystone-vm-screenshot" ''
+    set -euo pipefail
+
+    output_path="''${1:-$HOME/Pictures/vm-screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png}"
+
+    if [[ -z "''${XDG_RUNTIME_DIR:-}" ]]; then
+      export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+    fi
+
+    if [[ -z "''${WAYLAND_DISPLAY:-}" ]]; then
+      for socket in "$XDG_RUNTIME_DIR"/wayland-*; do
+        if [[ -S "$socket" ]]; then
+          export WAYLAND_DISPLAY="$(basename "$socket")"
+          break
+        fi
+      done
+    fi
+
+    if [[ -z "''${WAYLAND_DISPLAY:-}" ]]; then
+      echo "No Wayland socket found in $XDG_RUNTIME_DIR" >&2
+      exit 1
+    fi
+
+    mkdir -p "$(dirname "$output_path")"
+    ${pkgs.grim}/bin/grim "$output_path"
+    printf '%s\n' "$output_path"
+  '';
+in
 {
   # Minimal Keystone configuration for Hyprland desktop testing
   # Uses nixos-rebuild build-vm for fast iteration without encryption/secure boot
@@ -26,6 +55,7 @@
   # Simple boot configuration for VM
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
+  nixpkgs.overlays = [ keystone.overlays.default ];
 
   # Root filesystem (required for NixOS)
   fileSystems."/" = {
@@ -62,6 +92,17 @@
   # Basic networking with DHCP
   networking.useDHCP = lib.mkDefault true;
 
+  # VM-specific configuration for build-vm
+  virtualisation.vmVariant = {
+    virtualisation.forwardPorts = [
+      {
+        from = "host";
+        host.port = 2223;
+        guest.port = 22;
+      }
+    ];
+  };
+
   # Enable serial console for VM
   boot.kernelParams = [
     "console=ttyS0,115200n8"
@@ -94,7 +135,11 @@
   security.sudo.wheelNeedsPassword = false;
 
   # System packages
-  environment.systemPackages = [
+  environment.systemPackages = with pkgs; [
+    tmux
+    util-linux
+    jq
+    vmScreenshot
   ];
 
   # Nix settings
@@ -109,9 +154,32 @@
     ];
   };
 
+  # Configure home-manager
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    sharedModules = [
+      keystone.homeModules.desktop
+    ];
+  };
+
   # Configure home-manager for test user
   home-manager.users.testuser = {
     home.stateVersion = "25.05";
+
+    keystone = {
+      desktop.enable = true;
+      notes = {
+        enable = true;
+        repo = "git@example.com:testuser/notes.git";
+      };
+      terminal.git = {
+        userName = "Hyprland Test User";
+        userEmail = "testuser@keystone-buildvm-desktop";
+      };
+      terminal.ai.enable = false;
+      terminal.sandbox.enable = false;
+    };
 
     # Git configuration
     programs.git = {

--- a/vms/build-vm-terminal/configuration.nix
+++ b/vms/build-vm-terminal/configuration.nix
@@ -26,6 +26,7 @@
   # Simple boot configuration for VM
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
+  nixpkgs.overlays = [ keystone.overlays.default ];
 
   # Root filesystem (required for NixOS)
   fileSystems."/" = {
@@ -114,7 +115,7 @@
 
     # Import home-manager modules
     sharedModules = [
-      ../../modules/keystone/terminal
+      keystone.homeModules.terminal
     ];
   };
 
@@ -125,10 +126,16 @@
     # Enable terminal dev environment
     keystone.terminal = {
       enable = true;
+      ai.enable = false;
+      sandbox.enable = false;
       git = {
         userName = "Terminal Test User";
         userEmail = "testuser@keystone-buildvm-terminal";
       };
+    };
+    keystone.notes = {
+      enable = true;
+      repo = "git@example.com:testuser/notes.git";
     };
   };
 }


### PR DESCRIPTION
## Summary

- add a rootless `build-vm` workflow for background desktop and terminal VMs with status, stop, and SSH entrypoints
- add `bin/dev-vm-capture` for guest screenshots, terminal evidence, and journal capture
- add `bin/demo-artifact-publish` for R2-backed artifact publishing and markdown output
- wire the desktop and terminal build-vm profiles so they evaluate with the keystone overlay and the minimum home-manager settings required for notes and git
- document the VM development workflow and ignore local artifact/log output

## Verification

- `nix develop .#default --command shellcheck ./bin/build-vm ./bin/dev-vm-capture ./bin/demo-artifact-publish`
- started `nix build ./tests#nixosConfigurations.build-vm-desktop.config.system.build.vm`
- started `nix build ./tests#nixosConfigurations.build-vm-terminal.config.system.build.vm`

## Remaining

- interactive VM boot validation is still needed
- screenshot capture and R2 publishing were not exercised end to end in this branch
