### PR TITLE
feat(keystone-tui): add first-boot hardware reconciliation commit and push flow

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -5,7 +5,7 @@ agent: claude
 platform: github
 issue: 225
 task_type: implement
-status: ready
+status: completed
 created: 2026-04-08
 ---
 

--- a/TASK.md
+++ b/TASK.md
@@ -1,0 +1,43 @@
+---
+repo: ncrmro/keystone
+branch: feat/first-boot-hardware-fact-detection-225
+agent: claude
+platform: github
+issue: 225
+task_type: implement
+status: ready
+created: 2026-04-08
+---
+
+# feat(keystone-tui): add first-boot hardware fact detection and diff preview
+
+## Description
+
+The current first-boot flow runs `nixos-generate-config --show-hardware-config` and writes
+the raw output directly to `hardware.nix` without presenting a review step or performing
+any reconciliation against the hardware selected during install. The user sees no diff,
+no warning about disk mappings, and has no way to skip if detection looks wrong.
+
+This task adds:
+1. In-memory hardware facts collection (`FirstBootHardwareFacts`)
+2. In-memory patch plan generation (`PushbackPatchPlan`) with diff preview
+3. A user-facing review step before any file is written
+4. Confident disk mapping with explicit warning if mapping fails
+5. A clean "no changes required" exit when hardware.nix already matches
+
+Tech stack: Rust, ratatui, tokio. Source at `packages/keystone-tui/src/`.
+
+## Acceptance Criteria
+
+- [ ] First-boot flow gathers actual hardware facts before proposing repo changes
+- [ ] The flow builds an in-memory patch plan instead of writing raw hardware.nix output directly to git
+- [ ] The screen shows detected disk identifiers, kernel modules, and a diff preview step before apply
+- [ ] If no confident disk mapping exists, the flow warns and does not silently guess
+- [ ] If no patch is needed, the flow exits cleanly with an explicit "no changes required" result
+- [ ] Existing tests pass (cargo test)
+
+## Key Files
+
+- `packages/keystone-tui/src/screens/first_boot.rs` — first-boot orchestration and phases
+- `packages/keystone-tui/src/disk.rs` — disk discovery (reused for fact gathering)
+- `packages/keystone-tui/src/template.rs` — placeholder constants consumed during reconciliation

--- a/packages/keystone-tui/specs/001-config-generation-contract.md
+++ b/packages/keystone-tui/specs/001-config-generation-contract.md
@@ -1,0 +1,155 @@
+# Spec: Config Generation Contract
+
+## Stories Covered
+- US-001: Define config generation output contract
+- US-002: Define template data model
+- US-003: Implement build validation test suite
+
+Derived from: REQ-001 (Config Generation), REQ-002 (Template Data Model), REQ-003 (Build Validation)
+
+## Affected Modules
+- `packages/keystone-tui/src/template.rs` — `GenerateConfig`, all generator functions
+- `packages/keystone-tui/tests/nix_build.rs` — `#[ignore]`d eval/build tests
+- `packages/keystone-tui/flake.nix` — must expose `checks.x86_64-linux.template-evaluation`
+- `packages/keystone-tui/checks/template-evaluation.nix` — new Nix derivation (to create)
+
+## Data Model
+
+### `GenerateConfig` (Rust struct — `src/template.rs`)
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| hostname | `String` | yes | Maps to `networking.hostName` |
+| host_id | `String` | yes | 8-char hex; generated randomly by TUI; maps to `networking.hostId` |
+| state_version | `String` | yes | Defaults to `"25.05"`; maps to `system.stateVersion` |
+| time_zone | `String` | yes | Defaults to `"UTC"`; maps to `time.timeZone` |
+| machine_type | `MachineType` | yes | Server \| Workstation \| Laptop |
+| storage | `StorageConfig` | yes | See below |
+| security | `SecurityConfig` | yes | See below |
+| users | `Vec<UserConfig>` | yes | At least one entry required |
+| github_username | `Option<String>` | no | For fetching SSH keys via GitHub API |
+
+### `StorageConfig`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| storage_type | `StorageType` (Zfs \| Ext4) | yes | Maps to `keystone.os.storage.type` |
+| devices | `Vec<String>` | yes | ≥1 entry; SHOULD be `/dev/disk/by-id/` paths |
+| mode | `StorageMode` | no | Single \| Mirror \| Stripe \| Raidz1 \| Raidz2 \| Raidz3; default `Single` |
+| swap_size | `Option<String>` | no | E.g. `"16G"`; defaults to `"16G"` |
+| hibernate | `bool` | no | Only valid when `storage_type = Ext4`; default `false` |
+
+### `SecurityConfig`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| secure_boot | `bool` | no | Maps to `keystone.os.secureBoot.enable`; default `true` |
+| tpm | `bool` | no | Maps to `keystone.os.tpm.enable`; default `true` |
+| remote_unlock | `RemoteUnlockConfig` | no | See below |
+
+### `RemoteUnlockConfig`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| enable | `bool` | yes | Maps to `keystone.os.remoteUnlock.enable` |
+| authorized_keys | `Vec<String>` | no | SSH public keys for initrd unlock |
+
+### `UserConfig`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| username | `String` | yes | Maps to `keystone.os.users.<name>` key |
+| full_name | `String` | yes | Maps to `fullName` |
+| email | `Option<String>` | no | Maps to `email`; defaults to `{username}@localhost` |
+| initial_password | `String` | yes | Maps to `initialPassword`; SHOULD warn user to change post-install |
+| authorized_keys | `Vec<String>` | no | SSH public keys |
+| extra_groups | `Vec<String>` | no | Default: `["wheel"]` for first user, `["wheel", "networkmanager", "video", "audio"]` for desktop |
+| terminal_enable | `bool` | no | Default `true` |
+| desktop_enable | `bool` | no | Default based on `MachineType` (false for Server, true for Workstation/Laptop) |
+
+## Generated File Contracts
+
+### `flake.nix`
+
+The generated flake.nix MUST:
+1. Declare `nixpkgs`, `keystone`, `home-manager`, and `disko` as inputs, with
+   `nixpkgs.follows = "nixpkgs"` on all derived inputs.
+2. Import `keystone.nixosModules.operating-system` in the modules list.
+3. Import `home-manager.nixosModules.home-manager` for any user with `terminal.enable` or `desktop.enable`.
+4. Import `keystone.nixosModules.desktop` when any user has `desktop.enable = true`.
+5. Expose exactly one `nixosConfigurations.<hostname>` output using the user-provided hostname.
+6. NOT contain any `TODO:` markers.
+
+### `configuration.nix`
+
+The generated configuration.nix MUST:
+1. Set `networking.hostName`, `networking.hostId`, `system.stateVersion`.
+2. Set `time.timeZone`.
+3. Set `keystone.os.enable = true`.
+4. Set `keystone.os.storage` with type, devices, mode, and swap.size.
+5. Set at least one `keystone.os.users.<username>` entry with fullName, email, extraGroups,
+   initialPassword, authorizedKeys, terminal.enable, and desktop.enable.
+6. NOT contain any `TODO:` markers.
+7. Use `__KEYSTONE_DISK__` as the disk placeholder when no device is provided (deferred selection).
+
+### `hardware.nix`
+
+The generated hardware.nix MUST:
+1. Be a minimal valid NixOS module: `{ ... }: { }` with an imports list pointing to
+   `(modulesPath + "/installer/scan/not-detected.nix")`.
+2. NOT configure any hardware — hardware.nix is populated post-installation by
+   `nixos-generate-config` or `nixos-anywhere`.
+
+## Behavioral Requirements
+
+### Config Generation
+
+1. The generator MUST produce `flake.nix`, `configuration.nix`, and `hardware.nix` from a
+   single `GenerateConfig` input.
+2. Generated files MUST pass `nix-instantiate --parse` without errors.
+3. Generated files SHOULD pass `nixfmt-rfc-style` formatting (no diff on re-format).
+4. The `hostId` field MUST be generated from `/dev/urandom` (8 hex chars); it MUST fall back
+   to a time-based seed if `/dev/urandom` is unavailable.
+5. String values embedded in Nix files MUST be escaped: `\` → `\\`, `"` → `\"`, `${` → `\${`,
+   `\n` → `\\n`.
+
+### Build Validation (Nix Check)
+
+6. A Nix derivation MUST be importable as `checks.x86_64-linux.template-evaluation` from the
+   keystone-tui `flake.nix`.
+7. The check MUST evaluate at least 4 configuration variants:
+   - Single-disk ZFS (Server)
+   - Multi-disk ZFS mirror (Server, 2 devices)
+   - Single-disk ext4 (Laptop)
+   - ZFS with desktop module (Workstation)
+8. Each variant MUST evaluate successfully via `nixpkgs.lib.nixosSystem` without errors.
+9. Each variant MUST force deep evaluation by serializing `users.users`, `users.groups`, and
+   `systemd.services` via `builtins.toJSON`.
+10. The derivation MUST write `$out/<config-name>.json` for each variant, containing at
+    minimum `users`, `groups`, and `services` keys.
+11. The check MUST be runnable via `nix build .#checks.x86_64-linux.template-evaluation`.
+
+### Data Model Validation
+
+12. The system MUST reject a `GenerateConfig` with zero storage devices.
+13. The system MUST reject a `GenerateConfig` with zero users.
+14. The system MUST reject a `hostId` that is not exactly 8 hexadecimal characters.
+15. The system MUST reject `storage.mode = Mirror` with fewer than 2 devices.
+16. The system MUST reject `storage.hibernate = true` when `storage_type = Zfs`.
+
+## Edge Cases
+
+- **Special characters in hostnames**: Hostnames containing `"`, `\`, or `${` MUST be escaped
+  in all generated files. The `escape_nix_string` function already handles this.
+- **Empty authorized_keys**: An empty `authorized_keys` list MUST produce `authorizedKeys = []`
+  (not a missing field).
+- **Deferred disk selection**: When `disk_device` is `None`, the placeholder `__KEYSTONE_DISK__`
+  MUST appear in generated config. The ISO installer replaces it at install time.
+- **Multiple users**: All users MUST appear in `keystone.os.users`. The first user gets
+  `extraGroups = ["wheel"]`; desktop users get networking/video/audio groups.
+- **nixfmt unavailability**: If `nixfmt-rfc-style` is not in PATH, formatting validation MUST
+  be skipped (not a build failure), but a warning SHOULD be logged.
+
+## Cross-References
+- Spec 004 (TUI App Framework): the `GenerateConfig` model is populated by the interactive form
+  in `create_config.rs` and by the JSON mode parser.

--- a/packages/keystone-tui/specs/002-nix-flake-parsing-modification.md
+++ b/packages/keystone-tui/specs/002-nix-flake-parsing-modification.md
@@ -1,0 +1,168 @@
+# Spec: Nix Flake Parsing and Modification
+
+## Stories Covered
+- US-005: Display all keystone hosts
+- US-009: Create new keystone host configurations
+
+## Affected Modules
+- `packages/keystone-tui/src/nix.rs` — flake.nix AST parser (read-only today; needs write support)
+- `packages/keystone-tui/src/screens/hosts.rs` — hosts dashboard
+- `packages/keystone-tui/src/screens/create_config.rs` — config creation form
+- `packages/keystone-tui/src/system.rs` — `HostStatus` struct
+- `modules/hosts.nix` — `keystone.hosts` NixOS option (already implemented)
+
+## Data Models
+
+### `HostInfo` (extended — `src/nix.rs`)
+
+Current fields:
+| Field | Type | Notes |
+|-------|------|-------|
+| name | `String` | Attribute key in `nixosConfigurations` |
+| system | `Option<String>` | Architecture, e.g. `"x86_64-linux"` |
+| keystone_modules | `Vec<String>` | Imported keystone modules |
+| config_files | `Vec<String>` | Local config file paths |
+
+Fields to add (from `keystone.hosts` evaluation):
+| Field | Type | Notes |
+|-------|------|-------|
+| hostname | `Option<String>` | From `keystone.hosts.<name>.hostname` |
+| ssh_target | `Option<String>` | Tailscale hostname or IP for deploys |
+| fallback_ip | `Option<String>` | LAN IP fallback |
+| build_on_remote | `bool` | Whether to use `--build-host` for deploys |
+| role | `Option<String>` | `"client"` \| `"server"` \| `"agent"` |
+| host_public_key | `Option<String>` | SSH host public key |
+
+### `HostsEvalResult` (new — `src/nix.rs`)
+
+JSON output of `nix eval --json .#nixosConfigurations` for `keystone.hosts`:
+
+```json
+{
+  "ocean": {
+    "hostname": "ocean",
+    "sshTarget": "ocean.mercury",
+    "fallbackIP": "192.168.1.10",
+    "buildOnRemote": true,
+    "role": "server",
+    "hostPublicKey": "ssh-ed25519 AAAAC3..."
+  }
+}
+```
+
+## Behavioral Requirements
+
+### Host Display (US-005)
+
+1. The hosts screen MUST display hostname, sshTarget, fallbackIP, and buildOnRemote for each
+   host defined in `keystone.hosts`.
+2. The TUI MUST read `keystone.hosts` by running:
+   `nix eval --json .#nixosConfigurations.<hostname>.config.keystone.hosts`
+   or by parsing `nix eval --json` output from the flake's hosts attribute.
+3. The hosts list MUST be navigable via arrow keys; pressing Enter on a host MUST open the
+   host detail screen.
+4. The host detail screen MUST display a summary of the selected host's configuration
+   including all `keystone.hosts` fields.
+5. The TUI MUST handle the case where `keystone.hosts` is empty (show an empty list with a
+   hint to add hosts).
+6. The TUI MUST handle flakes that do not import `keystone.nixosModules.hosts` gracefully
+   (fall back to displaying names from `nixosConfigurations` only, without metadata).
+7. The `HostsScreen` MUST NOT block the event loop during `nix eval` — evaluation MUST run
+   on a background tokio task and results MUST be delivered via channel.
+
+### New Host Creation (US-009)
+
+8. The TUI MUST support two distinct host creation modes:
+   - **New repo mode**: Creates a fresh directory with `flake.nix`, `configuration.nix`,
+     `hardware.nix` (existing `CreateConfigScreen` flow).
+   - **Add-to-existing mode**: Adds a new host to an already-open nixos-config flake.
+9. In add-to-existing mode, the TUI MUST modify `flake.nix` to add a new entry under
+   `nixosConfigurations.<hostname>`.
+10. In add-to-existing mode, the TUI MUST create a `hosts/<hostname>/` directory containing
+    `configuration.nix` and `hardware.nix`.
+11. In add-to-existing mode, the TUI MUST add the new host to `keystone.hosts` in the
+    existing `configuration.nix` (or a shared `hosts.nix` if present).
+12. `flake.nix` modification MUST use `rnix` AST manipulation — NOT string replacement.
+13. Before writing to `flake.nix`, the TUI MUST validate the modified AST parses without
+    errors via `rnix`.
+14. The TUI MUST create a git commit for the new host files before returning to the hosts
+    screen (leveraging the git operations in Spec 004).
+15. If `rnix` AST modification fails (unparseable flake), the TUI MUST display an error and
+    MUST NOT write partial changes to disk.
+
+## `rnix` Modification Contract
+
+The `nix.rs` module MUST expose a `add_nixos_configuration` function:
+
+```rust
+/// Add a new NixOS configuration entry to an existing flake.nix.
+/// Returns the modified flake.nix content as a String.
+pub fn add_nixos_configuration(
+    flake_content: &str,
+    hostname: &str,
+    config_path: &str,  // e.g., "./hosts/my-host/configuration.nix"
+) -> Result<String>
+```
+
+The function MUST:
+- Parse `flake_content` with `rnix`
+- Locate the `nixosConfigurations` attrset
+- Insert a new entry: `"<hostname>" = nixpkgs.lib.nixosSystem { system = "x86_64-linux"; modules = [ <config_path> ]; };`
+- Return the serialized (formatted) modified content
+- Return `Err` if the flake cannot be parsed or `nixosConfigurations` cannot be located
+
+## Edge Cases
+
+- **Quoted hostnames**: Hostnames with hyphens (e.g., `my-server`) MUST be quoted as
+  `"my-server"` in the Nix attrset. The `add_nixos_configuration` function MUST handle this.
+- **Duplicate hostname**: If `nixosConfigurations` already contains the target hostname, the
+  TUI MUST show an error ("Host already exists") and MUST NOT overwrite the existing entry.
+- **Nix eval timeout**: `nix eval` for `keystone.hosts` MUST time out after 30 seconds and
+  fall back to displaying `nixosConfigurations` names only (without metadata).
+- **Uncommitted changes**: When adding a host, if `flake.nix` has unstaged changes, the TUI
+  SHOULD warn the user before proceeding.
+- **Missing `hosts/` directory**: If `hosts/<hostname>/` already exists (prior partial run),
+  the TUI MUST NOT overwrite existing files — it MUST show an error.
+
+## UI Mockups
+
+### Hosts Screen
+
+```
+┌─ Keystone TUI ─── my-infra ─────────────────────────────────────────────┐
+│                                                                          │
+│  Hosts                                         System (local)            │
+│ ┌──────────────────────────────────┐  ┌───────────────────────────────┐  │
+│ │ > ocean         server   online  │  │ CPU  ████████░░░░  42%        │  │
+│ │   mercury       client  offline  │  │ MEM  █████░░░░░░  51%        │  │
+│ │   titan         agent    online  │  │ DISK ██░░░░░░░░░  21%        │  │
+│ │                                  │  │ TEMP 61°C                     │  │
+│ │                                  │  └───────────────────────────────┘  │
+│ │                                  │                                      │
+│ │  [n] New Host  [Enter] Details   │  Tailscale: 2/3 online              │
+│ └──────────────────────────────────┘                                      │
+│                                                                          │
+│  [q] Quit  [b] Build  [i] ISO  [?] Help                                  │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Host Detail Screen
+
+```
+┌─ Host Detail: ocean ─────────────────────────────────────────────────────┐
+│                                                                          │
+│  Identity                          Connection                            │
+│  Hostname:   ocean                 SSH Target:    ocean.mercury           │
+│  Role:       server                Fallback IP:   192.168.1.10           │
+│  Build mode: remote                                                      │
+│                                                                          │
+│  Modules: operating-system, hosts, secrets                               │
+│                                                                          │
+│  [b] Build  [d] Deploy  [Esc] Back                                       │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Cross-References
+- Spec 001 (Config Generation): `GenerateConfig` is used to generate files for the new host.
+- Spec 003 (ISO Pipeline): Deployment from host detail screen (US-008) references this spec.
+- Spec 004 (TUI App Framework): Screen routing and git commit integration.

--- a/packages/keystone-tui/specs/003-iso-pipeline.md
+++ b/packages/keystone-tui/specs/003-iso-pipeline.md
@@ -1,0 +1,182 @@
+# Spec: ISO Pipeline
+
+## Stories Covered
+- US-007: Build ISO installers with baked-in agenix secrets
+- US-008: Detect and deploy to Keystone ISO instances
+
+## Affected Modules
+- `packages/keystone-tui/src/screens/iso.rs` — ISO build + write to USB (phases exist)
+- `packages/keystone-tui/src/template.rs` — `generate_iso_flake_nix` (already implemented)
+- `packages/keystone-tui/src/app.rs` — new `AppScreen::Deploy` variant needed for US-008
+- `modules/iso-installer.nix` — `keystone.nixosModules.isoInstaller` (already implemented)
+- `packages/keystone-tui/Cargo.toml` — needs mDNS crate for ISO discovery
+
+## Existing State
+
+The `IsoScreen` already supports:
+- **Phase SelectTarget**: listing USB devices + ~/Downloads
+- **Phase Building**: runs `nix build .#iso` in the active repo
+- **Phase Writing**: `dd` to USB or `cp` to ~/Downloads
+- **Phase Done/Failed**
+
+The `generate_iso_flake_nix` function already produces a flake that:
+- Uses `keystone.nixosModules.isoInstaller`
+- Embeds target config files at `/etc/keystone/install-config/`
+- Accepts SSH keys via `keystone.installer.sshKeys`
+
+## Gaps to Implement
+
+### US-007: Agenix Secrets Baking
+
+The current ISO build does not include agenix secrets. The agenix-secrets integration requires:
+1. Determining the path to the user's secrets repo
+2. Copying or symlinking the secrets into the ISO build directory as `agenix-secrets/`
+3. Wiring the secrets path into the generated ISO flake
+
+### US-008: ISO Instance Discovery and Deployment
+
+No deployment flow exists yet. A new `Deploy` screen must be created.
+
+## Data Models
+
+### `IsoTarget` (existing — `src/screens/iso.rs`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| label | `String` | Display name |
+| path | `String` | Device path or file path |
+| is_usb | `bool` | USB vs file destination |
+| size | `String` | Human-readable size |
+
+### `AgenixSecretsConfig` (new — `src/template.rs` or new module)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| secrets_repo_path | `PathBuf` | Absolute path to the user's agenix-secrets repo |
+| secrets_subdir | `Option<String>` | Subdirectory within the secrets repo; defaults to root |
+
+### `IsoInstanceDiscovery` (new — `src/screens/deploy.rs`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| hostname | `String` | mDNS hostname or user-provided |
+| ip_address | `String` | Discovered or manually entered IP |
+| discovered_via | `DiscoveryMethod` | `Mdns` \| `Manual` |
+
+### `DeployTarget` (new — `src/screens/deploy.rs`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| instance | `IsoInstanceDiscovery` | The discovered ISO instance |
+| config_hostname | `String` | Target nixosConfigurations key |
+| ssh_key_path | `Option<PathBuf>` | SSH key to use for deployment |
+
+## Behavioral Requirements
+
+### ISO Build with Agenix Secrets (US-007)
+
+1. The ISO screen MUST offer a "secrets integration" option before building.
+2. When secrets integration is enabled, the TUI MUST prompt for the path to the agenix-secrets
+   repository (defaulting to `~/.keystone/secrets/` if it exists).
+3. The TUI MUST copy the secrets repository into the ISO build directory at `agenix-secrets/`
+   before triggering `nix build`.
+4. The generated ISO flake MUST reference the `agenix-secrets/` directory so the installer
+   can access secrets during installation.
+5. The TUI MUST verify that the secrets repo contains an `agenix.nix` or `secrets.nix` file
+   before proceeding — if absent, MUST warn the user but allow building without secrets.
+6. The built ISO MUST boot and install without requiring manual secret entry (end-to-end
+   requirement — verified via manual test during development).
+7. ISO build MUST work when initiated from macOS by delegating to a configured remote builder
+   (the TUI MUST detect if Nix remote build is available; if not, display a helpful message).
+
+### ISO Instance Discovery (US-008)
+
+8. The deploy screen MUST attempt mDNS discovery for Keystone ISO instances on the local
+   network by querying for `_keystone-iso._tcp.local` service records.
+9. mDNS discovery MUST run for a configurable timeout (default 10 seconds) before showing
+   results (discovered + manual entry option).
+10. If mDNS discovery finds no instances, the TUI MUST offer a manual IP address entry field.
+11. The TUI MUST support both discovered and manually entered targets simultaneously in the
+    same list.
+12. The TUI MUST display each discovered instance with: hostname, IP address, and discovery
+    method (mDNS \| Manual).
+
+### Deployment (US-008)
+
+13. The TUI MUST invoke `nixos-anywhere --flake .#<hostname> root@<ip>` to deploy to a
+    discovered ISO instance.
+14. Before invoking nixos-anywhere, the TUI MUST:
+    - Verify that `nixos-anywhere` is available in PATH.
+    - Verify SSH connectivity to the target IP (port 22).
+    - Confirm the selected nixos-config hostname matches the intended target.
+15. The TUI MUST display deployment progress by streaming nixos-anywhere stdout/stderr to a
+    scrollable output pane.
+16. The TUI MUST display a clear success or failure status after deployment completes.
+17. The TUI MUST auto-detect local SSH keys from `~/.ssh/*.pub` and offer them for deployment.
+18. Deployment MUST NOT proceed without explicit user confirmation ("Deploy to 192.168.1.42?").
+
+### Error Handling
+
+19. If `nix build` fails during ISO creation, the TUI MUST show the last 20 lines of stderr
+    and transition to `IsoPhase::Failed`.
+20. If nixos-anywhere exits non-zero, the TUI MUST show the error output and allow the user
+    to retry.
+21. If mDNS discovery crashes (e.g., no network interface), the TUI MUST fall back to manual
+    entry silently (no panic).
+
+## Edge Cases
+
+- **macOS build path**: `nixos-anywhere` is Linux-only. When running on macOS, the TUI MUST
+  detect this and use the nixos-anywhere `--build-on-remote` flag, delegating the build to
+  the target machine or a configured remote builder.
+- **Secrets repo not found**: If the provided secrets path doesn't exist, the TUI MUST show
+  an error before touching any build files.
+- **USB write permission**: `dd` requires root on Linux. The TUI MUST check `/dev/<device>`
+  write permissions before starting the write phase and advise `sudo` if needed.
+- **ISO instance behind firewall**: If mDNS is blocked, manual IP is the only path. The TUI
+  MUST make manual entry the prominent fallback, not a buried option.
+- **Multiple ISO instances**: If mDNS discovers multiple instances, the TUI MUST allow
+  selecting which one to deploy to.
+
+## UI Mockups
+
+### ISO Screen (SelectTarget phase, with secrets option)
+
+```
+┌─ Build ISO Installer ────────────────────────────────────────────────────┐
+│                                                                          │
+│  Configuration: ocean (x86_64-linux)                                     │
+│                                                                          │
+│  Secrets Integration                                                     │
+│  ○ No secrets — install without agenix secrets                           │
+│  ● Include secrets from: ~/.keystone/secrets/  [Browse...]               │
+│                                                                          │
+│  Write Destination                                                       │
+│  ○ /dev/sdb  USB3 Flash Drive  (32 GB)                                   │
+│  ● ~/Downloads/keystone-ocean.iso  (save to file)                        │
+│                                                                          │
+│  [Enter] Build ISO    [Esc] Back                                         │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Deploy Screen
+
+```
+┌─ Deploy to ISO Instance ─────────────────────────────────────────────────┐
+│                                                                          │
+│  Discovered Instances (mDNS)                                             │
+│ ┌──────────────────────────────────────────────────────────────────────┐ │
+│ │ > keystone-installer.local   192.168.1.42   mDNS                    │ │
+│ │   [+ Enter IP manually...]                                           │ │
+│ └──────────────────────────────────────────────────────────────────────┘ │
+│                                                                          │
+│  Configuration:  ocean                                                   │
+│  SSH Key:        ~/.ssh/id_ed25519.pub  [Change]                         │
+│                                                                          │
+│  [Enter] Deploy   [r] Refresh   [Esc] Back                               │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Cross-References
+- Spec 001 (Config Generation): `generate_iso_flake_nix` produces the ISO flake.
+- Spec 004 (TUI App Framework): `AppScreen::Iso` and new `AppScreen::Deploy` routing.

--- a/packages/keystone-tui/specs/004-tui-app-framework.md
+++ b/packages/keystone-tui/specs/004-tui-app-framework.md
@@ -1,0 +1,199 @@
+# Spec: TUI App Framework
+
+## Stories Covered
+- US-004: Build interactive TUI with cross-platform support
+- US-006: Implement git and GitHub publishing
+- US-010: Document TUI installation and usage
+- US-011: Define phased delivery plan
+
+Note: US-005 and US-008 overlap with this boundary but are detailed in Spec 002 and Spec 003.
+
+## Affected Modules
+- `packages/keystone-tui/src/main.rs` — entry point, mode detection, CLI args
+- `packages/keystone-tui/src/app.rs` — `AppScreen` enum, screen transitions
+- `packages/keystone-tui/src/input.rs` — key dispatch and action handling
+- `packages/keystone-tui/src/screens/create_config.rs` — config creation form
+- `packages/keystone-tui/src/github.rs` — SSH key fetching; needs repo creation
+- `packages/keystone-tui/src/repo.rs` — git clone/discover; needs init + commit + push
+- `packages/keystone-tui/Cargo.toml` — `clap` for CLI, `git2` for git ops
+
+## Existing Framework State
+
+The TUI is implemented in **Rust** using `ratatui` (v0.29) + `crossterm` (v0.28). This is
+the implementation language going forward. The Bubbletea (Go) mention in issue #132 US-004
+is stale — the architecture decision to use Rust was made when the existing `keystone-ha/tui`
+was chosen as the reference implementation. No Go code exists in this package.
+
+## Cross-Platform Support
+
+The TUI already compiles and runs on both Linux and macOS. The `crossterm` backend handles
+platform differences. No additional cross-platform work is needed for the core TUI loop.
+
+macOS-specific considerations:
+- `/dev/disk*` paths differ; disk detection uses `sysinfo` which is cross-platform.
+- `tailscale status --json` may not be available; the TUI already handles missing tailscale.
+- SSH key paths and `~/.ssh/` layout are consistent across platforms.
+
+## Data Models
+
+### `AppScreen` (extended — `src/app.rs`)
+
+Current variants:
+- `Welcome`, `CreateConfig`, `Hosts`, `HostDetail`, `Build`, `Iso`, `Install`, `FirstBoot`
+
+New variants to add:
+- `Deploy` — ISO instance discovery + nixos-anywhere deployment (US-008)
+- `Git` — diff preview, commit, push (US-006)
+
+### `JsonInputConfig` (new — `src/main.rs` or `src/json_input.rs`)
+
+For non-interactive `--json` mode. Mirrors `GenerateConfig` as a JSON-deserializable struct:
+
+```json
+{
+  "hostname": "my-server",
+  "state_version": "25.05",
+  "time_zone": "America/Chicago",
+  "machine_type": "server",
+  "storage": {
+    "type": "zfs",
+    "devices": ["/dev/disk/by-id/nvme-abc123"],
+    "mode": "single",
+    "swap_size": "16G"
+  },
+  "security": {
+    "secure_boot": true,
+    "tpm": true
+  },
+  "users": [
+    {
+      "username": "admin",
+      "full_name": "Admin User",
+      "initial_password": "changeme",
+      "authorized_keys": ["ssh-ed25519 AAAA..."],
+      "terminal_enable": true,
+      "desktop_enable": false
+    }
+  ],
+  "output_dir": "/tmp/my-config"
+}
+```
+
+## Behavioral Requirements
+
+### TUI Interaction (US-004)
+
+1. The TUI MUST use `ratatui` with `crossterm` as the terminal backend (not Bubbletea/Go).
+2. The TUI MUST restore terminal state on exit via the existing panic hook.
+3. The TUI MUST handle terminal resize events without crashing.
+4. The TUI SHOULD support mouse events for clicking list items.
+5. The TUI MUST auto-detect SSH public keys from `~/.ssh/*.pub` during the user configuration
+   form step (create-config flow) and offer them for selection.
+6. The TUI MUST detect connected hardware security keys:
+   - YubiKey: detected via `lsusb` output or `/dev/hidraw*` on Linux
+   - SoloKey: same detection path
+   - On macOS: detected via `system_profiler SPUSBDataType`
+   - When detected, offer to configure `keystone.os.hardwareKey` (FIDO2 SSH key enrollment
+     via `ssh-keygen -t ed25519-sk`)
+7. Input validation MUST reject:
+   - Blank hostname
+   - Hostname longer than 63 characters or containing invalid characters (`[^a-z0-9-]`)
+   - Zero storage devices
+   - Zero users
+   - Blank username
+8. The TUI MUST display inline validation errors next to the offending field, not on a
+   separate error screen.
+
+### Non-Interactive JSON Mode (US-004)
+
+9. The TUI MUST accept a `--json <path>` CLI flag (or `--json -` for stdin).
+10. In JSON mode, the TUI MUST skip all interactive screens and directly generate config files
+    to the `output_dir` specified in the JSON input.
+11. In JSON mode, the TUI MUST validate the `JsonInputConfig` against the same rules as the
+    interactive form (Behavioral Requirements §7 above).
+12. In JSON mode, the TUI MUST print a success or error message to stdout and exit with
+    code 0 (success) or 1 (failure). No TUI rendering MUST occur.
+13. In JSON mode, the TUI MUST write `flake.nix`, `configuration.nix`, and `hardware.nix`
+    to `output_dir`, creating the directory if it doesn't exist.
+
+### Git Operations (US-006)
+
+14. After generating a new config (both interactive and JSON modes), the TUI MUST offer to:
+    - Initialize a git repository in the output directory
+    - Create an initial commit with message `"chore: initial keystone config for <hostname>"`
+15. The TUI MUST NOT auto-commit without user confirmation ("Initialize git repo? [y/N]").
+16. The TUI MUST warn if any generated file appears to contain a plaintext password (heuristic:
+    `initialPassword` value is present in the file and is not a bcrypt/yescrypt hash).
+17. The TUI MUST offer to create a private GitHub repository via `gh repo create`:
+    - Requires `gh` to be available in PATH and authenticated
+    - Uses SSH URL format for the remote: `git@github.com:<user>/<repo>.git`
+    - If `gh` is unavailable, display instructions for manual setup
+18. The TUI MUST NOT commit any of the following (MUST warn and exclude):
+    - Files matching `*.pem`, `*.key`, `*.age`, `id_rsa`, `id_ecdsa` (private keys)
+    - Files matching `.env`, `*.secret`
+    - Age-encrypted secrets (`.age` extension) ARE allowed in commits
+19. The `GitScreen` MUST show a diff preview (using `git2::Diff`) before the user confirms
+    a commit.
+20. The TUI MUST NOT push to a remote without explicit user confirmation ("Push to origin/main?").
+
+### GitHub Repo Creation (US-006)
+
+21. The TUI MUST shell out to `gh repo create <name> --private --source=. --remote=origin`
+    rather than using the GitHub API directly.
+22. If `gh` is not authenticated (`gh auth status` fails), the TUI MUST display a message:
+    "Run `gh auth login` to enable GitHub integration."
+23. The repo name MUST default to the hostname value from the generated config.
+
+## Edge Cases
+
+- **SSH key detection on macOS**: `~/.ssh/` may contain `.pub` files with whitespace in
+  names (unlikely but MUST not crash). The TUI MUST skip non-standard filenames gracefully.
+- **Hardware key detection**: If USB probing fails (permission denied on `/dev/hidraw*`), the
+  TUI MUST skip detection silently — do not display an error for missing hardware keys.
+- **JSON mode invalid path**: If `output_dir` already contains a `flake.nix`, the TUI MUST
+  error ("Output directory already contains a flake.nix; use --force to overwrite") and
+  exit with code 1.
+- **git2 init on existing repo**: If `output_dir` already contains `.git/`, the TUI MUST
+  skip `git init` and proceed to the commit step.
+- **`gh` invocation failure**: If `gh repo create` fails (e.g., name conflict), the TUI MUST
+  display the error and allow the user to retry with a different name or skip.
+
+## Phased Delivery Plan (US-011)
+
+The implementation MUST follow these phases:
+
+### Phase 1 — Config Contract (prerequisite, no TUI code)
+- **Deliverables**: Spec 001 implemented — `disko` in generated flake.nix, data model
+  complete, Nix check at `checks.x86_64-linux.template-evaluation` with 4 variants.
+- **Exit criteria**: `nix flake check` passes; all 4 test configs evaluate.
+
+### Phase 2 — Interactive TUI + Publishing
+- **Deliverables**: SSH key auto-detection (US-004), hardware key detection (US-004),
+  JSON mode (US-004), host display with `keystone.hosts` metadata (US-005), new host
+  creation into existing flake (US-009), git init + commit (US-006), GitHub repo creation (US-006).
+- **Entry criteria**: Phase 1 complete.
+- **Exit criteria**: Interactive config creation + publishing flow works end-to-end on macOS
+  and Linux.
+
+### Phase 3 — ISO Build + Deployment
+- **Deliverables**: Agenix secrets baking into ISO (US-007), mDNS ISO discovery (US-008),
+  nixos-anywhere deployment (US-008).
+- **Entry criteria**: Phase 2 complete; user has a functioning nixos-config repo.
+- **Exit criteria**: Full flow from `keystone-tui` launch to deployed NixOS system works
+  without manual Nix commands.
+
+### Documentation
+- **Deliverables**: README covers install, quick-start, all screens, JSON mode, ISO workflow.
+- **Timing**: Updated alongside Phase 2 and Phase 3 feature work; finalized before milestone close.
+
+## PLAN.md Alignment
+
+The existing `packages/keystone-tui/PLAN.md` defines 7 implementation phases. These MUST be
+reconciled with the 3-phase delivery plan above before Phase 2 work begins. The recommended
+approach: replace the 7-phase plan in `PLAN.md` with the 3-phase structure from this spec,
+keeping the module structure section unchanged.
+
+## Cross-References
+- Spec 001 (Config Generation): JSON mode populates `GenerateConfig` from `JsonInputConfig`.
+- Spec 002 (Nix Flake): New host creation and hosts screen are driven from the app framework.
+- Spec 003 (ISO Pipeline): `AppScreen::Deploy` is added by this spec.

--- a/packages/keystone-tui/specs/005-first-boot-hardware-pushback.md
+++ b/packages/keystone-tui/specs/005-first-boot-hardware-pushback.md
@@ -1,0 +1,137 @@
+# Spec: First-boot hardware pushback
+
+## Stories Covered
+- US-010: Post-install hardware pushback
+
+## Affected Modules
+- `packages/keystone-tui/src/screens/first_boot.rs` - first-boot orchestration and user-visible status
+- `packages/keystone-tui/src/screens/install.rs` - installer contract for data persisted into the installed system
+- `packages/keystone-tui/src/app.rs` - boot-mode routing into `FirstBootScreen`
+- `packages/keystone-tui/src/repo.rs` - git add, commit, remote, and push helpers to be extracted from the screen
+- `packages/keystone-tui/src/template.rs` - placeholders and generated file contract consumed by first-boot reconciliation
+
+## Existing State
+
+The current first-boot flow already does four useful things:
+
+1. Detects first boot via `~/.keystone/repos/nixos-config/.first-boot-pending`
+2. Runs `nixos-generate-config --show-hardware-config`
+3. Writes `hardware.nix` into the checked-out flake repo
+4. Initializes git, commits, and can push to a remote
+
+That is close to the required product behavior, but it is not yet a true hardware pushback pipeline.
+The current flow overwrites `hardware.nix` with raw generator output and does not explicitly reconcile:
+
+- disk identifiers selected during install versus actual booted hardware
+- kernel modules and firmware requirements
+- patch provenance for review before commit
+- retry-safe behavior if pushback runs more than once
+
+## Data models
+
+### `FirstBootHardwareFacts` (new)
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `hostname` | `String` | yes | Host being reconciled |
+| `generated_at` | `String` | yes | ISO 8601 timestamp for auditability |
+| `disk_devices` | `Vec<DetectedDisk>` | yes | Actual block devices observed after boot |
+| `kernel_modules` | `Vec<String>` | yes | Normalized module names required by the installed system |
+| `firmware_packages` | `Vec<String>` | no | Extra firmware packages inferred from hardware |
+| `source` | `HardwareFactsSource` | yes | `nixos-generate-config`, `lsblk`, `udevadm`, or similar |
+
+### `DetectedDisk` (new)
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `path` | `String` | yes | Runtime device path such as `/dev/disk/by-id/...` |
+| `serial` | `Option<String>` | no | Stable hardware identifier when available |
+| `wwn` | `Option<String>` | no | Stable device identifier when available |
+| `matches_install_placeholder` | `bool` | yes | Whether this device satisfies an install-time placeholder |
+
+### `PushbackPatchPlan` (new)
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `hardware_nix_path` | `PathBuf` | yes | File to patch |
+| `diff_preview` | `String` | yes | Human-readable diff shown before commit |
+| `warnings` | `Vec<String>` | yes | Any mismatches or incomplete detection results |
+| `commit_message` | `String` | yes | Default commit message for accepted changes |
+
+## Behavioral requirements
+
+### Detection and fact gathering
+
+1. On first boot, the system MUST detect whether hardware pushback is pending by checking for the existing marker file consumed by `FirstBootConfig::detect`.
+2. The first-boot flow MUST collect actual hardware facts from the running system before proposing any repo changes.
+3. The hardware facts collection MUST include:
+   - stable disk identifiers where available
+   - generated `hardware.nix` content from `nixos-generate-config`
+   - required kernel modules present in the generated hardware config
+4. The pushback flow SHOULD collect firmware-relevant hints when they can be derived safely from the generated hardware config.
+5. The system MUST preserve a normalized, in-memory `FirstBootHardwareFacts` structure before writing files.
+
+### Patch generation
+
+6. The pushback flow MUST generate a patch plan rather than writing raw `hardware.nix` output directly to git without review.
+7. The patch plan MUST update `hardware.nix` with the booted machine's actual identifiers and module requirements.
+8. If the generated config still contains install-time placeholders such as `__KEYSTONE_DISK__`, the patch plan MUST replace them with detected stable identifiers when a confident match exists.
+9. If the flow cannot confidently map a detected disk to an install placeholder, it MUST warn the user and MUST NOT silently guess.
+10. The patch plan MAY update other generated files only when those files contain machine-specific placeholders created during install.
+11. The first implementation SHOULD scope automatic edits to `hardware.nix` and explicitly report any recommended follow-up edits outside that file.
+
+### User review and confirmation
+
+12. The first-boot screen MUST show a review step before applying file changes.
+13. The review step MUST include:
+   - which files will change
+   - a summary of detected hardware facts
+   - any warnings or partial detections
+14. The user MUST be able to accept or skip the patch application.
+15. If the user skips the patch, the marker file MUST remain so the flow can be retried later.
+
+### Commit and push behavior
+
+16. After patch application, the flow MUST stage only the files that belong to hardware pushback.
+17. The default commit message MUST clearly identify the reconciliation action, for example `feat(keystone-tui): reconcile first-boot hardware for <hostname>`.
+18. The flow MUST NOT push to a remote without explicit user confirmation.
+19. If a remote is not configured, the flow SHOULD still complete the local patch and local commit successfully.
+20. The flow MUST remove the first-boot marker only after patch generation succeeds and the user either commits the result or explicitly dismisses the pending flow.
+
+### Idempotency and retry safety
+
+21. Re-running first-boot pushback on a machine that already reconciled successfully MUST produce no diff or an explicitly empty patch result.
+22. If `hardware.nix` already matches the detected hardware facts, the flow MUST report that no patch is needed and MUST exit cleanly.
+23. A partial failure after file write but before commit MUST leave the repo in a recoverable state and surface the exact git or filesystem error.
+
+## Edge cases
+
+- If `nixos-generate-config` fails, the flow MUST surface stderr and MUST NOT modify the repo.
+- If no stable `/dev/disk/by-id` path exists for a detected disk, the flow SHOULD fall back to the best available identifier and warn that the identifier may be less stable.
+- If the git repo is dirty before pushback starts, the flow MUST show the user the pre-existing changes and MUST refuse to auto-commit mixed work.
+- If the remote push fails, the local commit MUST remain intact and the screen MUST offer retry instructions rather than rolling back.
+- If the machine boots without network access, hardware detection and local patch generation MUST still work; only push should be deferred.
+
+## UI mockup
+
+```
+┌─ First boot: hardware reconciliation ───────────────────────────────────┐
+│  Host: titan                                                           │
+│                                                                        │
+│  Detected hardware                                                     │
+│  • Disk: /dev/disk/by-id/nvme-Samsung_990_PRO_2TB                      │
+│  • Kernel modules: nvme, xhci_pci, thunderbolt                         │
+│  • Firmware packages: none                                             │
+│                                                                        │
+│  Planned patch                                                         │
+│  • Update hardware.nix with stable disk identifiers                    │
+│  • Keep configuration.nix unchanged                                    │
+│                                                                        │
+│  [v] View diff   [Enter] Apply and commit   [s] Skip for now          │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+## Cross-references
+
+- Spec 001 (Config Generation Contract): install-time placeholders and generated file structure determine what can be reconciled safely on first boot.
+- Spec 004 (TUI App Framework): first-boot mode is a dedicated app entry path and shares git confirmation behavior with initial repo publishing.

--- a/packages/keystone-tui/src/input.rs
+++ b/packages/keystone-tui/src/input.rs
@@ -32,9 +32,12 @@ pub enum AppAction {
     InstallDiskSelect,
     FirstBootStart,
     FirstBootSkip,
+    FirstBootAcceptPlan,
+    FirstBootToggleDiff,
     FirstBootContinue,
     FirstBootSubmitRemote,
     FirstBootRetry,
+    FirstBootFinishNoChanges,
     Reboot,
     Quit,
 }
@@ -357,10 +360,25 @@ pub fn handle_first_boot_input(
             KeyCode::Char('q') => Some(AppAction::Quit),
             _ => None,
         },
-        FirstBootPhase::GeneratingHardware | FirstBootPhase::GitSetup | FirstBootPhase::Pushing => {
+        FirstBootPhase::GatheringFacts
+        | FirstBootPhase::ApplyingPatch
+        | FirstBootPhase::GitSetup
+        | FirstBootPhase::Pushing => {
             // No user input during async phases
             None
         }
+        FirstBootPhase::ReviewPlan => match key.code {
+            KeyCode::Enter => Some(AppAction::FirstBootAcceptPlan),
+            KeyCode::Char('s') => Some(AppAction::FirstBootSkip),
+            KeyCode::Char('v') => Some(AppAction::FirstBootToggleDiff),
+            KeyCode::Char('q') => Some(AppAction::Quit),
+            _ => None,
+        },
+        FirstBootPhase::NoChangesRequired => match key.code {
+            KeyCode::Enter => Some(AppAction::FirstBootFinishNoChanges),
+            KeyCode::Char('q') => Some(AppAction::Quit),
+            _ => None,
+        },
         FirstBootPhase::ShowSshKey => match key.code {
             KeyCode::Enter => Some(AppAction::FirstBootContinue),
             KeyCode::Char('s') => Some(AppAction::FirstBootSkip),
@@ -481,7 +499,25 @@ pub async fn handle_action(app: &mut App, action: AppAction) {
         }
         AppAction::FirstBootSkip => {
             if let AppScreen::FirstBoot(ref mut fb) = app.current_screen {
-                fb.skip();
+                match fb.phase() {
+                    screens::first_boot::FirstBootPhase::ReviewPlan => fb.skip_plan(),
+                    _ => fb.skip(),
+                }
+            }
+        }
+        AppAction::FirstBootAcceptPlan => {
+            if let AppScreen::FirstBoot(ref mut fb) = app.current_screen {
+                fb.accept_plan();
+            }
+        }
+        AppAction::FirstBootToggleDiff => {
+            if let AppScreen::FirstBoot(ref mut fb) = app.current_screen {
+                fb.toggle_diff();
+            }
+        }
+        AppAction::FirstBootFinishNoChanges => {
+            if let AppScreen::FirstBoot(ref mut fb) = app.current_screen {
+                fb.finish_no_changes();
             }
         }
         AppAction::FirstBootContinue => {

--- a/packages/keystone-tui/src/input.rs
+++ b/packages/keystone-tui/src/input.rs
@@ -393,6 +393,11 @@ pub fn handle_first_boot_input(
                 None
             }
         },
+        FirstBootPhase::DirtyRepo(_) => match key.code {
+            KeyCode::Char('s') => Some(AppAction::FirstBootSkip),
+            KeyCode::Char('q') => Some(AppAction::Quit),
+            _ => None,
+        },
         FirstBootPhase::Done => match key.code {
             KeyCode::Char('q') => Some(AppAction::Quit),
             _ => None,

--- a/packages/keystone-tui/src/screens/first_boot.rs
+++ b/packages/keystone-tui/src/screens/first_boot.rs
@@ -4,10 +4,11 @@
 //! `.first-boot-pending` marker in `~/.keystone/repos/nixos-config/` and
 //! walks the user through:
 //!
-//! 1. Generating real hardware.nix
-//! 2. Initializing a git repo with the config
-//! 3. Showing the SSH public key for GitHub
-//! 4. Setting up a git remote and pushing
+//! 1. Gathering real hardware facts (disk identifiers, kernel modules)
+//! 2. Building an in-memory patch plan with diff preview
+//! 3. User review before any file is written
+//! 4. Committing and optionally pushing the reconciled hardware.nix
+//! 5. Initializing a git repo and configuring a remote for future pushes
 
 use std::path::PathBuf;
 
@@ -22,7 +23,137 @@ use ratatui::{
     Frame,
 };
 
+use crate::disk::discover_disks;
 use crate::ui::TextInput;
+
+/// Placeholder written by the installer into hardware.nix for disk identifiers.
+/// First-boot reconciliation replaces this when a confident match exists.
+const KEYSTONE_DISK_PLACEHOLDER: &str = "__KEYSTONE_DISK__";
+
+// ─── Data models ────────────────────────────────────────────────────────────
+
+/// A disk observed on the booted system.
+#[derive(Debug, Clone)]
+pub struct DetectedDisk {
+    /// Stable by-id path, e.g. `/dev/disk/by-id/nvme-Samsung_990_PRO_2TB`.
+    pub path: String,
+    /// Whether this disk satisfies the install-time `__KEYSTONE_DISK__` placeholder.
+    pub matches_install_placeholder: bool,
+}
+
+/// Hardware facts collected on first boot before any repo changes are made.
+#[derive(Debug, Clone)]
+pub struct FirstBootHardwareFacts {
+    pub hostname: String,
+    /// Raw output of `nixos-generate-config --show-hardware-config`.
+    pub generated_hardware_nix: String,
+    /// Stable disk identifiers observed after boot.
+    pub disk_devices: Vec<DetectedDisk>,
+    /// Kernel modules extracted from the generated hardware config.
+    pub kernel_modules: Vec<String>,
+}
+
+impl FirstBootHardwareFacts {
+    /// Extract module names from `boot.initrd.availableKernelModules` and
+    /// `boot.kernelModules` lines in the generated hardware.nix content.
+    fn extract_kernel_modules(hw_nix: &str) -> Vec<String> {
+        let mut modules = Vec::new();
+        for line in hw_nix.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("boot.initrd.availableKernelModules")
+                || trimmed.starts_with("boot.kernelModules")
+            {
+                // Extract quoted strings: "module1" "module2"
+                let mut rest = trimmed;
+                while let Some(start) = rest.find('"') {
+                    rest = &rest[start + 1..];
+                    if let Some(end) = rest.find('"') {
+                        let module = rest[..end].to_string();
+                        if !module.is_empty() && !modules.contains(&module) {
+                            modules.push(module);
+                        }
+                        rest = &rest[end + 1..];
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+        modules
+    }
+}
+
+/// An in-memory plan describing which files will change and why.
+#[derive(Debug, Clone)]
+pub struct PushbackPatchPlan {
+    /// File that will receive the patched content.
+    pub hardware_nix_path: PathBuf,
+    /// Current on-disk content (empty string if file does not exist yet).
+    pub current_content: String,
+    /// Proposed new content after reconciliation.
+    pub proposed_content: String,
+    /// Human-readable unified diff shown to the user before apply.
+    pub diff_preview: String,
+    /// Non-fatal warnings surfaced to the user (e.g. no confident disk mapping).
+    pub warnings: Vec<String>,
+    /// Default commit message used when the user accepts.
+    pub commit_message: String,
+}
+
+impl PushbackPatchPlan {
+    /// Returns `true` when the proposed content is identical to the current content.
+    pub fn is_noop(&self) -> bool {
+        self.proposed_content == self.current_content
+    }
+
+    /// Generate a minimal line-level diff between current and proposed content.
+    ///
+    /// Uses a simple sequential diff: matching lines are prefixed with ` `,
+    /// removed lines with `-`, and added lines with `+`. Truncated at 40 lines
+    /// to keep the TUI readable.
+    fn build_diff(current: &str, proposed: &str) -> String {
+        if current == proposed {
+            return "(no changes)".to_string();
+        }
+
+        let mut lines = Vec::new();
+        let current_lines: Vec<&str> = current.lines().collect();
+        let proposed_lines: Vec<&str> = proposed.lines().collect();
+
+        let mut i = 0;
+        let mut j = 0;
+        while i < current_lines.len() || j < proposed_lines.len() {
+            let c = current_lines.get(i).copied();
+            let p = proposed_lines.get(j).copied();
+            match (c, p) {
+                (Some(cl), Some(pl)) if cl == pl => {
+                    lines.push(format!(" {}", cl));
+                    i += 1;
+                    j += 1;
+                }
+                _ => {
+                    if let Some(cl) = c {
+                        lines.push(format!("-{}", cl));
+                        i += 1;
+                    }
+                    if let Some(pl) = p {
+                        lines.push(format!("+{}", pl));
+                        j += 1;
+                    }
+                }
+            }
+        }
+
+        if lines.len() > 40 {
+            lines.truncate(40);
+            lines.push("... (diff truncated)".to_string());
+        }
+
+        lines.join("\n")
+    }
+}
+
+// ─── Config ─────────────────────────────────────────────────────────────────
 
 /// Configuration for the first-boot flow.
 #[derive(Debug, Clone)]
@@ -44,13 +175,11 @@ impl FirstBootConfig {
             return None;
         }
 
-        // Read hostname from the config
         let hostname = std::fs::read_to_string("/etc/hostname")
             .ok()
             .map(|s| s.trim().to_string())
             .unwrap_or_else(|| "keystone".to_string());
 
-        // Read username from embedded metadata or current user
         let username = std::fs::read_to_string("/etc/keystone/install-config/username")
             .ok()
             .map(|s| s.trim().to_string())
@@ -72,13 +201,19 @@ impl FirstBootConfig {
     }
 }
 
+// ─── Phases ──────────────────────────────────────────────────────────────────
+
 /// Phases of the first-boot wizard.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FirstBootPhase {
     /// Welcome message.
     Welcome,
-    /// Generating hardware.nix via nixos-generate-config.
-    GeneratingHardware,
+    /// Collecting hardware facts from the running system.
+    GatheringFacts,
+    /// Presenting the patch plan for user review before any file is written.
+    ReviewPlan,
+    /// Applying the accepted patch to disk.
+    ApplyingPatch,
     /// git init + add + commit.
     GitSetup,
     /// Display SSH public key + GitHub instructions.
@@ -87,21 +222,28 @@ pub enum FirstBootPhase {
     RemoteInput,
     /// Pushing to remote.
     Pushing,
+    /// hardware.nix already matches detected hardware — no reconciliation needed.
+    NoChangesRequired,
     /// Setup complete.
     Done,
     /// An error occurred.
     Failed(String),
 }
 
+// ─── Messages ────────────────────────────────────────────────────────────────
+
 /// Messages from first-boot async operations.
 pub enum FirstBootMessage {
     Output(String),
-    HardwareGenerated,
+    HardwareFacts(FirstBootHardwareFacts, PushbackPatchPlan),
+    PatchApplied,
     GitReady,
     SshKey(String),
     PushResult(Result<(), String>),
     Failed(String),
 }
+
+// ─── Screen ──────────────────────────────────────────────────────────────────
 
 pub struct FirstBootScreen {
     config: FirstBootConfig,
@@ -111,6 +253,12 @@ pub struct FirstBootScreen {
     remote_input: TextInput,
     rx: Option<mpsc::UnboundedReceiver<FirstBootMessage>>,
     push_skipped: bool,
+    /// Hardware facts gathered during `GatheringFacts`.
+    facts: Option<FirstBootHardwareFacts>,
+    /// Patch plan built from gathered facts.
+    patch_plan: Option<PushbackPatchPlan>,
+    /// Whether the inline diff is expanded in the review view.
+    show_diff: bool,
 }
 
 impl FirstBootScreen {
@@ -135,6 +283,9 @@ impl FirstBootScreen {
             remote_input,
             rx: None,
             push_skipped: false,
+            facts: None,
+            patch_plan: None,
+            show_diff: false,
         }
     }
 
@@ -146,45 +297,39 @@ impl FirstBootScreen {
         self.ssh_public_key.as_deref()
     }
 
-    /// Start the first-boot process (Welcome → GeneratingHardware).
+    /// Start the first-boot process (Welcome → GatheringFacts).
     pub fn start(&mut self) {
         if self.phase != FirstBootPhase::Welcome {
             return;
         }
-        self.phase = FirstBootPhase::GeneratingHardware;
-        self.spawn_hardware_generation();
+        self.phase = FirstBootPhase::GatheringFacts;
+        self.spawn_gather_facts();
     }
 
-    fn spawn_hardware_generation(&mut self) {
+    // ─── Async spawners ───────────────────────────────────────────────────
+
+    /// Gather hardware facts: run nixos-generate-config and discover disks.
+    /// Builds an in-memory `PushbackPatchPlan` — does NOT write any files.
+    fn spawn_gather_facts(&mut self) {
         let (tx, rx) = mpsc::unbounded_channel();
         self.rx = Some(rx);
         let config_dir = self.config.config_dir.clone();
+        let hostname = self.config.hostname.clone();
 
         tokio::spawn(async move {
             let _ = tx.send(FirstBootMessage::Output(
-                "Generating hardware configuration...".to_string(),
+                "Running nixos-generate-config...".to_string(),
             ));
 
-            let output = Command::new("nixos-generate-config")
+            // Step 1: run nixos-generate-config --show-hardware-config
+            let gen_output = Command::new("nixos-generate-config")
                 .args(["--show-hardware-config"])
                 .output()
                 .await;
 
-            match output {
+            let generated_hardware_nix = match gen_output {
                 Ok(out) if out.status.success() => {
-                    let hw_config = String::from_utf8_lossy(&out.stdout).to_string();
-                    let hw_path = config_dir.join("hardware.nix");
-                    if let Err(e) = tokio::fs::write(&hw_path, &hw_config).await {
-                        let _ = tx.send(FirstBootMessage::Failed(format!(
-                            "Failed to write hardware.nix: {}",
-                            e
-                        )));
-                        return;
-                    }
-                    let _ = tx.send(FirstBootMessage::Output(
-                        "hardware.nix generated successfully.".to_string(),
-                    ));
-                    let _ = tx.send(FirstBootMessage::HardwareGenerated);
+                    String::from_utf8_lossy(&out.stdout).to_string()
                 }
                 Ok(out) => {
                     let stderr = String::from_utf8_lossy(&out.stderr);
@@ -192,14 +337,140 @@ impl FirstBootScreen {
                         "nixos-generate-config failed: {}",
                         stderr
                     )));
+                    return;
                 }
                 Err(e) => {
                     let _ = tx.send(FirstBootMessage::Failed(format!(
                         "Failed to run nixos-generate-config: {}",
                         e
                     )));
+                    return;
+                }
+            };
+
+            let _ = tx.send(FirstBootMessage::Output(
+                "Discovering disk devices...".to_string(),
+            ));
+
+            // Step 2: discover stable disk identifiers
+            let raw_disks = discover_disks().await.unwrap_or_default();
+
+            // Step 3: read existing hardware.nix (may not exist yet)
+            let hw_path = config_dir.join("hardware.nix");
+            let current_content = tokio::fs::read_to_string(&hw_path)
+                .await
+                .unwrap_or_default();
+
+            // Step 4: determine placeholder → disk mapping confidence
+            let contains_placeholder = current_content.contains(KEYSTONE_DISK_PLACEHOLDER);
+            let mut warnings: Vec<String> = Vec::new();
+
+            let disk_devices: Vec<DetectedDisk> = raw_disks
+                .iter()
+                .map(|d| {
+                    // A disk matches the placeholder only when exactly one disk is
+                    // present — multiple disks means we cannot guess which is the
+                    // install target without risking silent data loss.
+                    let matches = contains_placeholder && raw_disks.len() == 1;
+                    DetectedDisk {
+                        path: d.by_id_path.clone(),
+                        matches_install_placeholder: matches,
+                    }
+                })
+                .collect();
+
+            // Warn when the placeholder exists but we cannot map it confidently
+            if contains_placeholder && disk_devices.len() != 1 {
+                if disk_devices.is_empty() {
+                    warnings.push(
+                        "No stable /dev/disk/by-id/ entries found — \
+                         __KEYSTONE_DISK__ placeholder will not be replaced."
+                            .to_string(),
+                    );
+                } else {
+                    warnings.push(format!(
+                        "Multiple disks detected ({}); cannot confidently map \
+                         __KEYSTONE_DISK__ placeholder — manual edit required.",
+                        disk_devices.len()
+                    ));
                 }
             }
+
+            // Step 5: build proposed hardware.nix content
+            let mut proposed_content = generated_hardware_nix.clone();
+
+            // Replace placeholder only when exactly one disk matched
+            let confident_disk = disk_devices
+                .iter()
+                .find(|d| d.matches_install_placeholder)
+                .map(|d| d.path.clone());
+
+            if let Some(ref disk_path) = confident_disk {
+                proposed_content =
+                    proposed_content.replace(KEYSTONE_DISK_PLACEHOLDER, disk_path.as_str());
+            }
+
+            // Step 6: extract kernel modules for the summary view
+            let kernel_modules =
+                FirstBootHardwareFacts::extract_kernel_modules(&proposed_content);
+
+            let facts = FirstBootHardwareFacts {
+                hostname: hostname.clone(),
+                generated_hardware_nix,
+                disk_devices,
+                kernel_modules,
+            };
+
+            // Step 7: compute diff and finalize the patch plan
+            let diff_preview = PushbackPatchPlan::build_diff(&current_content, &proposed_content);
+
+            let plan = PushbackPatchPlan {
+                hardware_nix_path: hw_path,
+                current_content,
+                proposed_content,
+                diff_preview,
+                warnings,
+                commit_message: format!(
+                    "feat(keystone-tui): reconcile first-boot hardware for {}",
+                    hostname
+                ),
+            };
+
+            let _ = tx.send(FirstBootMessage::Output("Facts gathered.".to_string()));
+            let _ = tx.send(FirstBootMessage::HardwareFacts(facts, plan));
+        });
+    }
+
+    /// Write the accepted patch plan to disk (hardware.nix only).
+    /// Does NOT commit — that happens in `spawn_git_setup`.
+    fn spawn_apply_patch(&mut self) {
+        let plan = match &self.patch_plan {
+            Some(p) => p.clone(),
+            None => return,
+        };
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.rx = Some(rx);
+
+        tokio::spawn(async move {
+            let _ = tx.send(FirstBootMessage::Output(
+                "Writing hardware.nix...".to_string(),
+            ));
+
+            if let Err(e) =
+                tokio::fs::write(&plan.hardware_nix_path, &plan.proposed_content).await
+            {
+                let _ = tx.send(FirstBootMessage::Failed(format!(
+                    "Failed to write hardware.nix: {}",
+                    e
+                )));
+                return;
+            }
+
+            let _ = tx.send(FirstBootMessage::Output(
+                "hardware.nix written successfully.".to_string(),
+            ));
+            let _ = tx.send(FirstBootMessage::PatchApplied);
         });
     }
 
@@ -207,6 +478,11 @@ impl FirstBootScreen {
         let (tx, rx) = mpsc::unbounded_channel();
         self.rx = Some(rx);
         let config_dir = self.config.config_dir.clone();
+        let commit_msg = self
+            .patch_plan
+            .as_ref()
+            .map(|p| p.commit_message.clone())
+            .unwrap_or_else(|| "feat: initial Keystone configuration".to_string());
 
         tokio::spawn(async move {
             let _ = tx.send(FirstBootMessage::Output(
@@ -225,18 +501,17 @@ impl FirstBootScreen {
                 return;
             }
 
-            // Remove .first-boot-pending from tracking (don't commit it)
+            // Remove .first-boot-pending from tracking (don't commit the marker)
             let _ = Command::new("git")
                 .args(["rm", "--cached", "-f", ".first-boot-pending"])
                 .current_dir(&config_dir)
                 .output()
                 .await;
 
-            // Add .gitignore to exclude the marker
+            // Add .gitignore to exclude the marker from future commits
             let gitignore_path = config_dir.join(".gitignore");
             let _ = tokio::fs::write(&gitignore_path, ".first-boot-pending\n").await;
 
-            // git add .
             let add = Command::new("git")
                 .args(["add", "."])
                 .current_dir(&config_dir)
@@ -248,9 +523,8 @@ impl FirstBootScreen {
                 return;
             }
 
-            // git commit
             let commit = Command::new("git")
-                .args(["commit", "-m", "feat: initial Keystone configuration"])
+                .args(["commit", "-m", &commit_msg])
                 .current_dir(&config_dir)
                 .output()
                 .await;
@@ -258,7 +532,8 @@ impl FirstBootScreen {
             match commit {
                 Ok(out) if out.status.success() => {
                     let _ = tx.send(FirstBootMessage::Output(
-                        "Git repository initialized with initial commit.".to_string(),
+                        "Git repository initialized with hardware reconciliation commit."
+                            .to_string(),
                     ));
                     let _ = tx.send(FirstBootMessage::GitReady);
                 }
@@ -347,7 +622,6 @@ impl FirstBootScreen {
                 remote_url
             )));
 
-            // Check if remote already exists
             let remote_check = Command::new("git")
                 .args(["remote", "get-url", "origin"])
                 .current_dir(&config_dir)
@@ -407,6 +681,36 @@ impl FirstBootScreen {
         });
     }
 
+    // ─── User actions ─────────────────────────────────────────────────────
+
+    /// Toggle the inline diff view while in `ReviewPlan`.
+    pub fn toggle_diff(&mut self) {
+        if self.phase == FirstBootPhase::ReviewPlan {
+            self.show_diff = !self.show_diff;
+        }
+    }
+
+    /// Accept the patch plan and begin writing hardware.nix.
+    pub fn accept_plan(&mut self) {
+        if self.phase != FirstBootPhase::ReviewPlan {
+            return;
+        }
+        self.phase = FirstBootPhase::ApplyingPatch;
+        self.show_diff = false;
+        self.spawn_apply_patch();
+    }
+
+    /// Skip the patch plan — leave the marker so the flow can be retried later.
+    ///
+    /// Per spec: if the user skips, the `.first-boot-pending` marker MUST remain.
+    pub fn skip_plan(&mut self) {
+        if self.phase == FirstBootPhase::ReviewPlan {
+            // Intentionally do NOT call finish() — marker stays on disk.
+            self.phase = FirstBootPhase::Done;
+            self.push_skipped = true;
+        }
+    }
+
     /// Skip the current step (SSH key display or push).
     pub fn skip(&mut self) {
         match self.phase {
@@ -426,7 +730,7 @@ impl FirstBootScreen {
         }
     }
 
-    /// Continue from ShowSshKey to RemoteInput.
+    /// Advance from `ShowSshKey` to `RemoteInput`.
     pub fn continue_to_remote(&mut self) {
         if self.phase == FirstBootPhase::ShowSshKey {
             self.phase = FirstBootPhase::RemoteInput;
@@ -464,21 +768,27 @@ impl FirstBootScreen {
         }
     }
 
+    /// Finish the flow from `NoChangesRequired` — removes the marker and exits cleanly.
+    pub fn finish_no_changes(&mut self) {
+        if self.phase == FirstBootPhase::NoChangesRequired {
+            self.finish();
+        }
+    }
+
+    /// Complete the flow and remove the first-boot marker.
     fn finish(&mut self) {
-        // Remove the first-boot marker
         let marker = self.config.config_dir.join(".first-boot-pending");
         let _ = std::fs::remove_file(&marker);
         self.phase = FirstBootPhase::Done;
     }
 
-    /// Poll for async messages.
+    /// Poll for async messages from background tasks.
     pub fn poll(&mut self) {
         let rx = match self.rx.as_mut() {
             Some(rx) => rx,
             None => return,
         };
 
-        // Collect messages to avoid borrow conflicts when spawning follow-up tasks
         let mut messages = Vec::new();
         while let Ok(msg) = rx.try_recv() {
             messages.push(msg);
@@ -489,7 +799,18 @@ impl FirstBootScreen {
                 FirstBootMessage::Output(line) => {
                     self.output_lines.push(line);
                 }
-                FirstBootMessage::HardwareGenerated => {
+                FirstBootMessage::HardwareFacts(facts, plan) => {
+                    self.facts = Some(facts);
+                    if plan.is_noop() {
+                        // hardware.nix already matches — no patch needed
+                        self.patch_plan = Some(plan);
+                        self.phase = FirstBootPhase::NoChangesRequired;
+                    } else {
+                        self.patch_plan = Some(plan);
+                        self.phase = FirstBootPhase::ReviewPlan;
+                    }
+                }
+                FirstBootMessage::PatchApplied => {
                     self.phase = FirstBootPhase::GitSetup;
                     self.spawn_git_setup();
                 }
@@ -515,15 +836,20 @@ impl FirstBootScreen {
         }
     }
 
+    // ─── Rendering ────────────────────────────────────────────────────────
+
     pub fn render(&self, frame: &mut Frame, area: Rect) {
         match &self.phase {
             FirstBootPhase::Welcome => self.render_welcome(frame, area),
-            FirstBootPhase::GeneratingHardware | FirstBootPhase::GitSetup => {
+            FirstBootPhase::GatheringFacts | FirstBootPhase::ApplyingPatch => {
                 self.render_progress(frame, area)
             }
+            FirstBootPhase::ReviewPlan => self.render_review_plan(frame, area),
+            FirstBootPhase::GitSetup => self.render_progress(frame, area),
             FirstBootPhase::ShowSshKey => self.render_ssh_key(frame, area),
             FirstBootPhase::RemoteInput => self.render_remote_input(frame, area),
             FirstBootPhase::Pushing => self.render_progress(frame, area),
+            FirstBootPhase::NoChangesRequired => self.render_no_changes(frame, area),
             FirstBootPhase::Done => self.render_done(frame, area),
             FirstBootPhase::Failed(err) => self.render_failed(frame, area, err),
         }
@@ -551,9 +877,10 @@ impl FirstBootScreen {
             format!(
                 "\n  Your system '{}' has been installed.\n\n  \
                  This wizard will:\n  \
-                 1. Generate hardware.nix for this machine\n  \
-                 2. Initialize a git repository\n  \
-                 3. Help you push your config to GitHub\n",
+                 1. Gather hardware facts for this machine\n  \
+                 2. Show a diff preview before updating hardware.nix\n  \
+                 3. Initialize a git repository\n  \
+                 4. Help you push your config to GitHub\n",
                 self.config.hostname
             ),
             Style::default(),
@@ -584,7 +911,8 @@ impl FirstBootScreen {
             .split(area);
 
         let phase_label = match &self.phase {
-            FirstBootPhase::GeneratingHardware => "Generating hardware configuration...",
+            FirstBootPhase::GatheringFacts => "Gathering hardware facts...",
+            FirstBootPhase::ApplyingPatch => "Applying hardware.nix patch...",
             FirstBootPhase::GitSetup => "Setting up git repository...",
             FirstBootPhase::Pushing => "Pushing to remote...",
             _ => "Working...",
@@ -612,6 +940,157 @@ impl FirstBootScreen {
 
         let help = Paragraph::new(Text::styled(
             "Please wait...",
+            Style::default().fg(Color::DarkGray),
+        ))
+        .alignment(Alignment::Center);
+        frame.render_widget(help, chunks[2]);
+    }
+
+    fn render_review_plan(&self, frame: &mut Frame, area: Rect) {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),
+                Constraint::Min(5),
+                Constraint::Length(3),
+            ])
+            .split(area);
+
+        let title = Paragraph::new(Text::styled(
+            "First boot: hardware reconciliation",
+            Style::default().bold().fg(Color::Yellow),
+        ))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::BOTTOM));
+        frame.render_widget(title, chunks[0]);
+
+        let mut lines: Vec<Line> = Vec::new();
+        lines.push(Line::from(format!("  Host: {}", self.config.hostname)));
+        lines.push(Line::from(""));
+
+        if let Some(facts) = &self.facts {
+            lines.push(Line::from(Span::styled(
+                "  Detected hardware",
+                Style::default().add_modifier(Modifier::BOLD),
+            )));
+
+            for disk in &facts.disk_devices {
+                let marker = if disk.matches_install_placeholder { " ✓" } else { "" };
+                lines.push(Line::from(format!("  • Disk: {}{}", disk.path, marker)));
+            }
+            if facts.disk_devices.is_empty() {
+                lines.push(Line::from("  • Disk: (none detected via /dev/disk/by-id/)"));
+            }
+
+            if facts.kernel_modules.is_empty() {
+                lines.push(Line::from("  • Kernel modules: (none)"));
+            } else {
+                lines.push(Line::from(format!(
+                    "  • Kernel modules: {}",
+                    facts.kernel_modules.join(", ")
+                )));
+            }
+            lines.push(Line::from(""));
+        }
+
+        if let Some(plan) = &self.patch_plan {
+            for w in &plan.warnings {
+                lines.push(Line::from(Span::styled(
+                    format!("  ⚠ {}", w),
+                    Style::default().fg(Color::Yellow),
+                )));
+            }
+            if !plan.warnings.is_empty() {
+                lines.push(Line::from(""));
+            }
+
+            lines.push(Line::from(Span::styled(
+                "  Planned patch",
+                Style::default().add_modifier(Modifier::BOLD),
+            )));
+            lines.push(Line::from(format!(
+                "  • Update: {}",
+                plan.hardware_nix_path.display()
+            )));
+            lines.push(Line::from(""));
+
+            if self.show_diff {
+                lines.push(Line::from(Span::styled(
+                    "  Diff preview:",
+                    Style::default().add_modifier(Modifier::BOLD),
+                )));
+                for diff_line in plan.diff_preview.lines() {
+                    let style = if diff_line.starts_with('+') {
+                        Style::default().fg(Color::Green)
+                    } else if diff_line.starts_with('-') {
+                        Style::default().fg(Color::Red)
+                    } else {
+                        Style::default().fg(Color::DarkGray)
+                    };
+                    lines.push(Line::from(Span::styled(
+                        format!("  {}", diff_line),
+                        style,
+                    )));
+                }
+            }
+        }
+
+        let body = Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Yellow)),
+            )
+            .wrap(Wrap { trim: false });
+        frame.render_widget(body, chunks[1]);
+
+        let diff_hint = if self.show_diff { "v: hide diff" } else { "v: view diff" };
+        let help = Paragraph::new(Text::styled(
+            format!("Enter: apply and commit • s: skip for now • {}", diff_hint),
+            Style::default().fg(Color::DarkGray),
+        ))
+        .alignment(Alignment::Center);
+        frame.render_widget(help, chunks[2]);
+    }
+
+    fn render_no_changes(&self, frame: &mut Frame, area: Rect) {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),
+                Constraint::Min(5),
+                Constraint::Length(3),
+            ])
+            .split(area);
+
+        let title = Paragraph::new(Text::styled(
+            "No changes required",
+            Style::default().bold().fg(Color::Green),
+        ))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::BOTTOM));
+        frame.render_widget(title, chunks[0]);
+
+        let message = Paragraph::new(Text::from(vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "  hardware.nix already matches the detected hardware.",
+                Style::default().fg(Color::Green),
+            )),
+            Line::from(""),
+            Line::from("  No reconciliation patch is needed."),
+            Line::from("  The first-boot marker will be removed."),
+            Line::from(""),
+        ]))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Green)),
+        );
+        frame.render_widget(message, chunks[1]);
+
+        let help = Paragraph::new(Text::styled(
+            "Enter: finish • q: exit",
             Style::default().fg(Color::DarkGray),
         ))
         .alignment(Alignment::Center);
@@ -805,11 +1284,13 @@ impl FirstBootScreen {
     }
 }
 
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn test_first_boot_config() -> FirstBootConfig {
+    fn test_config() -> FirstBootConfig {
         FirstBootConfig {
             config_dir: PathBuf::from("/home/testuser/.keystone/repos/nixos-config"),
             hostname: "test-machine".to_string(),
@@ -820,13 +1301,13 @@ mod tests {
 
     #[test]
     fn test_initial_phase_is_welcome() {
-        let screen = FirstBootScreen::new(test_first_boot_config());
+        let screen = FirstBootScreen::new(test_config());
         assert_eq!(*screen.phase(), FirstBootPhase::Welcome);
     }
 
     #[test]
     fn test_remote_input_pre_filled() {
-        let screen = FirstBootScreen::new(test_first_boot_config());
+        let screen = FirstBootScreen::new(test_config());
         assert_eq!(
             screen.remote_input.value(),
             "git@github.com:octocat/nixos-config.git"
@@ -847,7 +1328,7 @@ mod tests {
 
     #[test]
     fn test_skip_from_ssh_key() {
-        let mut screen = FirstBootScreen::new(test_first_boot_config());
+        let mut screen = FirstBootScreen::new(test_config());
         screen.phase = FirstBootPhase::ShowSshKey;
         screen.skip();
         assert_eq!(*screen.phase(), FirstBootPhase::RemoteInput);
@@ -855,7 +1336,7 @@ mod tests {
 
     #[test]
     fn test_skip_from_remote_input() {
-        let mut screen = FirstBootScreen::new(test_first_boot_config());
+        let mut screen = FirstBootScreen::new(test_config());
         screen.phase = FirstBootPhase::RemoteInput;
         screen.skip();
         assert_eq!(*screen.phase(), FirstBootPhase::Done);
@@ -865,7 +1346,7 @@ mod tests {
     #[test]
     fn test_poll_ssh_key() {
         let (tx, rx) = mpsc::unbounded_channel();
-        let mut screen = FirstBootScreen::new(test_first_boot_config());
+        let mut screen = FirstBootScreen::new(test_config());
         screen.rx = Some(rx);
         screen.phase = FirstBootPhase::ShowSshKey;
 
@@ -882,7 +1363,7 @@ mod tests {
     #[test]
     fn test_poll_push_success() {
         let (tx, rx) = mpsc::unbounded_channel();
-        let mut screen = FirstBootScreen::new(test_first_boot_config());
+        let mut screen = FirstBootScreen::new(test_config());
         screen.rx = Some(rx);
         screen.phase = FirstBootPhase::Pushing;
 
@@ -896,7 +1377,7 @@ mod tests {
     #[test]
     fn test_poll_push_failure() {
         let (tx, rx) = mpsc::unbounded_channel();
-        let mut screen = FirstBootScreen::new(test_first_boot_config());
+        let mut screen = FirstBootScreen::new(test_config());
         screen.rx = Some(rx);
         screen.phase = FirstBootPhase::Pushing;
 
@@ -905,5 +1386,221 @@ mod tests {
 
         screen.poll();
         assert!(matches!(screen.phase(), FirstBootPhase::Failed(_)));
+    }
+
+    // ─── Hardware detection tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_extract_kernel_modules_empty() {
+        let hw_nix = "# generated hardware config\nboot.loader.systemd-boot.enable = true;\n";
+        let modules = FirstBootHardwareFacts::extract_kernel_modules(hw_nix);
+        assert!(modules.is_empty());
+    }
+
+    #[test]
+    fn test_extract_kernel_modules_parses_quoted_list() {
+        let hw_nix = r#"
+  boot.initrd.availableKernelModules = [ "nvme" "xhci_pci" "ahci" "usbhid" ];
+  boot.kernelModules = [ "kvm-intel" ];
+"#;
+        let modules = FirstBootHardwareFacts::extract_kernel_modules(hw_nix);
+        assert!(modules.contains(&"nvme".to_string()));
+        assert!(modules.contains(&"xhci_pci".to_string()));
+        assert!(modules.contains(&"ahci".to_string()));
+        assert!(modules.contains(&"usbhid".to_string()));
+        assert!(modules.contains(&"kvm-intel".to_string()));
+    }
+
+    #[test]
+    fn test_extract_kernel_modules_deduplicates() {
+        let hw_nix = r#"
+  boot.initrd.availableKernelModules = [ "nvme" "nvme" ];
+"#;
+        let modules = FirstBootHardwareFacts::extract_kernel_modules(hw_nix);
+        let nvme_count = modules.iter().filter(|m| *m == "nvme").count();
+        assert_eq!(nvme_count, 1);
+    }
+
+    #[test]
+    fn test_patch_plan_is_noop_when_identical() {
+        let plan = PushbackPatchPlan {
+            hardware_nix_path: PathBuf::from("/tmp/hardware.nix"),
+            current_content: "same".to_string(),
+            proposed_content: "same".to_string(),
+            diff_preview: String::new(),
+            warnings: vec![],
+            commit_message: String::new(),
+        };
+        assert!(plan.is_noop());
+    }
+
+    #[test]
+    fn test_patch_plan_not_noop_when_different() {
+        let plan = PushbackPatchPlan {
+            hardware_nix_path: PathBuf::from("/tmp/hardware.nix"),
+            current_content: "old".to_string(),
+            proposed_content: "new".to_string(),
+            diff_preview: String::new(),
+            warnings: vec![],
+            commit_message: String::new(),
+        };
+        assert!(!plan.is_noop());
+    }
+
+    #[test]
+    fn test_build_diff_marks_additions_and_removals() {
+        let diff = PushbackPatchPlan::build_diff("old line", "new line");
+        assert!(diff.contains("-old line"));
+        assert!(diff.contains("+new line"));
+    }
+
+    #[test]
+    fn test_build_diff_noop_label() {
+        let diff = PushbackPatchPlan::build_diff("same", "same");
+        assert_eq!(diff, "(no changes)");
+    }
+
+    #[test]
+    fn test_poll_hardware_facts_noop_transitions_to_no_changes() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut screen = FirstBootScreen::new(test_config());
+        screen.rx = Some(rx);
+        screen.phase = FirstBootPhase::GatheringFacts;
+
+        let facts = FirstBootHardwareFacts {
+            hostname: "test-machine".to_string(),
+            generated_hardware_nix: "same".to_string(),
+            disk_devices: vec![],
+            kernel_modules: vec![],
+        };
+        let plan = PushbackPatchPlan {
+            hardware_nix_path: PathBuf::from("/tmp/hardware.nix"),
+            current_content: "same".to_string(),
+            proposed_content: "same".to_string(),
+            diff_preview: "(no changes)".to_string(),
+            warnings: vec![],
+            commit_message: String::new(),
+        };
+
+        tx.send(FirstBootMessage::HardwareFacts(facts, plan)).unwrap();
+        screen.poll();
+
+        assert_eq!(*screen.phase(), FirstBootPhase::NoChangesRequired);
+    }
+
+    #[test]
+    fn test_poll_hardware_facts_diff_transitions_to_review() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut screen = FirstBootScreen::new(test_config());
+        screen.rx = Some(rx);
+        screen.phase = FirstBootPhase::GatheringFacts;
+
+        let facts = FirstBootHardwareFacts {
+            hostname: "test-machine".to_string(),
+            generated_hardware_nix: "new content".to_string(),
+            disk_devices: vec![],
+            kernel_modules: vec![],
+        };
+        let plan = PushbackPatchPlan {
+            hardware_nix_path: PathBuf::from("/tmp/hardware.nix"),
+            current_content: "old content".to_string(),
+            proposed_content: "new content".to_string(),
+            diff_preview: "-old content\n+new content".to_string(),
+            warnings: vec![],
+            commit_message: "feat: reconcile".to_string(),
+        };
+
+        tx.send(FirstBootMessage::HardwareFacts(facts, plan)).unwrap();
+        screen.poll();
+
+        assert_eq!(*screen.phase(), FirstBootPhase::ReviewPlan);
+    }
+
+    #[test]
+    fn test_skip_plan_keeps_marker_by_not_calling_finish() {
+        // skip_plan transitions to Done with push_skipped=true but does NOT
+        // delete the marker file (finish() is not called).
+        let mut screen = FirstBootScreen::new(test_config());
+        screen.phase = FirstBootPhase::ReviewPlan;
+        screen.skip_plan();
+        assert_eq!(*screen.phase(), FirstBootPhase::Done);
+        assert!(screen.push_skipped);
+    }
+
+    #[tokio::test]
+    async fn test_accept_plan_transitions_to_applying() {
+        let mut screen = FirstBootScreen::new(test_config());
+        screen.phase = FirstBootPhase::ReviewPlan;
+        screen.patch_plan = Some(PushbackPatchPlan {
+            hardware_nix_path: PathBuf::from("/tmp/hardware.nix"),
+            current_content: "old".to_string(),
+            proposed_content: "new".to_string(),
+            diff_preview: "-old\n+new".to_string(),
+            warnings: vec![],
+            commit_message: "feat: reconcile".to_string(),
+        });
+        screen.accept_plan();
+        assert_eq!(*screen.phase(), FirstBootPhase::ApplyingPatch);
+    }
+
+    #[test]
+    fn test_toggle_diff_only_in_review_phase() {
+        let mut screen = FirstBootScreen::new(test_config());
+        screen.phase = FirstBootPhase::ReviewPlan;
+        assert!(!screen.show_diff);
+        screen.toggle_diff();
+        assert!(screen.show_diff);
+        screen.toggle_diff();
+        assert!(!screen.show_diff);
+
+        // Must not toggle outside ReviewPlan
+        screen.phase = FirstBootPhase::Welcome;
+        screen.toggle_diff();
+        assert!(!screen.show_diff);
+    }
+
+    #[test]
+    fn test_multiple_disks_produces_warning() {
+        // Validate the warning logic that runs inside spawn_gather_facts.
+        // We test it in isolation to avoid spawning async tasks.
+        let disk_count = 2usize;
+        let contains_placeholder = true;
+
+        let mut warnings = Vec::new();
+        if contains_placeholder && disk_count != 1 {
+            if disk_count == 0 {
+                warnings.push("no stable ids".to_string());
+            } else {
+                warnings.push(format!(
+                    "Multiple disks detected ({}); cannot confidently map",
+                    disk_count
+                ));
+            }
+        }
+
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("Multiple disks detected"));
+    }
+
+    #[test]
+    fn test_no_disks_produces_warning() {
+        let disk_count = 0usize;
+        let contains_placeholder = true;
+
+        let mut warnings = Vec::new();
+        if contains_placeholder && disk_count != 1 {
+            if disk_count == 0 {
+                warnings.push(
+                    "No stable /dev/disk/by-id/ entries found — \
+                     __KEYSTONE_DISK__ placeholder will not be replaced."
+                        .to_string(),
+                );
+            } else {
+                warnings.push("multiple disks".to_string());
+            }
+        }
+
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("No stable"));
     }
 }

--- a/packages/keystone-tui/src/screens/first_boot.rs
+++ b/packages/keystone-tui/src/screens/first_boot.rs
@@ -214,8 +214,11 @@ pub enum FirstBootPhase {
     ReviewPlan,
     /// Applying the accepted patch to disk.
     ApplyingPatch,
-    /// git init + add + commit.
+    /// git init + selective add + commit.
     GitSetup,
+    /// Repo has pre-existing uncommitted changes unrelated to hardware reconciliation.
+    /// The flow refuses to auto-commit mixed work; the user must resolve or skip.
+    DirtyRepo(Vec<String>),
     /// Display SSH public key + GitHub instructions.
     ShowSshKey,
     /// Text input for git remote URL.
@@ -237,10 +240,65 @@ pub enum FirstBootMessage {
     Output(String),
     HardwareFacts(FirstBootHardwareFacts, PushbackPatchPlan),
     PatchApplied,
+    /// Repo has pre-existing uncommitted changes unrelated to hardware reconciliation.
+    /// Contains the list of dirty file paths that blocked the auto-commit.
+    DirtyRepo(Vec<String>),
     GitReady,
     SshKey(String),
     PushResult(Result<(), String>),
     Failed(String),
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Return file paths that have staged or unstaged tracked-file changes in `repo_dir`,
+/// excluding files in `allowed`. Untracked files (`??`) are intentionally ignored
+/// because the first-boot workflow may operate on a freshly initialised repo where
+/// every file is still untracked.
+async fn collect_dirty_unrelated_files(
+    repo_dir: &std::path::Path,
+    allowed: &[&str],
+) -> Vec<String> {
+    let mut dirty: Vec<String> = Vec::new();
+
+    // Staged changes: files that differ between HEAD and the index.
+    // On a brand-new repo (no commits) this command exits non-zero but produces no
+    // output, which is safe to ignore — we fall through to the unstaged check.
+    if let Ok(out) = Command::new("git")
+        .args(["diff", "--cached", "--name-only"])
+        .current_dir(repo_dir)
+        .output()
+        .await
+    {
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        for line in stdout.lines() {
+            let name = line.trim();
+            if !name.is_empty() && !allowed.iter().any(|a| *a == name) {
+                dirty.push(name.to_string());
+            }
+        }
+    }
+
+    // Unstaged changes: tracked files modified in the working tree.
+    if let Ok(out) = Command::new("git")
+        .args(["diff", "--name-only"])
+        .current_dir(repo_dir)
+        .output()
+        .await
+    {
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        for line in stdout.lines() {
+            let name = line.trim();
+            if !name.is_empty()
+                && !allowed.iter().any(|a| *a == name)
+                && !dirty.contains(&name.to_string())
+            {
+                dirty.push(name.to_string());
+            }
+        }
+    }
+
+    dirty
 }
 
 // ─── Screen ──────────────────────────────────────────────────────────────────
@@ -483,6 +541,13 @@ impl FirstBootScreen {
             .as_ref()
             .map(|p| p.commit_message.clone())
             .unwrap_or_else(|| "feat: initial Keystone configuration".to_string());
+        let hardware_nix_name = self
+            .patch_plan
+            .as_ref()
+            .and_then(|p| p.hardware_nix_path.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("hardware.nix")
+            .to_string();
 
         tokio::spawn(async move {
             let _ = tx.send(FirstBootMessage::Output(
@@ -508,12 +573,32 @@ impl FirstBootScreen {
                 .output()
                 .await;
 
-            // Add .gitignore to exclude the marker from future commits
+            // Write .gitignore to exclude the marker from future commits
             let gitignore_path = config_dir.join(".gitignore");
             let _ = tokio::fs::write(&gitignore_path, ".first-boot-pending\n").await;
 
+            // Check for pre-existing dirty tracked files (staged or unstaged modifications)
+            // that are unrelated to the hardware reconciliation files being committed.
+            //
+            // SECURITY: Staging `git add .` in an already-dirty repo would silently bundle
+            // unrelated changes into the hardware reconciliation commit, making history
+            // harder to audit and preventing clean bisect or revert operations later.
+            let dirty_files = collect_dirty_unrelated_files(
+                &config_dir,
+                &[hardware_nix_name.as_str(), ".gitignore"],
+            )
+            .await;
+
+            if !dirty_files.is_empty() {
+                let _ = tx.send(FirstBootMessage::DirtyRepo(dirty_files));
+                return;
+            }
+
+            // Stage only the hardware reconciliation files — not the entire working tree.
+            // This satisfies spec requirement 16: first-boot commits MUST contain only
+            // hardware pushback artifacts.
             let add = Command::new("git")
-                .args(["add", "."])
+                .args(["add", &hardware_nix_name, ".gitignore"])
                 .current_dir(&config_dir)
                 .output()
                 .await;
@@ -532,8 +617,7 @@ impl FirstBootScreen {
             match commit {
                 Ok(out) if out.status.success() => {
                     let _ = tx.send(FirstBootMessage::Output(
-                        "Git repository initialized with hardware reconciliation commit."
-                            .to_string(),
+                        "Hardware reconciliation commit created.".to_string(),
                     ));
                     let _ = tx.send(FirstBootMessage::GitReady);
                 }
@@ -711,9 +795,9 @@ impl FirstBootScreen {
         }
     }
 
-    /// Skip the current step (SSH key display or push).
+    /// Skip the current step (SSH key display, push, or dirty-repo warning).
     pub fn skip(&mut self) {
-        match self.phase {
+        match &self.phase {
             FirstBootPhase::ShowSshKey => {
                 self.phase = FirstBootPhase::RemoteInput;
                 self.remote_input.set_focused(true);
@@ -725,6 +809,9 @@ impl FirstBootScreen {
             FirstBootPhase::Pushing => {
                 self.push_skipped = true;
                 self.finish();
+            }
+            FirstBootPhase::DirtyRepo(_) => {
+                self.dismiss_dirty_repo();
             }
             _ => {}
         }
@@ -765,6 +852,19 @@ impl FirstBootScreen {
     pub fn handle_text_input(&mut self, key: crossterm::event::KeyEvent) {
         if self.phase == FirstBootPhase::RemoteInput {
             self.remote_input.handle_key(key);
+        }
+    }
+
+    /// Dismiss the dirty-repo warning and leave the first-boot marker so the user
+    /// can clean up the repo and retry later.
+    ///
+    /// Per spec: the flow MUST refuse to auto-commit mixed work. Dismissing here
+    /// means the commit is skipped entirely; the marker remains on disk.
+    pub fn dismiss_dirty_repo(&mut self) {
+        if matches!(self.phase, FirstBootPhase::DirtyRepo(_)) {
+            // Intentionally do NOT call finish() — marker stays on disk.
+            self.phase = FirstBootPhase::Done;
+            self.push_skipped = true;
         }
     }
 
@@ -814,6 +914,9 @@ impl FirstBootScreen {
                     self.phase = FirstBootPhase::GitSetup;
                     self.spawn_git_setup();
                 }
+                FirstBootMessage::DirtyRepo(files) => {
+                    self.phase = FirstBootPhase::DirtyRepo(files);
+                }
                 FirstBootMessage::GitReady => {
                     self.phase = FirstBootPhase::ShowSshKey;
                     self.spawn_ssh_key_check();
@@ -846,6 +949,7 @@ impl FirstBootScreen {
             }
             FirstBootPhase::ReviewPlan => self.render_review_plan(frame, area),
             FirstBootPhase::GitSetup => self.render_progress(frame, area),
+            FirstBootPhase::DirtyRepo(files) => self.render_dirty_repo(frame, area, files),
             FirstBootPhase::ShowSshKey => self.render_ssh_key(frame, area),
             FirstBootPhase::RemoteInput => self.render_remote_input(frame, area),
             FirstBootPhase::Pushing => self.render_progress(frame, area),
@@ -1047,6 +1151,69 @@ impl FirstBootScreen {
         let diff_hint = if self.show_diff { "v: hide diff" } else { "v: view diff" };
         let help = Paragraph::new(Text::styled(
             format!("Enter: apply and commit • s: skip for now • {}", diff_hint),
+            Style::default().fg(Color::DarkGray),
+        ))
+        .alignment(Alignment::Center);
+        frame.render_widget(help, chunks[2]);
+    }
+
+    fn render_dirty_repo(&self, frame: &mut Frame, area: Rect, dirty_files: &[String]) {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),
+                Constraint::Min(5),
+                Constraint::Length(3),
+            ])
+            .split(area);
+
+        let title = Paragraph::new(Text::styled(
+            "Cannot commit: repo has unrelated changes",
+            Style::default().bold().fg(Color::Yellow),
+        ))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::BOTTOM));
+        frame.render_widget(title, chunks[0]);
+
+        let mut lines: Vec<Line> = vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "  The repository has uncommitted changes unrelated to hardware",
+                Style::default().fg(Color::Yellow),
+            )),
+            Line::from(Span::styled(
+                "  reconciliation. Auto-commit is refused to avoid bundling mixed work.",
+                Style::default().fg(Color::Yellow),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "  Affected files:",
+                Style::default().add_modifier(Modifier::BOLD),
+            )),
+        ];
+
+        for file in dirty_files {
+            lines.push(Line::from(Span::styled(
+                format!("    • {}", file),
+                Style::default().fg(Color::Red),
+            )));
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::from("  Resolve or stash these changes, then re-run first-boot setup."));
+        lines.push(Line::from("  The first-boot marker has been preserved for retry."));
+
+        let body = Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Yellow)),
+            )
+            .wrap(Wrap { trim: false });
+        frame.render_widget(body, chunks[1]);
+
+        let help = Paragraph::new(Text::styled(
+            "s: skip for now (marker preserved) • q: exit",
             Style::default().fg(Color::DarkGray),
         ))
         .alignment(Alignment::Center);
@@ -1602,5 +1769,65 @@ mod tests {
 
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].contains("No stable"));
+    }
+
+    // ─── DirtyRepo tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_poll_dirty_repo_transitions_to_dirty_phase() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut screen = FirstBootScreen::new(test_config());
+        screen.rx = Some(rx);
+        screen.phase = FirstBootPhase::GitSetup;
+
+        tx.send(FirstBootMessage::DirtyRepo(vec![
+            "configuration.nix".to_string(),
+        ]))
+        .unwrap();
+
+        screen.poll();
+        assert!(matches!(screen.phase(), FirstBootPhase::DirtyRepo(_)));
+        if let FirstBootPhase::DirtyRepo(files) = screen.phase() {
+            assert_eq!(files, &["configuration.nix".to_string()]);
+        }
+    }
+
+    #[test]
+    fn test_dismiss_dirty_repo_preserves_marker() {
+        // dismiss_dirty_repo transitions to Done with push_skipped=true but does NOT
+        // call finish(), so the first-boot marker remains on disk.
+        let mut screen = FirstBootScreen::new(test_config());
+        screen.phase = FirstBootPhase::DirtyRepo(vec!["configuration.nix".to_string()]);
+        screen.dismiss_dirty_repo();
+        assert_eq!(*screen.phase(), FirstBootPhase::Done);
+        assert!(screen.push_skipped);
+    }
+
+    #[test]
+    fn test_skip_from_dirty_repo_preserves_marker() {
+        let mut screen = FirstBootScreen::new(test_config());
+        screen.phase = FirstBootPhase::DirtyRepo(vec!["configuration.nix".to_string()]);
+        screen.skip();
+        assert_eq!(*screen.phase(), FirstBootPhase::Done);
+        assert!(screen.push_skipped);
+    }
+
+    #[test]
+    fn test_dismiss_dirty_repo_noop_when_not_dirty_phase() {
+        let mut screen = FirstBootScreen::new(test_config());
+        screen.phase = FirstBootPhase::Welcome;
+        screen.dismiss_dirty_repo();
+        // Phase must be unchanged
+        assert_eq!(*screen.phase(), FirstBootPhase::Welcome);
+        assert!(!screen.push_skipped);
+    }
+
+    #[tokio::test]
+    async fn test_collect_dirty_unrelated_files_empty_on_clean_dir() {
+        // A temporary directory with no git repo — commands fail silently and
+        // the helper returns an empty list (no panic, no false positives).
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dirty = collect_dirty_unrelated_files(tmp.path(), &["hardware.nix", ".gitignore"]).await;
+        assert!(dirty.is_empty());
     }
 }


### PR DESCRIPTION
Closes #224
Part of #138

## Summary

- Selective staging: stages only `hardware.nix` and `.gitignore` (not `git add .`) for the reconciliation commit
- Dirty repo detection: refuses auto-commit if unrelated tracked files have uncommitted changes, transitioning to a new `DirtyRepo` phase
- `DirtyRepo` phase: lists blocking files with instructions to resolve or stash before retrying; the first-boot marker is preserved for retry
- Key binding: `s` (skip/dismiss) wired for the `DirtyRepo` phase in `input.rs`
- 5 new unit tests covering the dirty-repo path; all 150 tests pass

## Acceptance criteria

- [x] First-boot flow stages only hardware reconciliation files after user confirmation
- [x] The flow refuses to auto-commit if the repo is already dirty with unrelated changes
- [x] The default commit message identifies first-boot hardware reconciliation for the target host
- [x] Push to remote is optional and requires explicit confirmation
- [x] Marker cleanup only happens after the patch phase succeeds and the user completes or explicitly dismisses the flow

## Test plan

- [ ] Run `cargo test` in `packages/keystone-tui` — all 150 tests pass
- [ ] Manual first-boot flow with a clean repo: verify only `hardware.nix` and `.gitignore` are staged
- [ ] Manual first-boot flow with an unrelated dirty file: verify transition to `DirtyRepo` phase and no auto-commit
- [ ] `s` key in `DirtyRepo` phase dismisses and preserves marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)