### PR TITLE
fix(templates): infer installer ISO system from Linux host inventory

### DIFF
--- a/docs/os/iso-generation.md
+++ b/docs/os/iso-generation.md
@@ -9,14 +9,14 @@ Generate a Keystone installer ISO with SSH keys for remote installation.
 
 ## Config repo (mkSystemFlake)
 
-Flakes built with `mkSystemFlake` automatically produce an installer ISO. Add your SSH
-public keys to the `owner` block and build:
+Flakes built with `mkSystemFlake` automatically produce an installer ISO when the flake
+declares at least one Linux host. Add your SSH public keys to the `admin` block and build:
 
 ```nix
 # flake.nix
 keystone.lib.mkSystemFlake {
-  owner = {
-    name = "Your Name";
+  admin = {
+    fullName = "Your Name";
     username = "admin";
     email = "admin@example.com";
     sshKeys = [
@@ -30,6 +30,10 @@ keystone.lib.mkSystemFlake {
 ```bash
 nix build .#packages.x86_64-linux.iso -o installer-iso
 ```
+
+Replace `x86_64-linux` with the correct target system for your flake, such as
+`aarch64-linux`, if you are not building for x86_64. The system is inferred
+automatically from your Linux host inventory; set `defaults.system` to override.
 
 The ISO includes the admin's terminal environment (helix, zsh, starship), SSH access
 with the declared keys, and the Keystone TUI installer.

--- a/docs/os/iso-generation.md
+++ b/docs/os/iso-generation.md
@@ -7,13 +7,38 @@ description: Generate a Keystone installer ISO with SSH keys for remote installa
 
 Generate a Keystone installer ISO with SSH keys for remote installation.
 
-## Quick Build
+## Config repo (mkSystemFlake)
+
+Flakes built with `mkSystemFlake` automatically produce an installer ISO. Add your SSH
+public keys to the `owner` block and build:
+
+```nix
+# flake.nix
+keystone.lib.mkSystemFlake {
+  owner = {
+    name = "Your Name";
+    username = "admin";
+    email = "admin@example.com";
+    sshKeys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG... user@host"
+    ];
+  };
+  # ...
+};
+```
 
 ```bash
-# Clone and build
-git clone https://github.com/yourusername/keystone
-cd keystone
+nix build .#packages.x86_64-linux.iso -o installer-iso
+```
 
+The ISO includes the admin's terminal environment (helix, zsh, starship), SSH access
+with the declared keys, and the Keystone TUI installer.
+
+## Keystone repo (build-iso)
+
+From the keystone repo itself, use the `build-iso` command:
+
+```bash
 # Build without SSH keys
 ./bin/build-iso
 
@@ -24,39 +49,22 @@ cd keystone
 ./bin/build-iso --ssh-key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG... user@host"
 ```
 
-## SSH Key Options
+The `--ssh-key` option accepts a file path (`~/.ssh/id_ed25519.pub`) or an inline key
+string.
 
-The `--ssh-key` option accepts either:
+## Validate in a VM
 
-### File Path
-
-```bash
-# File paths (starts with /, ~, or .)
-./bin/build-iso --ssh-key ~/.ssh/id_ed25519.pub
-./bin/build-iso --ssh-key /home/user/.ssh/authorized_keys
-./bin/build-iso --ssh-key ./my-keys.txt
-```
-
-### Direct Key String
+Test the ISO before flashing to hardware:
 
 ```bash
-# SSH key string directly
-./bin/build-iso --ssh-key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG... user@host"
-./bin/build-iso --ssh-key "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQD... user@host"
+# UEFI boot with QEMU (requires KVM and OVMF)
+qemu-system-x86_64 -m 4096 -smp 2 -enable-kvm \
+  -bios $(nix build nixpkgs#OVMF.fd --print-out-paths --no-link)/FV/OVMF.fd \
+  -cdrom installer-iso/iso/*.iso
 ```
 
-## Get Your SSH Key
-
-```bash
-# Ed25519 (recommended)
-cat ~/.ssh/id_ed25519.pub
-
-# RSA
-cat ~/.ssh/id_rsa.pub
-
-# Generate if needed
-ssh-keygen -t ed25519 -C "your-email@example.com"
-```
+The VM boots to the Keystone TUI installer on the graphical console. SSH is available
+at the VM's DHCP address if keys were configured.
 
 ## Write to USB
 
@@ -64,47 +72,28 @@ ssh-keygen -t ed25519 -C "your-email@example.com"
 # Find USB device
 lsblk
 
-# Write ISO
-sudo dd if=result/iso/*.iso of=/dev/sdX bs=4M status=progress
-sync
+# Write ISO (WARNING: erases all data on target device)
+sudo dd if=installer-iso/iso/*.iso of=/dev/sdX bs=4M status=progress oflag=sync
 ```
-
-⚠️ **Warning**: `dd` will erase all data on target device.
 
 ## Use the ISO
 
-1. Boot from USB
-2. System auto-configures: SSH, DHCP, tools
+1. Boot from USB (UEFI)
+2. System auto-configures: SSH, DHCP, networking
 3. Get IP: `ip addr show`
 4. Connect: `ssh root@<ip-address>`
+5. Install: `nixos-anywhere --flake .#hostname root@<ip-address>`
 
 ## Features
 
-- SSH with your keys
-- DHCP networking
-- Essential tools (git, vim, parted, etc.)
-- ZFS support
+- Terminal environment (helix, zsh, starship) when built via `mkSystemFlake`
+- SSH with your keys (public key auth only)
+- DHCP networking via NetworkManager
+- ZFS, disko, cryptsetup, sbctl, and TPM tools pre-installed
+- Keystone TUI installer on tty1
 - nixos-anywhere compatible
 
-## Advanced Usage
+## Platform setup
 
-```bash
-./bin/build-iso --help              # Show all options
-./bin/build-iso -o custom-dir       # Custom output directory
-
-# Direct Nix commands (no SSH keys)
-nix build .#iso                     # Build ISO directly
-```
-
-## Platform Setup
-
-Need to install Nix first? See **[Build Platforms](build-platforms.md)** for setup instructions on Ubuntu, macOS, Windows, and GitHub Actions.
-
-## File Format
-
-When using a file path, SSH keys file should contain one public key per line:
-
-```
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG... user@workstation
-ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQD... admin@server
-```
+Need to install Nix first? See [Build Platforms](build-platforms.md) for setup on
+Ubuntu, macOS, Windows, and GitHub Actions.

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -283,45 +283,21 @@ let
     (nixpkgs.lib.nixosSystem {
       inherit system;
       modules = [
-        # ISO image infrastructure (replaces installation-cd-minimal.nix to
-        # avoid the hardcoded "nixos" user from installation-device.nix)
-        "${nixpkgs}/nixos/modules/installer/cd-dvd/iso-image.nix"
-        "${nixpkgs}/nixos/modules/profiles/base.nix"
-        "${nixpkgs}/nixos/modules/profiles/minimal.nix"
-        # Hardware detection and installer channel (from installation-device.nix)
-        "${nixpkgs}/nixos/modules/installer/scan/detected.nix"
-        "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix"
-        "${nixpkgs}/nixos/modules/installer/cd-dvd/channel.nix"
-
-        # fileSystems must reference config.lib.isoFileSystems from inside a module
-        (
-          { config, ... }:
-          {
-            fileSystems = lib.mkImageMediaOverride config.lib.isoFileSystems;
-          }
-        )
-
+        "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
         self.nixosModules.isoInstaller
         self.nixosModules.experimental
         home-manager.nixosModules.home-manager
         {
-          # Force kernel 6.12
+          # Force kernel 6.12 — must override minimal CD default
           boot.kernelPackages = lib.mkForce nixpkgs.legacyPackages.${system}.linuxPackages_6_12;
 
-          # From installation-cd-base.nix
-          hardware.enableAllHardware = true;
-          isoImage.makeEfiBootable = true;
-          isoImage.makeUsbBootable = true;
-          isoImage.edition = lib.mkOverride 500 "minimal";
-          boot.loader.grub.memtest86.enable = true;
-          swapDevices = lib.mkImageMediaOverride [ ];
-          boot.initrd.luks.devices = lib.mkImageMediaOverride { };
-          programs.git.enable = lib.mkDefault true;
-          documentation.man.enable = lib.mkOverride 500 true;
-          documentation.doc.enable = lib.mkOverride 500 true;
-          fonts.fontconfig.enable = lib.mkOverride 500 false;
+          # Serial console for QEMU headless testing
+          boot.kernelParams = [
+            "console=ttyS0,115200n8"
+            "console=tty0"
+          ];
 
-          # Admin user (replaces the hardcoded "nixos" user)
+          # Admin user alongside the default "nixos" user from installation-device.nix
           users.users.${adminUsername} = {
             isNormalUser = true;
             extraGroups = [
@@ -331,34 +307,17 @@ let
             ];
             initialHashedPassword = "";
           };
-          users.users.root.initialHashedPassword = "";
 
-          security.polkit.enable = true;
-          security.sudo = {
-            enable = lib.mkDefault true;
-            wheelNeedsPassword = lib.mkImageMediaOverride false;
-          };
-
-          # Auto-login as the admin user
-          services.getty.autologinUser = adminUsername;
+          # Auto-login as admin instead of "nixos"
+          services.getty.autologinUser = lib.mkForce adminUsername;
           nix.settings.trusted-users = [
             "root"
             adminUsername
           ];
 
-          boot.swraid.enable = true;
-          boot.swraid.mdadmConf = "PROGRAM ${nixpkgs.legacyPackages.${system}.coreutils}/bin/true";
-          networking.firewall.logRefusedConnections = lib.mkDefault false;
-
           keystone.installer.sshKeys = sshKeys;
           # TUI is experimental — default off, auto-enabled by keystone.experimental
           keystone.installer.tui.enable = lib.mkDefault false;
-
-          # Serial console — required for QEMU -serial output and headless VM testing
-          boot.kernelParams = [
-            "console=ttyS0,115200n8"
-            "console=tty0"
-          ];
           nixpkgs.overlays = [ self.overlays.default ];
 
           # Terminal environment for root and admin users (helix, zsh, starship)

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -20,6 +20,7 @@ let
       timeZone ? "UTC",
       storage,
       admin,
+      adminUsername ? "admin",
       users,
       secureBoot ? {
         enable = true;
@@ -39,16 +40,22 @@ let
       },
       config ? { },
     }:
-    {
+    lib.recursiveUpdate {
       networking.hostName = hostname;
       system.stateVersion = stateVersion;
       time.timeZone = timeZone;
       boot.loader.systemd-boot.enable = lib.mkDefault true;
 
+      # Apply keystone overlay so pkgs.keystone.* packages are available
+      nixpkgs.overlays = [ self.overlays.default ];
+
       keystone.os = {
         enable = true;
+        # Tailscale requires hosts registry — template configs don't have one
+        tailscale.enable = lib.mkDefault false;
         inherit
           admin
+          adminUsername
           users
           storage
           secureBoot
@@ -62,8 +69,7 @@ let
         "root"
         "@wheel"
       ];
-    }
-    // config;
+    } config;
 
   mkLinuxHost =
     {
@@ -73,6 +79,7 @@ let
       timeZone ? "UTC",
       storage,
       admin,
+      adminUsername ? "admin",
       users ? { },
       desktop ? false,
       secureBoot ? {
@@ -110,6 +117,7 @@ let
             timeZone
             storage
             admin
+            adminUsername
             users
             secureBoot
             tpm
@@ -259,39 +267,103 @@ let
       spec;
 
   # Build an installer ISO with the admin's terminal environment (helix, zsh,
-  # starship) and SSH keys for remote access. Boots to a root shell on tty1.
+  # starship) and SSH keys for remote access. Boots to the admin user on tty1.
   # TUI installer is experimental — auto-enabled only when keystone.experimental = true.
-  # self.homeModules.terminal already embeds keystoneInputs via _module.args,
-  # so we don't need the full keystoneInputs attrset here.
+  #
+  # Imports iso-image.nix + base.nix + minimal.nix directly (skipping
+  # installation-device.nix which hardcodes a "nixos" user and auto-login).
   mkInstallerIsoForFlake =
     {
       system ? "x86_64-linux",
       sshKeys ? [ ],
+      adminUsername ? "admin",
       adminName ? "System Administrator",
       adminEmail ? "admin@example.com",
     }:
     (nixpkgs.lib.nixosSystem {
       inherit system;
       modules = [
-        "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+        # ISO image infrastructure (replaces installation-cd-minimal.nix to
+        # avoid the hardcoded "nixos" user from installation-device.nix)
+        "${nixpkgs}/nixos/modules/installer/cd-dvd/iso-image.nix"
+        "${nixpkgs}/nixos/modules/profiles/base.nix"
+        "${nixpkgs}/nixos/modules/profiles/minimal.nix"
+        # Hardware detection and installer channel (from installation-device.nix)
+        "${nixpkgs}/nixos/modules/installer/scan/detected.nix"
+        "${nixpkgs}/nixos/modules/installer/scan/not-detected.nix"
+        "${nixpkgs}/nixos/modules/installer/cd-dvd/channel.nix"
+
+        # fileSystems must reference config.lib.isoFileSystems from inside a module
+        (
+          { config, ... }:
+          {
+            fileSystems = lib.mkImageMediaOverride config.lib.isoFileSystems;
+          }
+        )
+
         self.nixosModules.isoInstaller
         self.nixosModules.experimental
         home-manager.nixosModules.home-manager
         {
-          # Force kernel 6.12 — must override minimal CD default
+          # Force kernel 6.12
           boot.kernelPackages = lib.mkForce nixpkgs.legacyPackages.${system}.linuxPackages_6_12;
+
+          # From installation-cd-base.nix
+          hardware.enableAllHardware = true;
+          isoImage.makeEfiBootable = true;
+          isoImage.makeUsbBootable = true;
+          isoImage.edition = lib.mkOverride 500 "minimal";
+          boot.loader.grub.memtest86.enable = true;
+          swapDevices = lib.mkImageMediaOverride [ ];
+          boot.initrd.luks.devices = lib.mkImageMediaOverride { };
+          programs.git.enable = lib.mkDefault true;
+          documentation.man.enable = lib.mkOverride 500 true;
+          documentation.doc.enable = lib.mkOverride 500 true;
+          fonts.fontconfig.enable = lib.mkOverride 500 false;
+
+          # Admin user (replaces the hardcoded "nixos" user)
+          users.users.${adminUsername} = {
+            isNormalUser = true;
+            extraGroups = [
+              "wheel"
+              "networkmanager"
+              "video"
+            ];
+            initialHashedPassword = "";
+          };
+          users.users.root.initialHashedPassword = "";
+
+          security.polkit.enable = true;
+          security.sudo = {
+            enable = lib.mkDefault true;
+            wheelNeedsPassword = lib.mkImageMediaOverride false;
+          };
+
+          # Auto-login as the admin user
+          services.getty.autologinUser = adminUsername;
+          nix.settings.trusted-users = [
+            "root"
+            adminUsername
+          ];
+
+          boot.swraid.enable = true;
+          boot.swraid.mdadmConf = "PROGRAM ${nixpkgs.legacyPackages.${system}.coreutils}/bin/true";
+          networking.firewall.logRefusedConnections = lib.mkDefault false;
 
           keystone.installer.sshKeys = sshKeys;
           # TUI is experimental — default off, auto-enabled by keystone.experimental
           keystone.installer.tui.enable = lib.mkDefault false;
           nixpkgs.overlays = [ self.overlays.default ];
 
-          # Terminal environment for root user (helix, zsh, starship)
+          # Terminal environment for root and admin users (helix, zsh, starship)
           home-manager.useGlobalPkgs = true;
           home-manager.useUserPackages = true;
           home-manager.backupFileExtension = "backup";
+          home-manager.sharedModules = [
+            self.homeModules.terminal
+            self.homeModules.notes
+          ];
           home-manager.users.root = {
-            imports = [ self.homeModules.terminal ];
             home.stateVersion = "25.05";
             keystone.terminal = {
               enable = true;
@@ -303,7 +375,26 @@ let
               };
             };
             keystone.projects.enable = false;
+            keystone.notes.enable = false;
           };
+          home-manager.users.${adminUsername} = {
+            home.stateVersion = "25.05";
+            home.username = adminUsername;
+            home.homeDirectory = "/home/${adminUsername}";
+            keystone.terminal = {
+              enable = true;
+              ai.enable = false;
+              sandbox.enable = false;
+              git = {
+                userName = adminName;
+                userEmail = adminEmail;
+              };
+            };
+            keystone.projects.enable = false;
+            keystone.notes.enable = false;
+          };
+
+          programs.zsh.enable = true;
         }
       ];
     }).config.system.build.isoImage;
@@ -461,7 +552,8 @@ rec {
       };
 
       # admin is the single source of truth — strip template-only fields
-      # (username, sshKeys) to produce a valid userSubmodule config
+      # (sshKeys) to produce a valid userSubmodule config.
+      # username is passed through to keystone.os.adminUsername.
       adminUsername = admin.username or "admin";
       adminSshKeys = admin.sshKeys or [ ];
       sharedAdmin = builtins.removeAttrs admin [
@@ -519,6 +611,7 @@ rec {
                   kindDefaults.system;
               timeZone = if hostCfg ? timeZone then hostCfg.timeZone else sharedTimeZone;
               admin = if hostCfg ? admin then hostCfg.admin else sharedAdmin;
+              inherit adminUsername;
               users = sharedUsers // (hostCfg.users or { });
               nixosModules = kindDefaults.nixosModules ++ (hostCfg.nixosModules or [ ]);
               config = lib.recursiveUpdate mergedConfig {
@@ -576,6 +669,7 @@ rec {
       packages.${defaultLinuxSystem}.iso = mkInstallerIsoForFlake {
         system = defaultLinuxSystem;
         sshKeys = adminSshKeys;
+        inherit adminUsername;
         adminName = sharedAdmin.fullName;
         adminEmail = sharedAdmin.email;
       };

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -291,12 +291,6 @@ let
           # Force kernel 6.12 — must override minimal CD default
           boot.kernelPackages = lib.mkForce nixpkgs.legacyPackages.${system}.linuxPackages_6_12;
 
-          # Serial console for QEMU headless testing
-          boot.kernelParams = [
-            "console=ttyS0,115200n8"
-            "console=tty0"
-          ];
-
           # Admin user alongside the default "nixos" user from installation-device.nix
           users.users.${adminUsername} = {
             isNormalUser = true;

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -524,7 +524,34 @@ rec {
       sharedSystemModules = shared.systemModules or [ ];
       sharedUserModules = shared.userModules or [ ];
       sharedTimeZone = defaults.timeZone or "UTC";
-      defaultLinuxSystem = defaults.system or "x86_64-linux";
+
+      # Resolve the system for each Linux host using the explicit per-host value
+      # (hostCfg.system) or the kind default.  Note: system overrides declared
+      # only inside a host's hardware.nix cannot be detected here without
+      # importing that file; if your hosts set a non-default system solely via
+      # hardware.nix, also set defaults.system explicitly.
+      linuxHostSystems = lib.unique (
+        lib.mapAttrsToList (
+          _: hostCfg:
+          if hostCfg ? system then
+            hostCfg.system
+          else
+            (linuxKindDefaults.${hostCfg.kind} or { system = "x86_64-linux"; }).system
+        ) linuxHosts
+      );
+
+      # defaults.system is the explicit override; when absent, infer from the
+      # Linux host inventory (requiring a single consistent system across all
+      # hosts).
+      defaultLinuxSystem =
+        if defaults ? system then
+          defaults.system
+        else if linuxHostSystems == [ ] then
+          "x86_64-linux"
+        else if builtins.length linuxHostSystems == 1 then
+          builtins.head linuxHostSystems
+        else
+          throw "keystone mkSystemFlake: Linux hosts use multiple systems (${lib.concatStringsSep ", " linuxHostSystems}). Set defaults.system to specify which system to use for the installer ISO.";
 
       hostFilePath =
         name: file:

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -404,6 +404,7 @@ rec {
   mkHost = mkLinuxHost;
   mkSharedLinuxHost = mkSharedLinuxHostHelper;
   mkSharedMacosHome = mkSharedMacosHomeHelper;
+  inherit mkInstallerIsoForFlake;
 
   mkLaptop =
     {

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -422,7 +422,7 @@ rec {
 
   mkSystemFlake =
     {
-      owner,
+      admin,
       defaults ? { },
       shared ? { },
       hostsRoot ? null,
@@ -456,18 +456,19 @@ rec {
         };
       };
 
-      sharedAdmin =
-        shared.admin or {
-          fullName = owner.name;
-          email = owner.email or "admin@example.com";
-          initialPassword = "changeme";
-        };
+      # admin is the single source of truth — strip template-only fields
+      # (username, sshKeys) to produce a valid userSubmodule config
+      adminUsername = admin.username or "admin";
+      adminSshKeys = admin.sshKeys or [ ];
+      sharedAdmin = builtins.removeAttrs admin [
+        "username"
+        "sshKeys"
+      ];
       sharedUsers = shared.users or { };
       sharedSystemModules = shared.systemModules or [ ];
       sharedUserModules = shared.userModules or [ ];
       sharedTimeZone = defaults.timeZone or "UTC";
       defaultLinuxSystem = defaults.system or "x86_64-linux";
-      ownerSshKeys = owner.sshKeys or [ ];
 
       hostFilePath =
         name: file:
@@ -551,7 +552,7 @@ rec {
             ])
             // {
               system = if hostCfg ? system then hostCfg.system else kindDefaults.system;
-              username = if hostCfg ? username then hostCfg.username else owner.username or "admin";
+              username = if hostCfg ? username then hostCfg.username else adminUsername;
               fullName = if hostCfg ? fullName then hostCfg.fullName else sharedAdmin.fullName;
               email = if hostCfg ? email then hostCfg.email else sharedAdmin.email;
               timeZone = if hostCfg ? timeZone then hostCfg.timeZone else sharedTimeZone;
@@ -570,7 +571,7 @@ rec {
     // lib.optionalAttrs (linuxHosts != { }) {
       packages.${defaultLinuxSystem}.iso = mkInstallerIsoForFlake {
         system = defaultLinuxSystem;
-        sshKeys = ownerSshKeys;
+        sshKeys = adminSshKeys;
         adminName = sharedAdmin.fullName;
         adminEmail = sharedAdmin.email;
       };

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -258,6 +258,52 @@ let
     else
       spec;
 
+  # Build an installer ISO with the admin's terminal environment (helix, zsh,
+  # starship), SSH keys for remote access, and the TUI installer.
+  # self.homeModules.terminal already embeds keystoneInputs via _module.args,
+  # so we don't need the full keystoneInputs attrset here.
+  mkInstallerIsoForFlake =
+    {
+      system ? "x86_64-linux",
+      sshKeys ? [ ],
+      adminName ? "System Administrator",
+      adminEmail ? "admin@example.com",
+    }:
+    (nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+        self.nixosModules.isoInstaller
+        home-manager.nixosModules.home-manager
+        {
+          # Force kernel 6.12 — must override minimal CD default
+          boot.kernelPackages = lib.mkForce nixpkgs.legacyPackages.${system}.linuxPackages_6_12;
+
+          keystone.installer.sshKeys = sshKeys;
+          nixpkgs.overlays = [ self.overlays.default ];
+
+          # Terminal environment for root user (helix, zsh, starship)
+          home-manager.useGlobalPkgs = true;
+          home-manager.useUserPackages = true;
+          home-manager.backupFileExtension = "backup";
+          home-manager.users.root = {
+            imports = [ self.homeModules.terminal ];
+            home.stateVersion = "25.05";
+            keystone.terminal = {
+              enable = true;
+              ai.enable = false;
+              sandbox.enable = false;
+              git = {
+                userName = adminName;
+                userEmail = adminEmail;
+              };
+            };
+            keystone.projects.enable = false;
+          };
+        }
+      ];
+    }).config.system.build.isoImage;
+
 in
 rec {
   mkHost = mkLinuxHost;
@@ -420,6 +466,8 @@ rec {
       sharedSystemModules = shared.systemModules or [ ];
       sharedUserModules = shared.userModules or [ ];
       sharedTimeZone = defaults.timeZone or "UTC";
+      defaultLinuxSystem = defaults.system or "x86_64-linux";
+      ownerSshKeys = owner.sshKeys or [ ];
 
       hostFilePath =
         name: file:
@@ -518,5 +566,13 @@ rec {
     {
       nixosConfigurations = lib.mapAttrs mkLinuxInventoryHost linuxHosts;
       homeConfigurations = lib.mapAttrs mkDarwinInventoryHost darwinHosts;
+    }
+    // lib.optionalAttrs (linuxHosts != { }) {
+      packages.${defaultLinuxSystem}.iso = mkInstallerIsoForFlake {
+        system = defaultLinuxSystem;
+        sshKeys = ownerSshKeys;
+        adminName = sharedAdmin.fullName;
+        adminEmail = sharedAdmin.email;
+      };
     };
 }

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -353,6 +353,12 @@ let
           keystone.installer.sshKeys = sshKeys;
           # TUI is experimental — default off, auto-enabled by keystone.experimental
           keystone.installer.tui.enable = lib.mkDefault false;
+
+          # Serial console — required for QEMU -serial output and headless VM testing
+          boot.kernelParams = [
+            "console=ttyS0,115200n8"
+            "console=tty0"
+          ];
           nixpkgs.overlays = [ self.overlays.default ];
 
           # Terminal environment for root and admin users (helix, zsh, starship)

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -665,6 +665,11 @@ rec {
     {
       nixosConfigurations = lib.mapAttrs mkLinuxInventoryHost linuxHosts;
       homeConfigurations = lib.mapAttrs mkDarwinInventoryHost darwinHosts;
+      # Expose admin identity so tooling (e.g. bin/test-iso) can read it without
+      # parsing flake.nix directly.
+      inherit adminUsername;
+      adminEmail = sharedAdmin.email;
+      adminName = sharedAdmin.fullName;
     }
     // lib.optionalAttrs (linuxHosts != { }) {
       packages.${defaultLinuxSystem}.iso = mkInstallerIsoForFlake {

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -259,7 +259,8 @@ let
       spec;
 
   # Build an installer ISO with the admin's terminal environment (helix, zsh,
-  # starship), SSH keys for remote access, and the TUI installer.
+  # starship) and SSH keys for remote access. Boots to a root shell on tty1.
+  # TUI installer is experimental — auto-enabled only when keystone.experimental = true.
   # self.homeModules.terminal already embeds keystoneInputs via _module.args,
   # so we don't need the full keystoneInputs attrset here.
   mkInstallerIsoForFlake =
@@ -274,12 +275,15 @@ let
       modules = [
         "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
         self.nixosModules.isoInstaller
+        self.nixosModules.experimental
         home-manager.nixosModules.home-manager
         {
           # Force kernel 6.12 — must override minimal CD default
           boot.kernelPackages = lib.mkForce nixpkgs.legacyPackages.${system}.linuxPackages_6_12;
 
           keystone.installer.sshKeys = sshKeys;
+          # TUI is experimental — default off, auto-enabled by keystone.experimental
+          keystone.installer.tui.enable = lib.mkDefault false;
           nixpkgs.overlays = [ self.overlays.default ];
 
           # Terminal environment for root user (helix, zsh, starship)

--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -87,8 +87,8 @@ in
 
     tui.enable = mkOption {
       type = types.bool;
-      default = true;
-      description = "Whether the installer ISO should include and auto-start the Keystone TUI.";
+      default = false;
+      description = "Whether the installer ISO should include and auto-start the Keystone TUI (experimental).";
     };
 
     isoImage = mkOption {
@@ -99,6 +99,9 @@ in
   };
 
   config = mkIf osCfg.enable {
+    # Auto-enable TUI when experimental features are on
+    keystone.os.installer.tui.enable = mkDefault config.keystone.experimental;
+
     # Auto-collect from wheel users + hardware root keys unless overridden
     keystone.os.installer.sshKeys = mkDefault autoCollectedKeys;
 

--- a/modules/iso-installer.nix
+++ b/modules/iso-installer.nix
@@ -69,9 +69,7 @@ in
       openssh.authorizedKeys.keys = installerCfg.sshKeys;
     };
 
-    # Enable networking via NetworkManager (for TUI installer network detection)
-    # mkForce needed — installation-cd-minimal.nix enables wpa_supplicant which
-    # conflicts with NetworkManager's own wireless management
+    # Disable wpa_supplicant — NetworkManager handles wireless
     networking = {
       wireless.enable = lib.mkForce false;
     };

--- a/modules/iso-installer.nix
+++ b/modules/iso-installer.nix
@@ -43,8 +43,8 @@ in
 
     tui.enable = lib.mkOption {
       type = lib.types.bool;
-      default = true;
-      description = "Whether to install and auto-start the Keystone installer TUI on the ISO.";
+      default = false;
+      description = "Whether to install and auto-start the Keystone installer TUI on the ISO (experimental).";
     };
   };
 

--- a/modules/iso-installer.nix
+++ b/modules/iso-installer.nix
@@ -23,6 +23,18 @@ let
 in
 {
   options.keystone.installer = {
+    edition = lib.mkOption {
+      type = lib.types.str;
+      default = "server";
+      description = "ISO edition name used in the filename (e.g. server, desktop).";
+    };
+
+    version = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0";
+      description = "Keystone installer version embedded in the ISO filename.";
+    };
+
     sshKeys = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
@@ -186,8 +198,8 @@ in
     documentation.enable = false;
     documentation.nixos.enable = false;
 
-    # Set the ISO label and boot splash image
-    image.fileName = lib.mkDefault "keystone-installer.iso";
+    # Set the ISO name, label, and boot splash image
+    image.baseName = lib.mkForce "keystone-${installerCfg.edition}-installer-${installerCfg.version}";
     isoImage.volumeID = lib.mkDefault "KEYSTONE";
     isoImage.efiSplashImage = ../assets/installer-splash.png;
     isoImage.splashImage = ../assets/installer-splash.png;

--- a/modules/os/default.nix
+++ b/modules/os/default.nix
@@ -539,13 +539,23 @@ in
     };
 
     # User configuration
+    adminUsername = mkOption {
+      type = types.str;
+      default = "admin";
+      description = ''
+        Unix username for the administrator account. Defaults to "admin".
+        Set via admin.username in mkSystemFlake.
+      '';
+      example = "noah";
+    };
+
     admin = mkOption {
       type = types.nullOr (userSubmodule);
       default = null;
       description = ''
         Canonical default administrator for this Keystone multi-host system.
-        Keystone synthesizes the normal `admin` account from this definition and
-        grants administrator privileges automatically.
+        Keystone synthesizes the user account named by adminUsername from this
+        definition and grants administrator privileges automatically.
       '';
       example = literalExpression ''
         {

--- a/modules/os/users.nix
+++ b/modules/os/users.nix
@@ -19,12 +19,13 @@ with lib;
 let
   osCfg = config.keystone.os;
   cfg = osCfg.users;
+  adminUsername = osCfg.adminUsername;
   legacyAdminCfg = if cfg ? admin then cfg.admin else null;
   effectiveAdminCfg = if osCfg.admin != null then osCfg.admin else legacyAdminCfg;
   effectiveUsers =
     (removeAttrs cfg [ "admin" ])
     // optionalAttrs (effectiveAdminCfg != null) {
-      admin = effectiveAdminCfg // {
+      ${adminUsername} = effectiveAdminCfg // {
         extraGroups = unique ([ "wheel" ] ++ effectiveAdminCfg.extraGroups);
       };
     };
@@ -364,49 +365,55 @@ in
             users = mapAttrs (
               username: userCfg:
               { pkgs, ... }:
-              {
-                home.username = username;
-                home.homeDirectory = "/home/${username}";
-                home.stateVersion = config.system.stateVersion;
+              # NOTE: use lib.recursiveUpdate (not //) to merge terminal and
+              # desktop configs. Both live under `keystone.*`, so a shallow //
+              # merge causes `keystone.desktop` to replace `keystone.terminal`.
+              lib.recursiveUpdate
+                {
+                  home.username = username;
+                  home.homeDirectory = "/home/${username}";
+                  home.stateVersion = config.system.stateVersion;
 
-                # Terminal development environment
-                # NOTE: Do NOT wrap this in mkIf — mkIf inside function-type
-                # home-manager.users definitions silently fails to merge when
-                # another module also defines the same user. Use mkDefault on
-                # enable instead; the terminal module's own config = mkIf cfg.enable
-                # handles gating.
-                keystone.terminal = {
-                  enable = mkDefault userCfg.terminal.enable;
-                  aiExtensions.capabilities = mkDefault userCfg.capabilities;
+                  # Terminal development environment
+                  # NOTE: Do NOT wrap this in mkIf — mkIf inside function-type
+                  # home-manager.users definitions silently fails to merge when
+                  # another module also defines the same user. Use mkDefault on
+                  # enable instead; the terminal module's own config = mkIf cfg.enable
+                  # handles gating.
+                  keystone.terminal = {
+                    enable = mkDefault userCfg.terminal.enable;
+                    aiExtensions.capabilities = mkDefault userCfg.capabilities;
 
-                  # development and repos are no longer bridged here;
-                  # they are inherited globally from keystone.development
-                  # and keystone.repos which are now shared options.
+                    # development and repos are no longer bridged here;
+                    # they are inherited globally from keystone.development
+                    # and keystone.repos which are now shared options.
 
-                  git = {
-                    enable = mkDefault (userCfg.terminal.enable && userCfg.email != null);
-                    userName = mkDefault userCfg.fullName;
-                    userEmail = mkDefault userCfg.email;
-                    # Bridge SSH public keys from keystone.keys for allowed_signers
-                    sshPublicKeys = mkDefault (if keysCfg ? ${username} then allKeysFor username else [ ]);
-                    forgejo.enable = mkDefault (config.keystone.services.git.host != null);
+                    git = {
+                      enable = mkDefault (userCfg.terminal.enable && userCfg.email != null);
+                      userName = mkDefault userCfg.fullName;
+                      userEmail = mkDefault userCfg.email;
+                      # Bridge SSH public keys from keystone.keys for allowed_signers
+                      sshPublicKeys = mkDefault (if keysCfg ? ${username} then allKeysFor username else [ ]);
+                      forgejo.enable = mkDefault (config.keystone.services.git.host != null);
+                    };
+
+                    sshAutoLoad.enable = mkDefault userCfg.sshAutoLoad.enable;
                   };
-
-                  sshAutoLoad.enable = mkDefault userCfg.sshAutoLoad.enable;
-                };
-              }
-              // optionalAttrs hasDesktopModule {
-                # Desktop configuration (Hyprland) — only set when desktop NixOS module is imported
-                keystone.desktop = mkIf userCfg.desktop.enable {
-                  enable = mkDefault true;
-                  uhk.enable = mkDefault config.keystone.hardware.uhk.enable;
-                  hyprland = {
-                    enable = mkDefault true;
-                    modifierKey = mkDefault userCfg.desktop.hyprland.modifierKey;
-                    capslockAsControl = mkDefault userCfg.desktop.hyprland.capslockAsControl;
-                  };
-                };
-              }
+                }
+                (
+                  optionalAttrs hasDesktopModule {
+                    # Desktop configuration (Hyprland) — only set when desktop NixOS module is imported
+                    keystone.desktop = mkIf userCfg.desktop.enable {
+                      enable = mkDefault true;
+                      uhk.enable = mkDefault config.keystone.hardware.uhk.enable;
+                      hyprland = {
+                        enable = mkDefault true;
+                        modifierKey = mkDefault userCfg.desktop.hyprland.modifierKey;
+                        capslockAsControl = mkDefault userCfg.desktop.hyprland.capslockAsControl;
+                      };
+                    };
+                  }
+                )
             ) (filterAttrs (_: u: u.terminal.enable || u.desktop.enable) effectiveUsers);
           };
     })

--- a/templates/default/.gitignore
+++ b/templates/default/.gitignore
@@ -1,0 +1,21 @@
+# Nix build outputs
+result
+result-*
+installer-iso
+
+# ISO files
+*.iso
+
+# Nix development
+.direnv/
+
+# Editor / AI tool files
+.vscode/
+.gemini/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/templates/default/AGENTS.md
+++ b/templates/default/AGENTS.md
@@ -1,0 +1,215 @@
+# Keystone config repo
+
+This repository manages NixOS and macOS system configurations using
+[Keystone](https://github.com/ncrmro/keystone), a NixOS-based infrastructure
+platform. The `flake.nix` is the single entry point — it calls
+`keystone.lib.mkSystemFlake` which expands a host inventory into full
+`nixosConfigurations`, `homeConfigurations`, and an installer ISO.
+
+## Architecture
+
+### flake.nix structure
+
+```nix
+keystone.lib.mkSystemFlake {
+  admin = { username, fullName, email, initialPassword, sshKeys };
+  defaults = { timeZone };
+  shared = { userModules, systemModules };
+  keystoneServices = { git.host, mail.host, ... };
+  hostsRoot = ./hosts;
+  hosts = {
+    <name> = { kind = "laptop" | "workstation" | "server" | "macbook"; ... };
+  };
+}
+```
+
+- **`admin`** — the system administrator. `username` is the login name on all
+  hosts. `sshKeys` are baked into the installer ISO for remote access. All other
+  fields (`fullName`, `email`, `initialPassword`, `terminal.enable`, etc.) map
+  directly to `keystone.os.admin` on each NixOS host.
+- **`hosts`** — each entry declares a machine. The `kind` field selects the
+  archetype: `laptop` (ext4, desktop), `workstation` (ZFS, desktop), `server`
+  (ZFS, no desktop), `macbook` (home-manager only).
+- **`shared.userModules`** — home-manager modules applied to every user on every
+  host. Use for terminal tools, shell config, and packages that follow your login.
+- **`shared.systemModules`** — NixOS modules applied to every Linux host. Use for
+  system-wide packages, services, or kernel config.
+- **`keystoneServices`** — declares which host runs each infrastructure service.
+  Keystone validates host references and auto-enables the service on the matching
+  machine.
+
+### Host directories
+
+Each Linux host can have a directory under `hosts/<name>/` with:
+
+- `hardware.nix` — hardware scan output (`nixos-generate-config`), disk IDs,
+  `networking.hostId`, storage device paths
+- `configuration.nix` — host-specific NixOS overrides
+
+VPS-style servers can omit both files. macOS hosts use `configuration.nix` for
+home-manager overrides only.
+
+## Common commands
+
+### Building and deploying
+
+```bash
+ks build                          # build current host (no deploy, no sudo)
+ks build <hostname>               # build a specific host
+ks update --lock <hostname>       # full deploy: lock, build, push, switch
+ks update --dev                   # deploy home-manager profiles only (dev mode)
+ks doctor                         # diagnose system health
+```
+
+`ks` discovers this repo via `$NIXOS_CONFIG_DIR`, the git root, or `~/nixos-config`.
+
+### Building the installer ISO
+
+```bash
+nix build .#packages.x86_64-linux.iso -o installer-iso
+```
+
+Validate in a VM:
+
+```bash
+qemu-system-x86_64 -m 4096 -smp 2 -enable-kvm \
+  -bios $(nix build nixpkgs#OVMF.fd --print-out-paths --no-link)/FV/OVMF.fd \
+  -cdrom installer-iso/iso/*.iso
+```
+
+Flash to USB:
+
+```bash
+sudo dd if=installer-iso/iso/*.iso of=/dev/sdX bs=4M status=progress oflag=sync
+```
+
+### Fresh install from ISO
+
+```bash
+nixos-anywhere --flake .#<hostname> root@<installer-ip>
+```
+
+### Updating keystone
+
+```bash
+nix flake update keystone         # update keystone input only — NEVER bare nix flake update
+git add flake.lock && git commit -m "chore(deps): update keystone"
+```
+
+## How to add packages
+
+### User packages (follow your login)
+
+Add to `shared.userModules` in `flake.nix`:
+
+```nix
+shared.userModules = [
+  ({ pkgs, ... }: {
+    home.packages = with pkgs; [
+      fd
+      ripgrep
+      jq
+    ];
+  })
+];
+```
+
+### System packages (all users, root-owned)
+
+Add to `shared.systemModules` in `flake.nix`:
+
+```nix
+shared.systemModules = [
+  ({ pkgs, ... }: {
+    environment.systemPackages = with pkgs; [
+      btop
+      lsof
+    ];
+  })
+];
+```
+
+### Host-specific packages
+
+Add a module to the host's `modules` list in `flake.nix` or in the host's
+`configuration.nix`:
+
+```nix
+# In flake.nix
+hosts.laptop = {
+  kind = "laptop";
+  modules = [
+    ({ pkgs, ... }: { environment.systemPackages = [ pkgs.steam ]; })
+  ];
+};
+
+# Or in hosts/laptop/configuration.nix
+{ pkgs, ... }: {
+  environment.systemPackages = [ pkgs.steam ];
+}
+```
+
+## How to enable services
+
+### Keystone infrastructure services
+
+Declare in `keystoneServices` to auto-enable on the target host:
+
+```nix
+keystoneServices = {
+  git.host = "server-ocean";
+  mail.host = "server-ocean";
+};
+```
+
+### Standard NixOS services
+
+Add to `shared.systemModules` or a host's `configuration.nix`:
+
+```nix
+# All hosts
+shared.systemModules = [
+  { services.tailscale.enable = true; }
+];
+
+# Single host
+hosts.server-ocean = {
+  kind = "server";
+  config.services.openssh.enable = true;
+};
+```
+
+### Per-host in configuration.nix
+
+```nix
+# hosts/server-ocean/configuration.nix
+{ ... }: {
+  services.postgresql.enable = true;
+  services.nginx.enable = true;
+}
+```
+
+## Adding a new host
+
+1. Add the host to `hosts` in `flake.nix`:
+   ```nix
+   hosts.new-server = {
+     kind = "server";
+     hostname = "new-server";
+   };
+   ```
+2. Create `hosts/new-server/hardware.nix` with disk IDs and `networking.hostId`
+   (generate with `head -c 4 /dev/urandom | od -A none -t x4 | tr -d ' '`)
+3. Optionally create `hosts/new-server/configuration.nix` for host-specific config
+4. Build: `ks build new-server`
+5. Deploy: `nixos-anywhere --flake .#new-server root@<ip>`
+
+## Keystone module reference
+
+| Module area | What it provides |
+|-------------|-----------------|
+| `keystone.os` | Storage (ZFS/ext4), Secure Boot, TPM, users, SSH |
+| `keystone.terminal` | Helix editor, zsh, starship, git, AI tools |
+| `keystone.desktop` | Hyprland, audio, bluetooth, greetd |
+| `keystone.services` | Service registry (git, mail, immich, etc.) |
+| `keystone.keys` | SSH public key registry |

--- a/templates/default/AGENTS.md
+++ b/templates/default/AGENTS.md
@@ -204,6 +204,49 @@ hosts.server-ocean = {
 4. Build: `ks build new-server`
 5. Deploy: `nixos-anywhere --flake .#new-server root@<ip>`
 
+## Exploring keystone via Nix CLI
+
+### Flake outputs
+
+```bash
+# Show all keystone flake outputs (modules, packages, checks, templates)
+nix flake show github:ncrmro/keystone
+
+# List exported NixOS modules
+nix eval github:ncrmro/keystone#nixosModules --apply 'x: builtins.attrNames x'
+
+# List exported home-manager modules
+nix eval github:ncrmro/keystone#homeModules --apply 'x: builtins.attrNames x'
+
+# List available packages
+nix eval github:ncrmro/keystone#packages.x86_64-linux --apply 'x: builtins.attrNames x'
+```
+
+### Inspecting options from a config repo
+
+```bash
+# List keystone.os options
+nix eval .#nixosConfigurations.<hostname>.options.keystone.os --apply 'x: builtins.attrNames x'
+
+# Inspect a specific option (type, default, description)
+nix eval .#nixosConfigurations.<hostname>.options.keystone.os.storage.type.type.description
+
+# List keystone services options
+nix eval .#nixosConfigurations.<hostname>.options.keystone.services --apply 'x: builtins.attrNames x'
+
+# List keystone terminal options (home-manager)
+nix eval .#nixosConfigurations.<hostname>.config.home-manager.users.<username>.options.keystone.terminal --apply 'x: builtins.attrNames x'
+```
+
+### Interactive exploration
+
+```bash
+# REPL is the most powerful tool for exploring options and config
+nix repl .#nixosConfigurations.<hostname>
+# then tab-complete: config.keystone.os.<TAB>
+#                    options.keystone.os.<TAB>
+```
+
 ## Keystone module reference
 
 | Module area | What it provides |

--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -81,6 +81,9 @@ The flake automatically produces an installer ISO with your terminal environment
 nix build .#packages.x86_64-linux.iso -o installer-iso
 ```
 
+> Replace `x86_64-linux` with your target system (e.g. `aarch64-linux`) if your hosts
+> use a different architecture.
+
 The ISO boots a live environment with SSH access (if `admin.sshKeys` is set), the Keystone TUI installer, and your terminal config (helix, zsh, starship).
 
 Validate in a VM before flashing:

--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -73,9 +73,33 @@ Shared infrastructure placement belongs in the top-level `keystoneServices` bloc
 - Keystone terminal Home Manager module: `keystone/modules/terminal/default.nix`
 - Keystone desktop Home Manager module: `keystone/modules/desktop/home/default.nix`
 
+## Build installer ISO
+
+The flake automatically produces an installer ISO with your terminal environment and SSH keys:
+
+```bash
+nix build .#packages.x86_64-linux.iso -o installer-iso
+```
+
+The ISO boots a live environment with SSH access (if `owner.sshKeys` is set), the Keystone TUI installer, and your terminal config (helix, zsh, starship).
+
+Validate in a VM before flashing:
+
+```bash
+qemu-system-x86_64 -m 4096 -smp 2 -enable-kvm \
+  -bios $(nix build nixpkgs#OVMF.fd --print-out-paths --no-link)/FV/OVMF.fd \
+  -cdrom installer-iso/iso/*.iso
+```
+
+Flash to a USB drive:
+
+```bash
+sudo dd if=installer-iso/iso/*.iso of=/dev/sdX bs=4M status=progress oflag=sync
+```
+
 ## Deploy
 
-Fresh laptop install:
+Fresh install from the ISO (run from another machine):
 
 ```bash
 nixos-anywhere --flake .#laptop root@<installer-ip>

--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -24,16 +24,16 @@ grep -RIn "TODO:" flake.nix hosts/
 
 Fill in:
 
-- `owner.name` in `flake.nix`
-- `owner.username` in `flake.nix` if your primary username is not `admin`
-- `owner.email` in `flake.nix`
+- `admin.username` in `flake.nix`
+- `admin.fullName` in `flake.nix`
+- `admin.email` in `flake.nix`
 - `defaults.timeZone` in `flake.nix`
 - hostnames in `flake.nix` if `laptop`, `server-ocean`, or `macbook` should be renamed
 - `system`, `networking.hostId`, and `keystone.os.storage.devices` in Linux `hardware.nix` files
 
 ## File layout
 
-- `flake.nix`: shared owner/defaults, shared module hooks, global `keystoneServices`, and the `hosts` inventory
+- `flake.nix`: admin config, shared defaults, module hooks, global `keystoneServices`, and the `hosts` inventory
 - `hosts/laptop/`: laptop-specific Linux files
 - `hosts/server-ocean/`: server-specific Linux files
 - `hosts/macbook/`: optional macOS Home Manager overrides

--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -81,7 +81,7 @@ The flake automatically produces an installer ISO with your terminal environment
 nix build .#packages.x86_64-linux.iso -o installer-iso
 ```
 
-The ISO boots a live environment with SSH access (if `owner.sshKeys` is set), the Keystone TUI installer, and your terminal config (helix, zsh, starship).
+The ISO boots a live environment with SSH access (if `admin.sshKeys` is set), the Keystone TUI installer, and your terminal config (helix, zsh, starship).
 
 Validate in a VM before flashing:
 

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -301,8 +301,8 @@ if [[ "$HEADLESS" == "true" ]]; then
     log_warn "VM is running (PID $QEMU_PID). Press Ctrl-C to shut it down."
     wait "$QEMU_PID"
 else
-    # ── GUI: QEMU window + serial on the terminal ───────────────────────────
-    log_warn "Close the QEMU window or Ctrl-C to stop."
+    # ── GUI: QEMU window ────────────────────────────────────────────────────
+    log_warn "Close the QEMU window to stop."
     echo >&2
-    exec qemu-system-x86_64 "${QEMU_COMMON[@]}" -serial stdio
+    exec qemu-system-x86_64 "${QEMU_COMMON[@]}"
 fi

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -16,7 +16,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 ISO_RESULT="$PROJECT_DIR/.test-iso"
-SSH_PORT=2222
+SSH_PORT=12222
 QEMU_MEM=4096
 QEMU_CPUS=2
 

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# test-iso — build the installer ISO with SSH keys and boot it in QEMU
+#
+# Usage:
+#   ./bin/test-iso                          # auto-detect ~/.ssh/id_*.pub
+#   ./bin/test-iso --ssh-key ~/.ssh/id_ed25519.pub
+#   ./bin/test-iso --ssh-key "ssh-ed25519 AAAA... user@host"
+#   ./bin/test-iso --build-only             # build but don't start VM
+#   ./bin/test-iso --no-build               # skip build, boot existing ISO
+#
+# SSH access once the VM boots:
+#   ssh -p 2222 -o StrictHostKeyChecking=no admin@localhost
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+ISO_RESULT="$PROJECT_DIR/.test-iso"
+SSH_PORT=2222
+QEMU_MEM=4096
+QEMU_CPUS=2
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${BLUE}$*${NC}" >&2; }
+log_ok()    { echo -e "${GREEN}$*${NC}" >&2; }
+log_warn()  { echo -e "${YELLOW}$*${NC}" >&2; }
+log_error() { echo -e "${RED}$*${NC}" >&2; }
+
+show_help() {
+    cat >&2 << EOF
+test-iso — build the installer ISO with SSH keys and boot it in QEMU
+
+Usage:
+  $(basename "$0") [OPTIONS]
+
+Options:
+  -k, --ssh-key INPUT   SSH public key as a file path or inline key string.
+                        May be repeated for multiple keys.
+                        Default: all ~/.ssh/id_*.pub files.
+  --build-only          Build the ISO but do not start the VM.
+  --no-build            Skip the build step and boot an existing ISO.
+  -m, --memory MB       QEMU RAM in MB (default: $QEMU_MEM).
+  -p, --port PORT       Host SSH port to forward (default: $SSH_PORT).
+  -h, --help            Show this help.
+
+SSH key input:
+  File path  — starts with /, ~, or .  (one key per line)
+  Key string — starts with ssh-        (single key inline)
+
+Examples:
+  ./bin/test-iso
+  ./bin/test-iso --ssh-key ~/.ssh/id_ed25519.pub
+  ./bin/test-iso -k ~/.ssh/id_ed25519.pub -k ~/.ssh/id_ed25519_sk.pub
+  ./bin/test-iso --ssh-key "ssh-ed25519 AAAA... user@host"
+  ./bin/test-iso --build-only
+EOF
+}
+
+# ── argument parsing ──────────────────────────────────────────────────────────
+
+SSH_KEY_INPUTS=()
+BUILD=true
+BOOT=true
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -k|--ssh-key)
+            SSH_KEY_INPUTS+=("$2")
+            shift 2
+            ;;
+        --build-only)
+            BOOT=false
+            shift
+            ;;
+        --no-build)
+            BUILD=false
+            shift
+            ;;
+        -m|--memory)
+            QEMU_MEM="$2"
+            shift 2
+            ;;
+        -p|--port)
+            SSH_PORT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# ── collect SSH keys ──────────────────────────────────────────────────────────
+
+collect_keys() {
+    # Returns a newline-separated list of SSH public key strings.
+    local input
+    for input in "${SSH_KEY_INPUTS[@]}"; do
+        if [[ "$input" =~ ^[/~.] ]]; then
+            # Expand ~ manually so the path check works
+            local expanded="${input/#\~/$HOME}"
+            if [[ ! -f "$expanded" ]]; then
+                log_error "SSH key file not found: $input"
+                exit 1
+            fi
+            grep "^ssh-" "$expanded" || true
+        else
+            echo "$input"
+        fi
+    done
+}
+
+SSH_KEYS_LIST=""
+
+if [[ ${#SSH_KEY_INPUTS[@]} -gt 0 ]]; then
+    SSH_KEYS_LIST="$(collect_keys)"
+else
+    # Auto-detect from ~/.ssh/id_*.pub
+    local_pub_keys=()
+    for f in "$HOME/.ssh/id_"*.pub; do
+        [[ -f "$f" ]] && local_pub_keys+=("$f")
+    done
+    if [[ ${#local_pub_keys[@]} -eq 0 ]]; then
+        log_warn "No SSH public keys found in ~/.ssh/id_*.pub"
+        log_warn "The ISO will have no SSH access unless you pass --ssh-key"
+    else
+        for f in "${local_pub_keys[@]}"; do
+            log_info "Using SSH key: $f"
+            SSH_KEYS_LIST+="$(grep "^ssh-" "$f" || true)"$'\n'
+        done
+    fi
+fi
+
+# Build a Nix list literal: [ "key1" "key2" ]
+nix_keys_list="["
+while IFS= read -r key; do
+    [[ -z "$key" ]] && continue
+    escaped="${key//\"/\\\"}"
+    nix_keys_list+=" \"$escaped\""
+done <<< "$SSH_KEYS_LIST"
+nix_keys_list+=" ]"
+
+# ── build ─────────────────────────────────────────────────────────────────────
+
+if [[ "$BUILD" == "true" ]]; then
+    log_info "Building installer ISO..."
+
+    # Read admin config from the flake to preserve name/email in the ISO
+    # Fall back to sensible test defaults if yq isn't available or fields are missing
+    ADMIN_NAME="Test Admin"
+    ADMIN_EMAIL="test@local"
+    ADMIN_USERNAME="admin"
+    if command -v yq &>/dev/null; then
+        local_name="$(yq '.outputs.keystone.lib.mkSystemFlake.admin.fullName // ""' "$PROJECT_DIR/flake.nix" 2>/dev/null || true)"
+        local_email="$(yq '.outputs.keystone.lib.mkSystemFlake.admin.email // ""' "$PROJECT_DIR/flake.nix" 2>/dev/null || true)"
+        local_username="$(yq '.outputs.keystone.lib.mkSystemFlake.admin.username // ""' "$PROJECT_DIR/flake.nix" 2>/dev/null || true)"
+        [[ -n "$local_name" && "$local_name" != "null" ]] && ADMIN_NAME="$local_name"
+        [[ -n "$local_email" && "$local_email" != "null" ]] && ADMIN_EMAIL="$local_email"
+        [[ -n "$local_username" && "$local_username" != "null" ]] && ADMIN_USERNAME="$local_username"
+    fi
+
+    # Build via keystone.lib.mkInstallerIsoForFlake so the ISO gets the full
+    # admin terminal environment (helix, zsh, starship) from the keystone flake.
+    nix_expr="
+      let
+        self = builtins.getFlake (toString $(printf '%q' "$PROJECT_DIR"));
+        keystone = self.inputs.keystone;
+      in keystone.lib.mkInstallerIsoForFlake {
+        sshKeys = $nix_keys_list;
+        adminUsername = \"$ADMIN_USERNAME\";
+        adminName    = \"$ADMIN_NAME\";
+        adminEmail   = \"$ADMIN_EMAIL\";
+      }
+    "
+
+    nix build \
+        --impure \
+        --expr "$nix_expr" \
+        --out-link "$ISO_RESULT" \
+        --print-build-logs
+
+    iso_path="$(find "$ISO_RESULT/iso" -maxdepth 1 -name '*.iso' -print -quit 2>/dev/null || true)"
+    if [[ -z "$iso_path" ]]; then
+        log_error "Build succeeded but no ISO found in $ISO_RESULT/iso/"
+        exit 1
+    fi
+
+    iso_size="$(du -h "$iso_path" | cut -f1)"
+    log_ok "ISO built: $iso_path ($iso_size)"
+fi
+
+if [[ "$BOOT" == "false" ]]; then
+    exit 0
+fi
+
+# ── locate the ISO ────────────────────────────────────────────────────────────
+
+iso_path="$(find "$ISO_RESULT/iso" -maxdepth 1 -name '*.iso' -print -quit 2>/dev/null || true)"
+if [[ -z "$iso_path" ]]; then
+    log_error "No ISO found at $ISO_RESULT/iso/"
+    log_error "Run without --no-build to build it first."
+    exit 1
+fi
+
+# ── locate OVMF firmware ──────────────────────────────────────────────────────
+
+find_ovmf() {
+    # 1. Already on the system (NixOS with OVMF installed)
+    local candidate
+    candidate="$(find /run/current-system/sw/share -name 'OVMF.fd' 2>/dev/null | head -1 || true)"
+    [[ -n "$candidate" ]] && { echo "$candidate"; return; }
+
+    # 2. Anywhere in the Nix store (fast path)
+    candidate="$(find /nix/store -maxdepth 3 -name 'OVMF.fd' 2>/dev/null | head -1 || true)"
+    [[ -n "$candidate" ]] && { echo "$candidate"; return; }
+
+    # 3. Build it on demand
+    log_warn "OVMF not found on PATH — building from nixpkgs (one-time, ~2 min)..."
+    local store_path
+    store_path="$(nix build nixpkgs#OVMF.fd --print-out-paths --no-link 2>/dev/null || true)"
+    [[ -n "$store_path" ]] && candidate="$store_path/FV/OVMF.fd"
+    [[ -f "${candidate:-}" ]] && { echo "$candidate"; return; }
+
+    log_error "Could not locate OVMF firmware. Install it with:"
+    log_error "  environment.systemPackages = [ pkgs.OVMF ];"
+    exit 1
+}
+
+ovmf_path="$(find_ovmf)"
+log_info "OVMF: $ovmf_path"
+
+# ── check port availability ───────────────────────────────────────────────────
+
+if ss -tlnp 2>/dev/null | grep -q ":${SSH_PORT} " || \
+   netstat -tlnp 2>/dev/null | grep -q ":${SSH_PORT} "; then
+    log_warn "Port $SSH_PORT is already in use — choose another with --port"
+    exit 1
+fi
+
+# ── boot the VM ──────────────────────────────────────────────────────────────
+
+log_info "Starting QEMU with ISO: $(basename "$iso_path")"
+log_info "SSH port forwarding: localhost:$SSH_PORT → VM:22"
+echo >&2
+log_ok "Connect once the VM boots:"
+log_ok "  ssh -p $SSH_PORT -o StrictHostKeyChecking=no ${ADMIN_USERNAME}@localhost"
+echo >&2
+log_warn "Close QEMU window or press Ctrl-C to stop the VM."
+echo >&2
+
+# Use -serial stdio for console output in addition to the graphical window.
+# -nic user provides NAT networking with SSH port forwarding.
+exec qemu-system-x86_64 \
+    -enable-kvm \
+    -m "$QEMU_MEM" \
+    -smp "$QEMU_CPUS" \
+    -bios "$ovmf_path" \
+    -cdrom "$iso_path" \
+    -nic "user,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22" \
+    -serial stdio \
+    -boot d

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -68,6 +68,12 @@ SSH_KEY_INPUTS=()
 BUILD=true
 BOOT=true
 
+# Admin identity — overridden from flake outputs when BUILD=true, or when
+# --no-build is used we read them upfront so the SSH hint is accurate.
+ADMIN_USERNAME="admin"
+ADMIN_NAME="Test Admin"
+ADMIN_EMAIL="test@local"
+
 while [[ $# -gt 0 ]]; do
     case $1 in
         -k|--ssh-key)
@@ -101,6 +107,15 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# ── read admin identity from flake ───────────────────────────────────────────
+
+local_username="$(nix eval --raw "${PROJECT_DIR}#adminUsername" 2>/dev/null || true)"
+local_name="$(nix eval --raw "${PROJECT_DIR}#adminName" 2>/dev/null || true)"
+local_email="$(nix eval --raw "${PROJECT_DIR}#adminEmail" 2>/dev/null || true)"
+[[ -n "$local_username" ]] && ADMIN_USERNAME="$local_username"
+[[ -n "$local_name" ]]     && ADMIN_NAME="$local_name"
+[[ -n "$local_email" ]]    && ADMIN_EMAIL="$local_email"
 
 # ── collect SSH keys ──────────────────────────────────────────────────────────
 
@@ -156,20 +171,6 @@ nix_keys_list+=" ]"
 
 if [[ "$BUILD" == "true" ]]; then
     log_info "Building installer ISO..."
-
-    # Read admin config from the flake to preserve name/email in the ISO
-    # Fall back to sensible test defaults if yq isn't available or fields are missing
-    ADMIN_NAME="Test Admin"
-    ADMIN_EMAIL="test@local"
-    ADMIN_USERNAME="admin"
-    if command -v yq &>/dev/null; then
-        local_name="$(yq '.outputs.keystone.lib.mkSystemFlake.admin.fullName // ""' "$PROJECT_DIR/flake.nix" 2>/dev/null || true)"
-        local_email="$(yq '.outputs.keystone.lib.mkSystemFlake.admin.email // ""' "$PROJECT_DIR/flake.nix" 2>/dev/null || true)"
-        local_username="$(yq '.outputs.keystone.lib.mkSystemFlake.admin.username // ""' "$PROJECT_DIR/flake.nix" 2>/dev/null || true)"
-        [[ -n "$local_name" && "$local_name" != "null" ]] && ADMIN_NAME="$local_name"
-        [[ -n "$local_email" && "$local_email" != "null" ]] && ADMIN_EMAIL="$local_email"
-        [[ -n "$local_username" && "$local_username" != "null" ]] && ADMIN_USERNAME="$local_username"
-    fi
 
     # Build via keystone.lib.mkInstallerIsoForFlake so the ISO gets the full
     # admin terminal environment (helix, zsh, starship) from the keystone flake.
@@ -257,11 +258,12 @@ echo >&2
 log_ok "Connect once the VM boots:"
 log_ok "  ssh -p $SSH_PORT -o StrictHostKeyChecking=no ${ADMIN_USERNAME}@localhost"
 echo >&2
-log_warn "Close QEMU window or press Ctrl-C to stop the VM."
+log_warn "Press Ctrl-C to stop the VM. Serial console output below:"
 echo >&2
 
-# Use -serial stdio for console output in addition to the graphical window.
-# -nic user provides NAT networking with SSH port forwarding.
+# -display none: headless — all interaction is over SSH or the serial console.
+# -serial mon:stdio: serial console + QEMU monitor on stdin/stdout.
+# -nic user: NAT networking with SSH port forwarding.
 exec qemu-system-x86_64 \
     -enable-kvm \
     -m "$QEMU_MEM" \
@@ -269,5 +271,6 @@ exec qemu-system-x86_64 \
     -bios "$ovmf_path" \
     -cdrom "$iso_path" \
     -nic "user,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22" \
-    -serial stdio \
+    -display none \
+    -serial mon:stdio \
     -boot d

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -270,8 +270,8 @@ QEMU_COMMON=(
     -smp "$QEMU_CPUS"
     -bios "$ovmf_path"
     -cdrom "$iso_path"
-    -nic "user,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22"
-    -boot d
+    -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22"
+    -device "virtio-net-pci,netdev=net0,romfile="
 )
 
 if [[ "$HEADLESS" == "true" ]]; then

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -68,11 +68,10 @@ SSH_KEY_INPUTS=()
 BUILD=true
 BOOT=true
 
-# Admin identity — overridden from flake outputs when BUILD=true, or when
-# --no-build is used we read them upfront so the SSH hint is accurate.
-ADMIN_USERNAME="admin"
-ADMIN_NAME="Test Admin"
-ADMIN_EMAIL="test@local"
+# Admin identity — read from flake outputs (mkSystemFlake exposes these).
+ADMIN_USERNAME=""
+ADMIN_NAME=""
+ADMIN_EMAIL=""
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -110,12 +109,14 @@ done
 
 # ── read admin identity from flake ───────────────────────────────────────────
 
-local_username="$(nix eval --raw "${PROJECT_DIR}#adminUsername" 2>/dev/null || true)"
-local_name="$(nix eval --raw "${PROJECT_DIR}#adminName" 2>/dev/null || true)"
-local_email="$(nix eval --raw "${PROJECT_DIR}#adminEmail" 2>/dev/null || true)"
-[[ -n "$local_username" ]] && ADMIN_USERNAME="$local_username"
-[[ -n "$local_name" ]]     && ADMIN_NAME="$local_name"
-[[ -n "$local_email" ]]    && ADMIN_EMAIL="$local_email"
+ADMIN_USERNAME="$(nix eval --raw "${PROJECT_DIR}#adminUsername" 2>/dev/null)"
+ADMIN_NAME="$(nix eval --raw "${PROJECT_DIR}#adminName" 2>/dev/null)"
+ADMIN_EMAIL="$(nix eval --raw "${PROJECT_DIR}#adminEmail" 2>/dev/null)"
+
+if [[ -z "$ADMIN_USERNAME" ]]; then
+    log_error "Could not read adminUsername from flake. Ensure the flake uses mkSystemFlake and has admin.username set."
+    exit 1
+fi
 
 # ── collect SSH keys ──────────────────────────────────────────────────────────
 

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -259,18 +259,37 @@ echo >&2
 log_ok "Connect once the VM boots:"
 log_ok "  ssh -p $SSH_PORT -o StrictHostKeyChecking=no ${ADMIN_USERNAME}@localhost"
 echo >&2
-log_warn "Serial console is live. To exit QEMU: Ctrl-A X"
+log_warn "Press Ctrl-C to stop the VM."
 echo >&2
 
-# -nographic: fully headless — serial console on stdin/stdout, no window.
-#   Ctrl-A X exits QEMU; Ctrl-A C switches to the QEMU monitor.
-# -nic user: NAT networking with SSH port forwarding.
-exec qemu-system-x86_64 \
+# Boot headless. QEMU runs in the background; we poll SSH until it's up.
+qemu-system-x86_64 \
     -enable-kvm \
     -m "$QEMU_MEM" \
     -smp "$QEMU_CPUS" \
     -bios "$ovmf_path" \
     -cdrom "$iso_path" \
     -nic "user,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22" \
-    -nographic \
-    -boot d
+    -display none \
+    -boot d &
+QEMU_PID=$!
+
+trap 'kill "$QEMU_PID" 2>/dev/null; exit 0' INT TERM
+
+log_info "Waiting for SSH on port $SSH_PORT (this takes ~60s)..."
+until ssh \
+        -p "$SSH_PORT" \
+        -o StrictHostKeyChecking=no \
+        -o ConnectTimeout=2 \
+        -o LogLevel=ERROR \
+        "${ADMIN_USERNAME}@localhost" \
+        exit 0 2>/dev/null; do
+    kill -0 "$QEMU_PID" 2>/dev/null || { log_error "QEMU exited unexpectedly."; exit 1; }
+    sleep 3
+done
+
+log_ok "SSH is up!"
+log_ok "  ssh -p $SSH_PORT -o StrictHostKeyChecking=no ${ADMIN_USERNAME}@localhost"
+echo >&2
+log_warn "VM is running (PID $QEMU_PID). Press Ctrl-C to shut it down."
+wait "$QEMU_PID"

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -45,19 +45,18 @@ Options:
                         Default: all ~/.ssh/id_*.pub files.
   --build-only          Build the ISO but do not start the VM.
   --no-build            Skip the build step and boot an existing ISO.
+  --headless            No GUI window — poll for SSH in the background.
   -m, --memory MB       QEMU RAM in MB (default: $QEMU_MEM).
   -p, --port PORT       Host SSH port to forward (default: $SSH_PORT).
   -h, --help            Show this help.
 
-SSH key input:
-  File path  — starts with /, ~, or .  (one key per line)
-  Key string — starts with ssh-        (single key inline)
+By default the QEMU window opens (GUI mode) with serial output on the
+terminal. Use --headless to run without a window (SSH-only).
 
 Examples:
-  ./bin/test-iso
+  ./bin/test-iso                           # GUI + serial
+  ./bin/test-iso --headless                # no window, polls SSH
   ./bin/test-iso --ssh-key ~/.ssh/id_ed25519.pub
-  ./bin/test-iso -k ~/.ssh/id_ed25519.pub -k ~/.ssh/id_ed25519_sk.pub
-  ./bin/test-iso --ssh-key "ssh-ed25519 AAAA... user@host"
   ./bin/test-iso --build-only
 EOF
 }
@@ -67,6 +66,7 @@ EOF
 SSH_KEY_INPUTS=()
 BUILD=true
 BOOT=true
+HEADLESS=false
 
 # Admin identity — read from flake outputs (mkSystemFlake exposes these).
 ADMIN_USERNAME=""
@@ -85,6 +85,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --no-build)
             BUILD=false
+            shift
+            ;;
+        --headless)
+            HEADLESS=true
             shift
             ;;
         -m|--memory)
@@ -256,40 +260,49 @@ fi
 log_info "Starting QEMU with ISO: $(basename "$iso_path")"
 log_info "SSH port forwarding: localhost:$SSH_PORT → VM:22"
 echo >&2
-log_ok "Connect once the VM boots:"
+log_ok "SSH command:"
 log_ok "  ssh -p $SSH_PORT -o StrictHostKeyChecking=no ${ADMIN_USERNAME}@localhost"
 echo >&2
-log_warn "Press Ctrl-C to stop the VM."
-echo >&2
 
-# Boot headless. QEMU runs in the background; we poll SSH until it's up.
-qemu-system-x86_64 \
-    -enable-kvm \
-    -m "$QEMU_MEM" \
-    -smp "$QEMU_CPUS" \
-    -bios "$ovmf_path" \
-    -cdrom "$iso_path" \
-    -nic "user,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22" \
-    -display none \
-    -boot d &
-QEMU_PID=$!
+QEMU_COMMON=(
+    -enable-kvm
+    -m "$QEMU_MEM"
+    -smp "$QEMU_CPUS"
+    -bios "$ovmf_path"
+    -cdrom "$iso_path"
+    -nic "user,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22"
+    -boot d
+)
 
-trap 'kill "$QEMU_PID" 2>/dev/null; exit 0' INT TERM
+if [[ "$HEADLESS" == "true" ]]; then
+    # ── headless: background QEMU, poll for SSH ──────────────────────────────
+    log_warn "Headless mode. Press Ctrl-C to stop the VM."
+    echo >&2
 
-log_info "Waiting for SSH on port $SSH_PORT (this takes ~60s)..."
-until ssh \
-        -p "$SSH_PORT" \
-        -o StrictHostKeyChecking=no \
-        -o ConnectTimeout=2 \
-        -o LogLevel=ERROR \
-        "${ADMIN_USERNAME}@localhost" \
-        exit 0 2>/dev/null; do
-    kill -0 "$QEMU_PID" 2>/dev/null || { log_error "QEMU exited unexpectedly."; exit 1; }
-    sleep 3
-done
+    qemu-system-x86_64 "${QEMU_COMMON[@]}" -display none &
+    QEMU_PID=$!
+    trap 'kill "$QEMU_PID" 2>/dev/null; exit 0' INT TERM
 
-log_ok "SSH is up!"
-log_ok "  ssh -p $SSH_PORT -o StrictHostKeyChecking=no ${ADMIN_USERNAME}@localhost"
-echo >&2
-log_warn "VM is running (PID $QEMU_PID). Press Ctrl-C to shut it down."
-wait "$QEMU_PID"
+    log_info "Waiting for SSH on port $SSH_PORT (this takes ~60s)..."
+    until ssh \
+            -p "$SSH_PORT" \
+            -o StrictHostKeyChecking=no \
+            -o ConnectTimeout=2 \
+            -o LogLevel=ERROR \
+            "${ADMIN_USERNAME}@localhost" \
+            exit 0 2>/dev/null; do
+        kill -0 "$QEMU_PID" 2>/dev/null || { log_error "QEMU exited unexpectedly."; exit 1; }
+        sleep 3
+    done
+
+    log_ok "SSH is up!"
+    log_ok "  ssh -p $SSH_PORT -o StrictHostKeyChecking=no ${ADMIN_USERNAME}@localhost"
+    echo >&2
+    log_warn "VM is running (PID $QEMU_PID). Press Ctrl-C to shut it down."
+    wait "$QEMU_PID"
+else
+    # ── GUI: QEMU window + serial on the terminal ───────────────────────────
+    log_warn "Close the QEMU window or Ctrl-C to stop."
+    echo >&2
+    exec qemu-system-x86_64 "${QEMU_COMMON[@]}" -serial stdio
+fi

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -259,11 +259,11 @@ echo >&2
 log_ok "Connect once the VM boots:"
 log_ok "  ssh -p $SSH_PORT -o StrictHostKeyChecking=no ${ADMIN_USERNAME}@localhost"
 echo >&2
-log_warn "Press Ctrl-C to stop the VM. Serial console output below:"
+log_warn "Serial console is live. To exit QEMU: Ctrl-A X"
 echo >&2
 
-# -display none: headless — all interaction is over SSH or the serial console.
-# -serial mon:stdio: serial console + QEMU monitor on stdin/stdout.
+# -nographic: fully headless — serial console on stdin/stdout, no window.
+#   Ctrl-A X exits QEMU; Ctrl-A C switches to the QEMU monitor.
 # -nic user: NAT networking with SSH port forwarding.
 exec qemu-system-x86_64 \
     -enable-kvm \
@@ -272,6 +272,5 @@ exec qemu-system-x86_64 \
     -bios "$ovmf_path" \
     -cdrom "$iso_path" \
     -nic "user,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22" \
-    -display none \
-    -serial mon:stdio \
+    -nographic \
     -boot d

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -31,10 +31,11 @@
       ...
     }:
     keystone.lib.mkSystemFlake {
-      owner = {
-        name = "Your Name"; # TODO: Change to your name
-        username = "admin"; # TODO: Change to your primary username if needed
+      admin = {
+        username = "admin"; # TODO: Change to your login username
+        fullName = "Your Name"; # TODO: Change to your full name
         email = "admin@example.com"; # TODO: Change to your email
+        initialPassword = "changeme";
         # sshKeys = []; # TODO: Add SSH public keys for installer ISO remote access
       };
       defaults = {

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -35,6 +35,7 @@
         name = "Your Name"; # TODO: Change to your name
         username = "admin"; # TODO: Change to your primary username if needed
         email = "admin@example.com"; # TODO: Change to your email
+        # sshKeys = []; # TODO: Add SSH public keys for installer ISO remote access
       };
       defaults = {
         timeZone = "UTC"; # TODO: Set your default timezone

--- a/tests/module/template-evaluation.nix
+++ b/tests/module/template-evaluation.nix
@@ -69,6 +69,21 @@ let
     template-default-laptop = evalNixos "template-default-laptop" templateOutputs.nixosConfigurations.laptop;
     template-default-server-ocean = evalNixos "template-default-server-ocean" templateOutputs.nixosConfigurations.server-ocean;
 
+    template-default-iso =
+      let
+        isoImage = templateOutputs.packages.x86_64-linux.iso;
+      in
+      pkgs.runCommand "eval-template-iso" { } ''
+        mkdir -p $out
+        cat > $out/template-default-iso.json <<'ENDJSON'
+        {
+          "name": "template-default-iso",
+          "kind": "iso",
+          "isoName": "${isoImage.name}"
+        }
+        ENDJSON
+      '';
+
     laptop-ext4 = evalNixos "laptop-ext4" (
       self.lib.mkLaptop {
         hostname = "laptop";

--- a/tests/module/template-evaluation.nix
+++ b/tests/module/template-evaluation.nix
@@ -177,10 +177,11 @@ let
 
     inventory-server-no-hardware = evalNixos "inventory-server-no-hardware" (
       (self.lib.mkSystemFlake {
-        owner = {
-          name = "Fleet Owner";
+        admin = {
           username = "admin";
+          fullName = "Fleet Owner";
           email = "fleet@example.com";
+          initialPassword = "changeme";
         };
         defaults.timeZone = "UTC";
         keystoneServices = {

--- a/tests/module/template-evaluation.nix
+++ b/tests/module/template-evaluation.nix
@@ -71,7 +71,7 @@ let
 
     template-default-iso =
       let
-        isoImage = templateOutputs.packages.x86_64-linux.iso;
+        isoImage = templateOutputs.packages."x86_64-linux".iso;
       in
       pkgs.runCommand "eval-template-iso" { } ''
         mkdir -p $out


### PR DESCRIPTION
Four Copilot review threads remained unresolved after rebase. Three touched architecture hard-coding; one covered undocumented conditional ISO behavior.

## Changes

- **`lib/templates.nix` — system inference**: `defaultLinuxSystem` now derives from the Linux host inventory rather than blindly using `defaults.system or "x86_64-linux"`. Resolution order: explicit `defaults.system` → unique system across all Linux hosts (inferred from `hostCfg.system` or kind default) → `"x86_64-linux"` when no Linux hosts exist. Mixed systems without an explicit `defaults.system` throw a descriptive error.

- **`lib/templates.nix` — conditional ISO docs**: The `linuxHosts != {}` guard is intentional (macOS-only flakes have nothing to install); `docs/os/iso-generation.md` now documents this precondition explicitly.

- **`templates/default/README.md`**: Added a note to substitute `x86_64-linux` with the actual target system for non-x86_64 hosts.

- **`docs/os/iso-generation.md`**: Added architecture substitution guidance, corrected the stale `owner` API example to the current `admin` block, and documented the Linux-host precondition for ISO generation.