### PR TITLE
fix(terminal): bundle agent-assets templates in scriptPackage and add KEYSTONE_AGENT_TEMPLATES_DIR fallback

### DIFF
--- a/modules/terminal/generated-agent-assets.nix
+++ b/modules/terminal/generated-agent-assets.nix
@@ -16,9 +16,23 @@ let
     if config.keystone ? os && config.keystone.os ? agents then config.keystone.os.agents else { };
   manifestRelPath = ".config/keystone/agent-assets.json";
   scriptRelPath = "modules/terminal/scripts/keystone-sync-agent-assets.sh";
-  scriptPackage = pkgs.writeShellScriptBin "keystone-sync-agent-assets" (
-    builtins.readFile ./scripts/keystone-sync-agent-assets.sh
-  );
+  scriptPackage =
+    let
+      scriptBin = pkgs.writeShellScriptBin "keystone-sync-agent-assets" (
+        builtins.readFile ./scripts/keystone-sync-agent-assets.sh
+      );
+      templates = pkgs.runCommandLocal "keystone-sync-agent-assets-templates" { } ''
+        mkdir -p $out/share/agent-assets
+        cp -r ${./agent-assets}/. $out/share/agent-assets/
+      '';
+    in
+    pkgs.symlinkJoin {
+      name = "keystone-sync-agent-assets";
+      paths = [
+        scriptBin
+        templates
+      ];
+    };
   agentsWithMcp = mapAttrs (name: agentCfg: {
     inherit (agentCfg) host archetype;
     notesPath = agentCfg.notes.path;
@@ -97,9 +111,11 @@ in
         }:$PATH"
         if [ -f "${syncScriptPath}" ]; then
           KEYSTONE_AGENT_ASSETS_MANIFEST="$HOME/${manifestRelPath}" \
+          KEYSTONE_AGENT_TEMPLATES_DIR="${scriptPackage}/share/agent-assets" \
             ${pkgs.bash}/bin/bash "${syncScriptPath}"
         else
           KEYSTONE_AGENT_ASSETS_MANIFEST="$HOME/${manifestRelPath}" \
+          KEYSTONE_AGENT_TEMPLATES_DIR="${scriptPackage}/share/agent-assets" \
             ${scriptPackage}/bin/keystone-sync-agent-assets
         fi
       '';

--- a/modules/terminal/scripts/keystone-sync-agent-assets.sh
+++ b/modules/terminal/scripts/keystone-sync-agent-assets.sh
@@ -287,20 +287,40 @@ repo_checkout="$(json_get '.repoCheckout')"
 archetype="$(json_get '.archetype')"
 development_mode="$(json_get '.developmentMode')"
 
-if [[ "$repo_checkout" == "null" || -z "$repo_checkout" ]]; then
-  echo "Error: manifest does not declare a live keystone repo checkout" >&2
+# Resolve templates_dir.
+# Priority: KEYSTONE_AGENT_TEMPLATES_DIR (Nix-store bundled) → live checkout → error.
+if [[ -n "${KEYSTONE_AGENT_TEMPLATES_DIR:-}" && -d "$KEYSTONE_AGENT_TEMPLATES_DIR" ]]; then
+  templates_dir="$KEYSTONE_AGENT_TEMPLATES_DIR"
+elif [[ "$repo_checkout" != "null" && -n "$repo_checkout" && -d "$repo_checkout/modules/terminal/agent-assets" ]]; then
+  templates_dir="$repo_checkout/modules/terminal/agent-assets"
+else
+  echo "Error: no templates directory found." >&2
+  if [[ -n "${KEYSTONE_AGENT_TEMPLATES_DIR:-}" ]]; then
+    echo "  KEYSTONE_AGENT_TEMPLATES_DIR=$KEYSTONE_AGENT_TEMPLATES_DIR (not found)" >&2
+  else
+    echo "  KEYSTONE_AGENT_TEMPLATES_DIR is not set" >&2
+  fi
+  if [[ "$repo_checkout" != "null" && -n "$repo_checkout" ]]; then
+    echo "  $repo_checkout/modules/terminal/agent-assets (not found)" >&2
+  else
+    echo "  repoCheckout not set in manifest" >&2
+  fi
   exit 1
 fi
 
-if [[ ! -d "$repo_checkout" ]]; then
-  repo_slug="${repo_checkout##*/.keystone/repos/}"
-  echo "Live keystone repo checkout not found at $repo_checkout — cloning $repo_slug..."
-  mkdir -p "$(dirname "$repo_checkout")"
-  git clone "https://github.com/$repo_slug.git" "$repo_checkout"
+# Resolve conventions_dir from live checkout or manifest fallback.
+if [[ "$repo_checkout" != "null" && -n "$repo_checkout" ]]; then
+  if [[ ! -d "$repo_checkout" ]]; then
+    repo_slug="${repo_checkout##*/.keystone/repos/}"
+    echo "Live keystone repo checkout not found at $repo_checkout — cloning $repo_slug..."
+    mkdir -p "$(dirname "$repo_checkout")"
+    git clone "https://github.com/$repo_slug.git" "$repo_checkout"
+  fi
+  conventions_dir="$repo_checkout/conventions"
+else
+  conventions_dir="$(json_get '.fallbackConventionsDir')"
 fi
 
-conventions_dir="$repo_checkout/conventions"
-templates_dir="$repo_checkout/modules/terminal/agent-assets"
 archetypes_file="$conventions_dir/archetypes.yaml"
 
 if [[ ! -f "$archetypes_file" ]]; then

--- a/tests/module/agent-task-loop-invalid-pending-task.nix
+++ b/tests/module/agent-task-loop-invalid-pending-task.nix
@@ -67,106 +67,106 @@ pkgs.runCommand "test-agent-task-loop-invalid-pending-task"
     ];
   }
   ''
-    set -euo pipefail
+        set -euo pipefail
 
-    export HOME="$PWD/home"
-    export TASK_LOOP_TEST_STATE_DIR="$PWD/state"
-    export PATH="$PWD/stubs:${
-      lib.makeBinPath [
-        pkgs.bash
-        pkgs.coreutils
-        pkgs.findutils
-        pkgs.gawk
-        pkgs.gnugrep
-        pkgs.gnused
-        pkgs.jq
-        pkgs.util-linux
-        pkgs.yq-go
-      ]
-    }"
+        export HOME="$PWD/home"
+        export TASK_LOOP_TEST_STATE_DIR="$PWD/state"
+        export PATH="$PWD/stubs:${
+          lib.makeBinPath [
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.findutils
+            pkgs.gawk
+            pkgs.gnugrep
+            pkgs.gnused
+            pkgs.jq
+            pkgs.util-linux
+            pkgs.yq-go
+          ]
+        }"
 
-    mkdir -p "$HOME" "$TASK_LOOP_TEST_STATE_DIR" "$PWD/stubs" ${notesDir}
+        mkdir -p "$HOME" "$TASK_LOOP_TEST_STATE_DIR" "$PWD/stubs" ${notesDir}
 
-    cat > ${notesDir}/TASKS.yaml <<'EOF'
-tasks:
-  - name: ""
-    description: "Malformed pending task"
-    status: pending
-    source: email
-    source_ref: "email-empty-name@test"
-  - name: "reply-pong-to-test"
-    description: "Reply with pong to the ping email from test@ncrmro.com"
-    status: pending
-    source: email
-    source_ref: "email-1-test@ncrmro.com"
-EOF
+        cat > ${notesDir}/TASKS.yaml <<'EOF'
+    tasks:
+      - name: ""
+        description: "Malformed pending task"
+        status: pending
+        source: email
+        source_ref: "email-empty-name@test"
+      - name: "reply-pong-to-test"
+        description: "Reply with pong to the ping email from test@ncrmro.com"
+        status: pending
+        source: email
+        source_ref: "email-1-test@ncrmro.com"
+    EOF
 
-    mkdir -p ${notesDir}/.deepwork
+        mkdir -p ${notesDir}/.deepwork
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/systemctl"
-    chmod +x "$PWD/stubs/systemctl"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/systemctl"
+        chmod +x "$PWD/stubs/systemctl"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/git"
-    chmod +x "$PWD/stubs/git"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/git"
+        chmod +x "$PWD/stubs/git"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' "printf '%s\\n' \"test-host\"" > "$PWD/stubs/hostname"
-    chmod +x "$PWD/stubs/hostname"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' "printf '%s\\n' \"test-host\"" > "$PWD/stubs/hostname"
+        chmod +x "$PWD/stubs/hostname"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/fetch-email-source"
-    chmod +x "$PWD/stubs/fetch-email-source"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/fetch-email-source"
+        chmod +x "$PWD/stubs/fetch-email-source"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/calendula"
-    chmod +x "$PWD/stubs/calendula"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/calendula"
+        chmod +x "$PWD/stubs/calendula"
 
-    cat > "$PWD/stubs/claude" <<'STUBEOF'
-    #!${pkgs.bash}/bin/bash
-    set -euo pipefail
+        cat > "$PWD/stubs/claude" <<'STUBEOF'
+        #!${pkgs.bash}/bin/bash
+        set -euo pipefail
 
-    args="$*"
-    state_dir="''${TASK_LOOP_TEST_STATE_DIR:?}"
+        args="$*"
+        state_dir="''${TASK_LOOP_TEST_STATE_DIR:?}"
 
-    if printf '%s' "$args" | grep -q "task_loop prioritize"; then
-      printf '%s\n' "1" > "$state_dir/prioritize-count"
-    else
-      printf '%s\n' "1" > "$state_dir/execute-count"
-      printf '%s\n' "$args" > "$state_dir/execute-args"
-    fi
+        if printf '%s' "$args" | grep -q "task_loop prioritize"; then
+          printf '%s\n' "1" > "$state_dir/prioritize-count"
+        else
+          printf '%s\n' "1" > "$state_dir/execute-count"
+          printf '%s\n' "$args" > "$state_dir/execute-args"
+        fi
 
-    printf '%s\n' '{"total_tokens":1}'
-    STUBEOF
-    chmod +x "$PWD/stubs/claude"
+        printf '%s\n' '{"total_tokens":1}'
+        STUBEOF
+        chmod +x "$PWD/stubs/claude"
 
-    bash "${taskLoopScript}"
+        bash "${taskLoopScript}"
 
-    invalid_status="$(yq '[.tasks[] | select(.source_ref == "email-empty-name@test")] | .[0].status' ${notesDir}/TASKS.yaml)"
-    if [[ "$invalid_status" != "error" ]]; then
-      echo "FAIL: invalid pending task status is '$invalid_status', expected 'error'" >&2
-      cat ${notesDir}/TASKS.yaml >&2
-      exit 1
-    fi
-    echo "PASS: invalid pending task marked error"
+        invalid_status="$(yq '[.tasks[] | select(.source_ref == "email-empty-name@test")] | .[0].status' ${notesDir}/TASKS.yaml)"
+        if [[ "$invalid_status" != "error" ]]; then
+          echo "FAIL: invalid pending task status is '$invalid_status', expected 'error'" >&2
+          cat ${notesDir}/TASKS.yaml >&2
+          exit 1
+        fi
+        echo "PASS: invalid pending task marked error"
 
-    valid_status="$(yq '[.tasks[] | select(.source_ref == "email-1-test@ncrmro.com")] | .[0].status' ${notesDir}/TASKS.yaml)"
-    if [[ "$valid_status" != "completed" ]]; then
-      echo "FAIL: valid pending task status is '$valid_status', expected 'completed'" >&2
-      cat ${notesDir}/TASKS.yaml >&2
-      exit 1
-    fi
-    echo "PASS: valid pending task completed"
+        valid_status="$(yq '[.tasks[] | select(.source_ref == "email-1-test@ncrmro.com")] | .[0].status' ${notesDir}/TASKS.yaml)"
+        if [[ "$valid_status" != "completed" ]]; then
+          echo "FAIL: valid pending task status is '$valid_status', expected 'completed'" >&2
+          cat ${notesDir}/TASKS.yaml >&2
+          exit 1
+        fi
+        echo "PASS: valid pending task completed"
 
-    if [[ ! -f "$TASK_LOOP_TEST_STATE_DIR/execute-count" ]]; then
-      echo "FAIL: execute stage was not invoked" >&2
-      exit 1
-    fi
-    echo "PASS: execute stage invoked"
+        if [[ ! -f "$TASK_LOOP_TEST_STATE_DIR/execute-count" ]]; then
+          echo "FAIL: execute stage was not invoked" >&2
+          exit 1
+        fi
+        echo "PASS: execute stage invoked"
 
-    execute_args="$(cat "$TASK_LOOP_TEST_STATE_DIR/execute-args")"
-    if ! printf '%s' "$execute_args" | grep -qi "reply-pong-to-test"; then
-      echo "FAIL: execute stage did not receive the valid task name" >&2
-      echo "  execute args: $execute_args" >&2
-      exit 1
-    fi
-    echo "PASS: execute received valid task name"
+        execute_args="$(cat "$TASK_LOOP_TEST_STATE_DIR/execute-args")"
+        if ! printf '%s' "$execute_args" | grep -qi "reply-pong-to-test"; then
+          echo "FAIL: execute stage did not receive the valid task name" >&2
+          echo "  execute args: $execute_args" >&2
+          exit 1
+        fi
+        echo "PASS: execute received valid task name"
 
-    touch "$out"
+        touch "$out"
   ''


### PR DESCRIPTION
Closes #261

## Summary

- Reworks `scriptPackage` in `generated-agent-assets.nix` into a `symlinkJoin` that bundles `modules/terminal/agent-assets/` at `share/agent-assets/`, making the derivation self-contained.
- Activation now always passes `KEYSTONE_AGENT_TEMPLATES_DIR` pointing to the bundled Nix-store templates, so `keystoneSyncAgentAssets` succeeds even when the live keystone checkout predates `agent-assets/` (introduced 2026-03-29).
- `keystone-sync-agent-assets.sh` resolves `templates_dir` with explicit priority: `KEYSTONE_AGENT_TEMPLATES_DIR` env var → live checkout → error naming both paths tried. `conventions_dir` falls back to `fallbackConventionsDir` from the manifest when `repoCheckout` is null (agent profiles).

## Test plan

- [ ] Verify `nix flake check --no-build` passes (pre-existing unrelated failure on `keystone-conventions.drv` is not introduced by this PR).
- [ ] Run `ks update --dev` on a host with a fresh checkout — `keystoneSyncAgentAssets` activation should succeed and produce expected `~/.keystone/AGENTS.md` and skill files.
- [ ] Simulate a stale checkout by temporarily renaming `modules/terminal/agent-assets/` in a local clone and rerunning the script with `KEYSTONE_AGENT_TEMPLATES_DIR` set — script should use the bundled templates and succeed.
- [ ] Run `ks sync-agent-assets` manually without `KEYSTONE_AGENT_TEMPLATES_DIR` — script should fall through to the live checkout templates.
- [ ] Confirm that with neither `KEYSTONE_AGENT_TEMPLATES_DIR` set nor a valid checkout, the error message names both paths tried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)