### PR TITLE
test(agents): add e2e test for agent task loop pipeline

### DIFF
--- a/bin/test-agent-pipeline
+++ b/bin/test-agent-pipeline
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# test-agent-pipeline: end-to-end test for the agent task loop.
+# Sends a ping email to a named agent, triggers the task loop, and
+# verifies the agent creates and completes a pong reply task.
+#
+# Usage:
+#   bin/test-agent-pipeline --agent NAME [--stage ingest|e2e] [--timeout SECS]
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+AGENT_NAME=""
+STAGE="e2e"
+TIMEOUT=300
+
+usage() {
+  cat <<'EOF'
+Usage: bin/test-agent-pipeline --agent NAME [--stage ingest|e2e] [--timeout SECS]
+
+  --agent NAME     OS agent to test (required)
+  --stage STAGE    Test stage: ingest (controlled input) or e2e (full pipeline)
+                   Default: e2e
+  --timeout SECS   Max wait for task loop completion. Default: 300
+  -h, --help       Show this help
+EOF
+}
+
+pass() { printf "${GREEN}PASS${NC}: %s\n" "$1"; }
+fail() { printf "${RED}FAIL${NC}: %s\n" "$1" >&2; }
+info() { printf "${CYAN}INFO${NC}: %s\n" "$1"; }
+warn() { printf "${YELLOW}WARN${NC}: %s\n" "$1"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent) AGENT_NAME="$2"; shift 2 ;;
+    --stage) STAGE="$2"; shift 2 ;;
+    --timeout) TIMEOUT="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$AGENT_NAME" ]]; then
+  echo "Error: --agent NAME is required" >&2
+  usage >&2
+  exit 1
+fi
+
+USERNAME="agent-${AGENT_NAME}"
+UNIT="agent-${AGENT_NAME}-task-loop"
+TIMER="${UNIT}.timer"
+STATE_DIR_REL=".local/state/agent-task-loop/state"
+NOTES_DIR=""
+BACKUP_DONE=false
+TIMER_STOPPED=false
+
+cleanup() {
+  local exit_code=$?
+  if [[ "$BACKUP_DONE" == "true" ]]; then
+    info "Restoring TASKS.yaml backup..."
+    sudo -u "$USERNAME" bash -lc "
+      cd \"$NOTES_DIR\" 2>/dev/null || true
+      if [[ -f TASKS.yaml.test-backup ]]; then
+        mv TASKS.yaml.test-backup TASKS.yaml
+      fi
+    " || warn "Failed to restore TASKS.yaml backup"
+  fi
+  if [[ "$TIMER_STOPPED" == "true" ]]; then
+    info "Resuming task loop timer..."
+    sudo -u "$USERNAME" bash -lc "systemctl --user start $TIMER" || warn "Failed to restart timer"
+  fi
+  if [[ $exit_code -eq 0 ]]; then
+    echo ""
+    printf '%b' "${GREEN}All tests passed.${NC}\n"
+  else
+    echo ""
+    printf '%b' "${RED}Test failed.${NC}\n"
+  fi
+}
+trap cleanup EXIT
+
+# === Preflight checks ===
+info "Running preflight checks for agent '$AGENT_NAME'..."
+
+# Check agent user exists
+if ! id "$USERNAME" &>/dev/null; then
+  fail "User '$USERNAME' does not exist"
+  exit 1
+fi
+pass "Agent user '$USERNAME' exists"
+
+# Discover notes dir
+NOTES_DIR=$(sudo -u "$USERNAME" bash -lc 'echo $HOME' 2>/dev/null)
+# Try common notes paths
+for candidate in \
+  "/home/$USERNAME/agent-space" \
+  "/home/$USERNAME/notes" \
+  "/home/$USERNAME"; do
+  if sudo -u "$USERNAME" test -f "$candidate/TASKS.yaml" 2>/dev/null || \
+     sudo -u "$USERNAME" test -d "$candidate" 2>/dev/null; then
+    NOTES_DIR="$candidate"
+    break
+  fi
+done
+info "Using notes dir: $NOTES_DIR"
+
+# Check task-loop service exists
+if ! sudo -u "$USERNAME" bash -lc "systemctl --user cat $UNIT" &>/dev/null; then
+  fail "Service unit '$UNIT' not found"
+  exit 1
+fi
+pass "Task loop service exists"
+
+# Check himalaya is available
+if ! sudo -u "$USERNAME" bash -lc "command -v himalaya" &>/dev/null; then
+  fail "himalaya not found in agent PATH"
+  exit 1
+fi
+pass "himalaya available"
+
+if [[ "$STAGE" == "e2e" ]]; then
+  # === E2E test ===
+  info "Starting full e2e test..."
+
+  # Stop the timer to prevent races
+  info "Pausing task loop timer..."
+  sudo -u "$USERNAME" bash -lc "systemctl --user stop $TIMER" 2>/dev/null || true
+  TIMER_STOPPED=true
+
+  # Wait for any in-progress run to finish
+  WAIT_COUNT=0
+  while sudo -u "$USERNAME" bash -lc "systemctl --user is-active $UNIT" &>/dev/null; do
+    if [[ $WAIT_COUNT -ge 60 ]]; then
+      fail "Timed out waiting for existing task loop to finish"
+      exit 1
+    fi
+    info "Waiting for existing task loop run to finish..."
+    sleep 5
+    WAIT_COUNT=$((WAIT_COUNT + 5))
+  done
+
+  # Backup TASKS.yaml
+  info "Backing up TASKS.yaml..."
+  sudo -u "$USERNAME" bash -lc "
+    cd \"$NOTES_DIR\" 2>/dev/null || true
+    if [[ -f TASKS.yaml ]]; then
+      cp TASKS.yaml TASKS.yaml.test-backup
+    fi
+  "
+  BACKUP_DONE=true
+
+  # Send ping email
+  info "Sending ping email to $USERNAME..."
+  DOMAIN=$(sudo -u "$USERNAME" bash -lc '
+    config="${XDG_CONFIG_HOME:-$HOME/.config}/himalaya/config.toml"
+    if [[ -f "$config" ]]; then
+      grep -m1 "^email" "$config" | sed "s/^email.*= *\"\(.*\)\"/\1/" | cut -d@ -f2
+    else
+      hostname -f
+    fi
+  ' 2>/dev/null || hostname -f)
+  AGENT_EMAIL="${USERNAME}@${DOMAIN}"
+
+  sudo -u "$USERNAME" bash -lc "
+    printf 'From: test-pipeline@${DOMAIN}\r\nTo: ${AGENT_EMAIL}\r\nSubject: ping\r\nDate: $(date -R)\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nping\r\n' \
+      | himalaya message send
+  "
+  pass "Ping email sent to $AGENT_EMAIL"
+
+  # Clear hash caches
+  info "Clearing ingest hash cache..."
+  sudo -u "$USERNAME" bash -lc "
+    rm -f \"\$HOME/$STATE_DIR_REL/ingest-inputs.sha256\"
+    rm -f \"\$HOME/$STATE_DIR_REL/prioritize-inputs.sha256\"
+  "
+
+  # Trigger task loop
+  info "Triggering task loop..."
+  sudo -u "$USERNAME" bash -lc "systemctl --user start $UNIT"
+
+  # Poll for completion
+  info "Waiting for task loop to complete (timeout: ${TIMEOUT}s)..."
+  ELAPSED=0
+  while sudo -u "$USERNAME" bash -lc "systemctl --user is-active $UNIT" &>/dev/null; do
+    if [[ $ELAPSED -ge $TIMEOUT ]]; then
+      fail "Task loop did not complete within ${TIMEOUT}s"
+      sudo -u "$USERNAME" bash -lc "journalctl --user -u $UNIT --no-pager -n 20" 2>/dev/null || true
+      exit 1
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  pass "Task loop completed in ${ELAPSED}s"
+
+  # Check task loop exit status
+  LOOP_EXIT=$(sudo -u "$USERNAME" bash -lc "systemctl --user show -p ExecMainStatus $UNIT" 2>/dev/null | cut -d= -f2)
+  if [[ "$LOOP_EXIT" != "0" ]]; then
+    warn "Task loop exited with status $LOOP_EXIT"
+    sudo -u "$USERNAME" bash -lc "journalctl --user -u $UNIT --no-pager -n 30" 2>/dev/null || true
+  fi
+
+  # Verify pong task exists in TASKS.yaml
+  PONG_COUNT=$(sudo -u "$USERNAME" bash -lc "
+    cd \"$NOTES_DIR\" 2>/dev/null || true
+    yq '[.tasks[] | select(.name | test(\"pong\"))] | length' TASKS.yaml 2>/dev/null || echo 0
+  ")
+  if [[ "$PONG_COUNT" -eq 0 ]]; then
+    fail "No pong task found in TASKS.yaml"
+    sudo -u "$USERNAME" bash -lc "cd \"$NOTES_DIR\"; cat TASKS.yaml" 2>/dev/null || true
+    exit 1
+  fi
+  pass "Pong task found in TASKS.yaml ($PONG_COUNT match(es))"
+
+  # Check pong task status
+  PONG_STATUS=$(sudo -u "$USERNAME" bash -lc "
+    cd \"$NOTES_DIR\" 2>/dev/null || true
+    yq '[.tasks[] | select(.name | test(\"pong\"))] | .[0].status' TASKS.yaml 2>/dev/null || echo unknown
+  ")
+  info "Pong task status: $PONG_STATUS"
+  if [[ "$PONG_STATUS" == "completed" ]]; then
+    pass "Pong task completed successfully"
+  elif [[ "$PONG_STATUS" == "error" ]]; then
+    warn "Pong task errored (Claude may have failed to send reply)"
+  else
+    warn "Pong task status is '$PONG_STATUS' (expected completed)"
+  fi
+
+  # Check for pong in sent mail (best-effort)
+  SENT_PONG=$(sudo -u "$USERNAME" bash -lc "
+    himalaya envelope list --output json 2>/dev/null | \
+      jq '[.[] | select(.subject | test(\"pong\"; \"i\"))] | length' 2>/dev/null || echo 0
+  ")
+  if [[ "$SENT_PONG" -gt 0 ]]; then
+    pass "Pong reply found in mailbox"
+  else
+    info "No pong reply found in mailbox (may need to check sent folder)"
+  fi
+
+elif [[ "$STAGE" == "ingest" ]]; then
+  # === Ingest-only test ===
+  info "Starting ingest-only test..."
+
+  FIXTURE_DIR="$(cd "$(dirname "$0")/.." && pwd)/tests/fixtures/task-loop"
+  if [[ ! -f "$FIXTURE_DIR/email-ping-source.json" ]]; then
+    fail "Fixture not found: $FIXTURE_DIR/email-ping-source.json"
+    exit 1
+  fi
+
+  SOURCES_JSON=$(jq -c '[{"source": "email", "data": .}]' "$FIXTURE_DIR/email-ping-source.json")
+
+  info "Invoking ingest with controlled fixture input..."
+  sudo -u "$USERNAME" bash -lc "
+    cd \"$NOTES_DIR\" 2>/dev/null || true
+    if [[ -f TASKS.yaml ]]; then
+      cp TASKS.yaml TASKS.yaml.test-backup
+    fi
+  "
+  BACKUP_DONE=true
+
+  sudo -u "$USERNAME" bash -lc "
+    cd \"$NOTES_DIR\" 2>/dev/null || true
+    claude --print --output-format json --dangerously-skip-permissions \
+      '/deepwork task_loop ingest
+
+Source data (pre-fetched):
+$(echo "$SOURCES_JSON" | jq .)'
+  " 2>&1 || true
+
+  PONG_COUNT=$(sudo -u "$USERNAME" bash -lc "
+    cd \"$NOTES_DIR\" 2>/dev/null || true
+    yq '[.tasks[] | select(.name | test(\"pong\"))] | length' TASKS.yaml 2>/dev/null || echo 0
+  ")
+  if [[ "$PONG_COUNT" -gt 0 ]]; then
+    pass "Ingest created pong task ($PONG_COUNT match(es))"
+  else
+    fail "Ingest did not create a pong task"
+    sudo -u "$USERNAME" bash -lc "cd \"$NOTES_DIR\"; cat TASKS.yaml" 2>/dev/null || true
+    exit 1
+  fi
+
+else
+  echo "Error: unknown stage '$STAGE' (expected: ingest, e2e)" >&2
+  exit 1
+fi

--- a/flake.nix
+++ b/flake.nix
@@ -416,6 +416,9 @@
           agent-task-loop-hash-regression = import ./tests/module/agent-task-loop-hash-regression.nix {
             inherit pkgs lib;
           };
+          agent-task-loop-ping-pong = import ./tests/module/agent-task-loop-ping-pong.nix {
+            inherit pkgs lib;
+          };
         };
 
       # Packages exported for consumption — sourced from the overlay (single source of truth)

--- a/modules/os/agents/scripts/task-loop.sh
+++ b/modules/os/agents/scripts/task-loop.sh
@@ -130,7 +130,7 @@ extract_urls_json() {
     return
   fi
 
-  grep -Eo 'https?://[^ )"'"'"']+' "$file" 2>/dev/null | sort -u | jq -R . | jq -s .
+  grep -Eo 'https?://[^ )"'"'"']+' "$file" 2>/dev/null | sort -u | jq -R . | jq -s . || printf '[]\n'
 }
 
 extract_issue_urls_json() {
@@ -231,7 +231,8 @@ stage_builtin_profile() {
 
 resolve_stage_runtime() {
   local stage_name="$1"
-  local task_json="${2:-{}}"
+  local task_json
+  task_json="${2:-"{}"}"
   local built_in_profile stage_json
 
   built_in_profile=$(stage_builtin_profile "$stage_name")

--- a/tests/fixtures/task-loop/email-ping-source.json
+++ b/tests/fixtures/task-loop/email-ping-source.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "1",
+    "flags": [],
+    "subject": "ping",
+    "from": {
+      "name": "Test User",
+      "addr": "test@ncrmro.com"
+    },
+    "to": [
+      {
+        "name": "Test Agent",
+        "addr": "agent-test@ncrmro.com"
+      }
+    ],
+    "date": "2026-04-03T12:00:00Z",
+    "has_attachment": false
+  }
+]

--- a/tests/module/agent-task-loop-ping-pong.nix
+++ b/tests/module/agent-task-loop-ping-pong.nix
@@ -1,0 +1,190 @@
+{
+  pkgs,
+  lib,
+}:
+let
+  emailPingFixture = ../fixtures/task-loop/email-ping-source.json;
+  calendulaEventsFixture = ../fixtures/task-loop/calendula-events.json;
+  emptyProjectIndexFixture = ../fixtures/task-loop/project-index-empty.json;
+  defaultsJson = builtins.toJSON {
+    profile = "";
+    provider = "";
+    model = "";
+    fallbackModel = "";
+    effort = "";
+  };
+  profilesJson = builtins.toJSON {
+    fast = {
+      claude = { };
+    };
+    medium = {
+      claude = { };
+    };
+  };
+  projectIndexHelper = pkgs.writeShellScriptBin "keystone-project-index" ''
+    cat ${emptyProjectIndexFixture}
+  '';
+  taskLoopScript = pkgs.replaceVars ../../modules/os/agents/scripts/task-loop.sh {
+    notesDir = "/tmp/task-loop-ping-pong-notes";
+    maxTasks = "1";
+    agentName = "test";
+    githubUsername = "";
+    forgejoUsername = "";
+    defaultsJson = defaultsJson;
+    ingestJson = defaultsJson;
+    prioritizeJson = defaultsJson;
+    executeJson = defaultsJson;
+    profilesJson = profilesJson;
+    projectIndexHelper = projectIndexHelper;
+  };
+in
+pkgs.runCommand "test-agent-task-loop-ping-pong"
+  {
+    nativeBuildInputs = with pkgs; [
+      bash
+      coreutils
+      findutils
+      gawk
+      gnugrep
+      gnused
+      jq
+      util-linux
+      yq-go
+    ];
+  }
+  ''
+    set -euo pipefail
+
+    export HOME="$PWD/home"
+    export TASK_LOOP_TEST_STATE_DIR="$PWD/state"
+    export PATH="$PWD/stubs:${
+      lib.makeBinPath [
+        pkgs.bash
+        pkgs.coreutils
+        pkgs.findutils
+        pkgs.gawk
+        pkgs.gnugrep
+        pkgs.gnused
+        pkgs.jq
+        pkgs.util-linux
+        pkgs.yq-go
+      ]
+    }"
+
+    mkdir -p "$HOME" "$TASK_LOOP_TEST_STATE_DIR" "$PWD/stubs" /tmp/task-loop-ping-pong-notes
+
+    printf '%s\n' 'tasks: []' > /tmp/task-loop-ping-pong-notes/TASKS.yaml
+
+    # Stub: systemctl (no-op)
+    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/systemctl"
+    chmod +x "$PWD/stubs/systemctl"
+
+    # Stub: git (no-op)
+    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/git"
+    chmod +x "$PWD/stubs/git"
+
+    # Stub: hostname
+    printf '%s\n' '#!${pkgs.bash}/bin/bash' "printf '%s\\n' \"test-host\"" > "$PWD/stubs/hostname"
+    chmod +x "$PWD/stubs/hostname"
+
+    # Stub: himalaya - returns ping email fixture
+    printf '%s\n' '#!${pkgs.bash}/bin/bash' "cat ${emailPingFixture}" > "$PWD/stubs/himalaya"
+    chmod +x "$PWD/stubs/himalaya"
+
+    # Stub: calendula - returns events fixture
+    printf '%s\n' '#!${pkgs.bash}/bin/bash' "cat ${calendulaEventsFixture}" > "$PWD/stubs/calendula"
+    chmod +x "$PWD/stubs/calendula"
+
+    # Stub: claude - handles ingest, prioritize, and execute stages
+    cat > "$PWD/stubs/claude" <<'STUBEOF'
+    #!${pkgs.bash}/bin/bash
+    set -euo pipefail
+
+    args="$*"
+    state_dir="''${TASK_LOOP_TEST_STATE_DIR:?}"
+
+    if printf '%s' "$args" | grep -q "task_loop ingest"; then
+      # Ingest stage: create a pong reply task from the ping email
+      printf '%s\n' "1" > "$state_dir/ingest-count"
+      cat > TASKS.yaml <<'YAML'
+    tasks:
+      - name: reply-pong-to-test
+        description: "Reply with pong to the ping email from test@ncrmro.com"
+        status: pending
+        source: email
+        source_ref: "email-1-test@ncrmro.com"
+    YAML
+
+    elif printf '%s' "$args" | grep -q "task_loop prioritize"; then
+      # Prioritize stage: assign model haiku to the pong task
+      printf '%s\n' "1" > "$state_dir/prioritize-count"
+      yq -i '(.tasks[] | select(.name == "reply-pong-to-test")).model = "haiku"' TASKS.yaml
+
+    else
+      # Execute stage: record the task name and exit 0
+      # (task-loop.sh marks the task completed on exit 0)
+      printf '%s\n' "1" > "$state_dir/execute-count"
+      printf '%s\n' "$args" > "$state_dir/execute-args"
+    fi
+
+    printf '%s\n' '{"total_tokens":1}'
+    STUBEOF
+    chmod +x "$PWD/stubs/claude"
+
+    # Run the task loop once
+    bash "${taskLoopScript}"
+
+    # === Assertions ===
+
+    # 1. Ingest was invoked
+    if [[ ! -f "$TASK_LOOP_TEST_STATE_DIR/ingest-count" ]]; then
+      echo "FAIL: ingest stage was not invoked" >&2
+      exit 1
+    fi
+    echo "PASS: ingest stage invoked"
+
+    # 2. Prioritize was invoked
+    if [[ ! -f "$TASK_LOOP_TEST_STATE_DIR/prioritize-count" ]]; then
+      echo "FAIL: prioritize stage was not invoked" >&2
+      exit 1
+    fi
+    echo "PASS: prioritize stage invoked"
+
+    # 3. Execute was invoked
+    if [[ ! -f "$TASK_LOOP_TEST_STATE_DIR/execute-count" ]]; then
+      echo "FAIL: execute stage was not invoked" >&2
+      exit 1
+    fi
+    echo "PASS: execute stage invoked"
+
+    # 4. Execute received the pong task name
+    execute_args="$(cat "$TASK_LOOP_TEST_STATE_DIR/execute-args")"
+    if ! printf '%s' "$execute_args" | grep -qi "reply-pong-to-test"; then
+      echo "FAIL: execute stage did not receive pong task name" >&2
+      echo "  execute args: $execute_args" >&2
+      exit 1
+    fi
+    echo "PASS: execute received pong task name"
+
+    # 5. TASKS.yaml has the pong task (status should be completed after execute exit 0)
+    pong_status="$(yq '[.tasks[] | select(.name == "reply-pong-to-test")] | .[0].status' /tmp/task-loop-ping-pong-notes/TASKS.yaml)"
+    if [[ "$pong_status" != "completed" ]]; then
+      echo "FAIL: pong task status is '$pong_status', expected 'completed'" >&2
+      echo "  TASKS.yaml contents:" >&2
+      cat /tmp/task-loop-ping-pong-notes/TASKS.yaml >&2
+      exit 1
+    fi
+    echo "PASS: pong task completed"
+
+    # 6. Pong task has model haiku assigned
+    pong_model="$(yq '[.tasks[] | select(.name == "reply-pong-to-test")] | .[0].model' /tmp/task-loop-ping-pong-notes/TASKS.yaml)"
+    if [[ "$pong_model" != "haiku" ]]; then
+      echo "FAIL: pong task model is '$pong_model', expected 'haiku'" >&2
+      exit 1
+    fi
+    echo "PASS: pong task model is haiku"
+
+    echo ""
+    echo "All ping-pong pipeline assertions passed."
+    touch "$out"
+  ''


### PR DESCRIPTION
## Summary

- Add Nix sandbox test (`agent-task-loop-ping-pong`) that validates the full task-loop pipeline with stub binaries
- Add live e2e script (`bin/test-agent-pipeline`) for testing any named agent on a running system
- **Fix two critical production bugs** in `task-loop.sh` that broke every agent task execution:
  - Bash `${2:-{}}` brace expansion appended extra `}` to JSON, corrupting runtime config
  - `extract_urls_json` crashed when task logs contained no URLs (grep exits 1 on no match with pipefail)

## Test plan

- [x] `nix build .#checks.x86_64-linux.agent-task-loop-ping-pong` passes
- [x] `nix build .#checks.x86_64-linux.agent-task-loop-hash-regression` passes (no regression)
- [x] `shellcheck bin/test-agent-pipeline` clean
- [ ] After deploy: `bin/test-agent-pipeline --agent drago --stage e2e` passes on live system

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)