### PR TITLE
feat(desktop): sessions-first Walker picker for $mod+D

### DIFF
--- a/docs/terminal/projects.md
+++ b/docs/terminal/projects.md
@@ -124,6 +124,23 @@ pz keystone review
 zellij list-sessions
 ```
 
+### Session management
+
+There are three ways to find and switch between Zellij sessions:
+
+| Method | Context | What it shows |
+|--------|---------|---------------|
+| `pz` / `pz list` | Terminal | Project sessions in a tree view |
+| `zs` (`zesh connect`) | Terminal | Interactive fzf picker across all sessions with zoxide ranking |
+| `$mod+D` | Desktop | Walker fuzzy-search menu showing all active sessions |
+
+For scripting and tooling, `pz all-sessions-json` outputs every active Zellij
+session as JSON, annotated with project metadata where available:
+
+```bash
+pz all-sessions-json | jq '.[] | select(.status == "attached")'
+```
+
 ### Helix
 
 Use Helix as the default editor for code, notes, and docs:
@@ -179,27 +196,31 @@ Or refresh the hub through the workflow command:
 
 Use [Notes](../notes.md) for the canonical hub-note structure and note flow.
 
-## Desktop project navigation with Walker
+## Desktop session picker with Walker
 
-Keystone Desktop uses Walker as the quick project switcher. The desktop menu is
-an adapter over the same project data that powers `pz`, so there is no separate
-desktop-only project registry.
+`$mod+D` opens a Walker menu showing all active Zellij sessions with fuzzy
+search. Select a session to attach, or choose "New session" to browse projects
+and create one through the project picker.
+
+The sessions menu shows both project-backed sessions (with project metadata)
+and ad-hoc sessions (with their raw Zellij session name).
 
 Relevant commands and scripts:
 
-- `keystone-context-switch` opens the Walker project switcher
+- `keystone-context-switch` opens the Walker session picker
 - `keystone-project-menu` delegates session data and launch behavior to `pz`
 - `pz` remains the source of truth for sessions and project metadata
 
 The practical effect is:
 
-- active hub note in `~/notes/index/` creates a discoverable project,
-- `pz` resolves the project session and metadata,
-- Walker lets you jump to the right Ghostty/Zellij window or launch it if it is
-  not already open.
+- `pz all-sessions-json` enumerates every active Zellij session,
+- project-backed sessions get project icons and route through the full
+  project launch flow (host targeting, layouts),
+- ad-hoc sessions attach directly via `zellij attach`,
+- Walker provides native fuzzy matching across all entries.
 
-That is why stale notes state leads to stale desktop project menus. Keep the
-notes repo synchronized and keep the project hub note accurate.
+The project picker remains accessible via the "New session" entry and through
+the `$mod+Escape` main menu.
 
 ## Session naming
 

--- a/modules/desktop/home/components/keystone-sessions.lua
+++ b/modules/desktop/home/components/keystone-sessions.lua
@@ -1,0 +1,52 @@
+Name = "keystone-sessions"
+NamePretty = "Sessions"
+Description = "Active Zellij sessions"
+Icon = "utilities-terminal"
+HideFromProviderlist = true
+SearchName = true
+History = false
+FixedOrder = true
+
+local function json_decode(value)
+    if jsonDecode ~= nil then
+        return jsonDecode(value)
+    end
+
+    if jsonDecodes ~= nil then
+        return jsonDecodes(value)
+    end
+
+    return nil
+end
+
+local function command_path(name)
+    local home = os.getenv("HOME") or ""
+    if home ~= "" then
+        return home .. "/.local/bin/" .. name
+    end
+
+    return name
+end
+
+Action = command_path("keystone-project-menu") .. " dispatch '%VALUE%'"
+
+function GetEntries()
+    local handle = io.popen(command_path("keystone-project-menu") .. " sessions-json 2>/dev/null")
+    if not handle then
+        return {}
+    end
+
+    local payload = handle:read("*a") or ""
+    handle:close()
+
+    if payload == "" then
+        return {}
+    end
+
+    local ok, entries = pcall(json_decode, payload)
+    if not ok or type(entries) ~= "table" then
+        return {}
+    end
+
+    return entries
+end

--- a/modules/desktop/home/components/launcher.nix
+++ b/modules/desktop/home/components/launcher.nix
@@ -104,6 +104,11 @@ in
           sourcePath = ./keystone-project-notes.lua;
         }
         {
+          targetPath = ".config/elephant/menus/keystone-sessions.lua";
+          relativePath = "modules/desktop/home/components/keystone-sessions.lua";
+          sourcePath = ./keystone-sessions.lua;
+        }
+        {
           targetPath = ".config/elephant/menus/keystone-project-session.lua";
           relativePath = "modules/desktop/home/components/keystone-project-session.lua";
           sourcePath = ./keystone-project-session.lua;
@@ -286,6 +291,10 @@ in
             "menus:keystone-update" = {
               input = " Update";
               list = "No update actions available";
+            };
+            "menus:keystone-sessions" = {
+              input = " Sessions";
+              list = "No active sessions";
             };
             "menus:keystone-projects" = {
               input = " Projects";

--- a/modules/desktop/home/scripts/keystone-context-switch.sh
+++ b/modules/desktop/home/scripts/keystone-context-switch.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if [[ -x "$HOME/.local/bin/keystone-launch-walker" ]]; then
-  exec "$HOME/.local/bin/keystone-launch-walker" -m menus:keystone-projects
+  exec "$HOME/.local/bin/keystone-launch-walker" -m menus:keystone-sessions
 fi
 
-exec keystone-launch-walker -m menus:keystone-projects
+exec keystone-launch-walker -m menus:keystone-sessions

--- a/modules/desktop/home/scripts/keystone-project-menu.sh
+++ b/modules/desktop/home/scripts/keystone-project-menu.sh
@@ -495,6 +495,40 @@ cmd_project_preview() {
   '
 }
 
+cmd_sessions_json() {
+  local raw
+  raw=$(pz all-sessions-json 2>/dev/null || printf '[]\n')
+
+  printf '%s\n' "$raw" | jq '
+    [
+      {
+        Text: "New session",
+        Subtext: "Browse projects to create a new session",
+        Value: "new-session",
+        Icon: "list-add"
+      }
+    ]
+    + [
+        .[]
+        | if .project != "" then
+            {
+              Text: (if .session_slug == "main" then .project else (.project + " / " + .session_slug) end),
+              Subtext: .status,
+              Value: ("open\t" + .project + "\t" + .session_slug + "\t"),
+              Icon: "folder-development"
+            }
+          else
+            {
+              Text: .session_name,
+              Subtext: (.status + " · ad-hoc"),
+              Value: ("attach-raw\t" + .session_name),
+              Icon: "utilities-terminal"
+            }
+          end
+      ]
+  '
+}
+
 cmd_refresh_cache() {
   refresh_snapshot_sync
   printf "%s\n" "$SNAPSHOT_PATH"
@@ -546,6 +580,13 @@ cmd_dispatch() {
     clear-project-prefs)
       pz project-clear-prefs "$project_slug" >/dev/null
       ;;
+    attach-raw)
+      detach ghostty -e zellij attach "$project_slug"
+      ;;
+    new-session)
+      walker -q >/dev/null 2>&1 || true
+      setsid "$(keystone_cmd keystone-launch-walker)" -m "menus:keystone-projects" >/dev/null 2>&1 &
+      ;;
     open-note)
       cmd_open_note "$project_slug"
       ;;
@@ -581,6 +622,10 @@ case "${1:-}" in
     shift
     cmd_projects_json "$@"
     ;;
+  sessions-json)
+    shift
+    cmd_sessions_json "$@"
+    ;;
   project-details-json)
     shift
     cmd_project_details_json "$@"
@@ -604,7 +649,7 @@ case "${1:-}" in
     exec pz "$cmd" "$@"
     ;;
   *)
-    echo "Usage: keystone-project-menu {open|set-current-project|get-current-project|open-session-menu|refresh-cache|projects-json|project-details-json|project-notes-json|project-preview|dispatch|summary|sessions|preview|export-menu-data|export-menu-cache|menu-cache-path} ..." >&2
+    echo "Usage: keystone-project-menu {open|set-current-project|get-current-project|open-session-menu|refresh-cache|projects-json|sessions-json|project-details-json|project-notes-json|project-preview|dispatch|summary|sessions|preview|export-menu-data|export-menu-cache|menu-cache-path} ..." >&2
     exit 1
     ;;
 esac

--- a/packages/pz/pz.sh
+++ b/packages/pz/pz.sh
@@ -60,6 +60,7 @@ Usage:
   pz project-set-host <slug> <host>  Set a project-specific target host
   pz project-set-models <slug> <provider> <model> [fallback]  Set project launch defaults
   pz project-clear-prefs <slug>   Clear project-specific launch defaults
+  pz all-sessions-json             List all Zellij sessions as JSON
   pz agent <agent> <cmd> [args]   Run agentctl within the project context
   pz --help                       Show this help message
 
@@ -946,6 +947,69 @@ match_registered_project_slug() {
   fi
 }
 
+# list all active zellij sessions as JSON, annotated with project metadata
+cmd_all_sessions_json() {
+  local project_output
+  project_output=$(discover_projects 2>/dev/null || true)
+
+  local slugs=()
+  if [[ -n "$project_output" ]]; then
+    while IFS=$'\t' read -r s _rest; do
+      [[ -z "$s" ]] && continue
+      slugs+=("$s")
+    done <<< "$project_output"
+  fi
+
+  local sessions
+  sessions=$(zellij list-sessions --no-formatting 2>/dev/null || true)
+  if [[ -z "$sessions" ]]; then
+    printf '[]\n'
+    return 0
+  fi
+
+  local json_entries=()
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" == *"EXITED"* ]] && continue
+
+    local session_name status project_slug session_slug
+    session_name=$(printf "%s\n" "$line" | awk '{print $1}')
+    status=$(session_status_from_line "$line")
+
+    if [[ ${#slugs[@]} -gt 0 ]]; then
+      project_slug=$(match_registered_project_slug "$session_name" "${slugs[@]}")
+    else
+      project_slug=""
+    fi
+
+    if [[ -n "$project_slug" ]]; then
+      local suffix="${session_name#"$project_slug"}"
+      if [[ -z "$suffix" ]]; then
+        session_slug="main"
+      else
+        session_slug="${suffix#-}"
+        [[ -z "$session_slug" ]] && session_slug="main"
+      fi
+    else
+      session_slug=""
+    fi
+
+    json_entries+=("$(jq -cn \
+      --arg session_name "$session_name" \
+      --arg project "$project_slug" \
+      --arg session_slug "$session_slug" \
+      --arg status "$status" \
+      '{session_name: $session_name, project: $project, session_slug: $session_slug, status: $status}'
+    )")
+  done <<< "$sessions"
+
+  if [[ ${#json_entries[@]} -eq 0 ]]; then
+    printf '[]\n'
+    return 0
+  fi
+
+  printf '%s\n' "${json_entries[@]}" | jq -s '.'
+}
+
 # list active project sessions for registered projects only
 cmd_list() {
   set +e
@@ -1495,6 +1559,10 @@ case "$1" in
     ;;
   completion)
     cmd_completion
+    ;;
+  all-sessions-json)
+    shift
+    cmd_all_sessions_json "$@"
     ;;
   discover-slugs)
     cmd_discover_slugs


### PR DESCRIPTION
## Summary

- **`$mod+D` now shows all active Zellij sessions** with Walker fuzzy search instead of the projects list
- "New session" entry routes to the existing projects picker for creating new sessions
- Ad-hoc (non-project) sessions are included alongside project-backed ones
- Adds `pz all-sessions-json` CLI command for scripting access to session data
- Documents the three session management paths: `pz list` (terminal tree), `zs` (terminal fzf), `$mod+D` (desktop)

## Test plan

- [ ] Run `pz all-sessions-json` with active Zellij sessions and verify JSON output
- [ ] Run `keystone-project-menu sessions-json` and verify Walker-formatted JSON
- [ ] `ks build` and test `$mod+D` opens sessions menu with fuzzy search
- [ ] Verify "New session" entry opens the projects picker
- [ ] Verify attaching to both project-backed and ad-hoc sessions works
- [ ] Confirm `nix flake check` passes (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)