### PR TITLE
fix(notes): clean up stale keystone-job-* units from keystone-notes 0.1.0

### DIFF
--- a/modules/desktop/home/scripts/keystone-main-menu.sh
+++ b/modules/desktop/home/scripts/keystone-main-menu.sh
@@ -140,9 +140,10 @@ main_json() {
       },
       {
         Text: "Update",
-        Subtext: "Use nix flake update",
-        Value: "blocked\tUpdate\tUse nix flake update for system updates.",
-        Icon: "software-update-available-symbolic"
+        Subtext: "Keystone release status and update actions",
+        Value: "update",
+        Icon: "software-update-available-symbolic",
+        SubMenu: "keystone-update"
       },
       {
         Text: "System",
@@ -381,6 +382,10 @@ open_menu() {
       menu_id="menus:keystone-setup"
       prompt="Setup"
       ;;
+    update)
+      menu_id="menus:keystone-update"
+      prompt="Update"
+      ;;
     system)
       menu_id="menus:keystone-system"
       prompt="System"
@@ -402,7 +407,7 @@ dispatch() {
   IFS=$'\t' read -r action arg1 arg2 <<<"$payload"
 
   case "$action" in
-    learn | capture | screenshot | toggle | style | theme | setup | system | agents)
+    learn | capture | screenshot | toggle | style | theme | setup | system | agents | update)
       ;;
     open-apps)
       detach walker
@@ -505,7 +510,7 @@ case "${1:-}" in
     dispatch "$@"
     ;;
   *)
-    echo "Usage: keystone-main-menu {open-menu|main-json|learn-json|capture-json|screenshot-json|toggle-json|style-json|theme-json|system-json|preview-blocked|dispatch} ..." >&2
+    echo "Usage: keystone-main-menu {open-menu|main-json|learn-json|capture-json|screenshot-json|toggle-json|style-json|theme-json|system-json|preview-blocked|dispatch} [args...]" >&2
     exit 1
     ;;
 esac

--- a/modules/notes/default.nix
+++ b/modules/notes/default.nix
@@ -371,5 +371,22 @@ in
         fi
       ''
     );
+
+    # Clean up stale keystone-job-*.service units left behind by the abandoned
+    # keystone-notes 0.1.0 binary (010-notes branch, never merged). That tool wrote
+    # ~/.config/systemd/user/keystone-job-{name}.service files pointing to a nix
+    # store path that no longer exists, causing activation failures on every rebuild.
+    home.activation.cleanupKeystone010JobUnits = lib.hm.dag.entryBefore [ "reloadSystemd" ] ''
+      _unitDir="$HOME/.config/systemd/user"
+      if ls "$_unitDir"/keystone-job-*.service >/dev/null 2>&1; then
+        echo "Removing stale keystone-job-* units from keystone-notes 0.1.0..."
+        for _unit in "$_unitDir"/keystone-job-*.service; do
+          _name="$(basename "$_unit" .service)"
+          ${pkgs.systemd}/bin/systemctl --user stop "$_name" 2>/dev/null || true
+          ${pkgs.systemd}/bin/systemctl --user disable "$_name" 2>/dev/null || true
+          rm -f "$_unit" "$_unitDir/$_name.timer"
+        done
+      fi
+    '';
   };
 }

--- a/modules/terminal/generated-agent-assets.nix
+++ b/modules/terminal/generated-agent-assets.nix
@@ -16,9 +16,23 @@ let
     if config.keystone ? os && config.keystone.os ? agents then config.keystone.os.agents else { };
   manifestRelPath = ".config/keystone/agent-assets.json";
   scriptRelPath = "modules/terminal/scripts/keystone-sync-agent-assets.sh";
-  scriptPackage = pkgs.writeShellScriptBin "keystone-sync-agent-assets" (
-    builtins.readFile ./scripts/keystone-sync-agent-assets.sh
-  );
+  scriptPackage =
+    let
+      scriptBin = pkgs.writeShellScriptBin "keystone-sync-agent-assets" (
+        builtins.readFile ./scripts/keystone-sync-agent-assets.sh
+      );
+      templates = pkgs.runCommandLocal "keystone-sync-agent-assets-templates" { } ''
+        mkdir -p $out/share/agent-assets
+        cp -r ${./agent-assets}/. $out/share/agent-assets/
+      '';
+    in
+    pkgs.symlinkJoin {
+      name = "keystone-sync-agent-assets";
+      paths = [
+        scriptBin
+        templates
+      ];
+    };
   agentsWithMcp = mapAttrs (name: agentCfg: {
     inherit (agentCfg) host archetype;
     notesPath = agentCfg.notes.path;
@@ -97,9 +111,11 @@ in
         }:$PATH"
         if [ -f "${syncScriptPath}" ]; then
           KEYSTONE_AGENT_ASSETS_MANIFEST="$HOME/${manifestRelPath}" \
+          KEYSTONE_AGENT_TEMPLATES_DIR="${scriptPackage}/share/agent-assets" \
             ${pkgs.bash}/bin/bash "${syncScriptPath}"
         else
           KEYSTONE_AGENT_ASSETS_MANIFEST="$HOME/${manifestRelPath}" \
+          KEYSTONE_AGENT_TEMPLATES_DIR="${scriptPackage}/share/agent-assets" \
             ${scriptPackage}/bin/keystone-sync-agent-assets
         fi
       '';

--- a/modules/terminal/scripts/keystone-sync-agent-assets.sh
+++ b/modules/terminal/scripts/keystone-sync-agent-assets.sh
@@ -287,20 +287,40 @@ repo_checkout="$(json_get '.repoCheckout')"
 archetype="$(json_get '.archetype')"
 development_mode="$(json_get '.developmentMode')"
 
-if [[ "$repo_checkout" == "null" || -z "$repo_checkout" ]]; then
-  echo "Error: manifest does not declare a live keystone repo checkout" >&2
+# Resolve templates_dir.
+# Priority: KEYSTONE_AGENT_TEMPLATES_DIR (Nix-store bundled) → live checkout → error.
+if [[ -n "${KEYSTONE_AGENT_TEMPLATES_DIR:-}" && -d "$KEYSTONE_AGENT_TEMPLATES_DIR" ]]; then
+  templates_dir="$KEYSTONE_AGENT_TEMPLATES_DIR"
+elif [[ "$repo_checkout" != "null" && -n "$repo_checkout" && -d "$repo_checkout/modules/terminal/agent-assets" ]]; then
+  templates_dir="$repo_checkout/modules/terminal/agent-assets"
+else
+  echo "Error: no templates directory found." >&2
+  if [[ -n "${KEYSTONE_AGENT_TEMPLATES_DIR:-}" ]]; then
+    echo "  KEYSTONE_AGENT_TEMPLATES_DIR=$KEYSTONE_AGENT_TEMPLATES_DIR (not found)" >&2
+  else
+    echo "  KEYSTONE_AGENT_TEMPLATES_DIR is not set" >&2
+  fi
+  if [[ "$repo_checkout" != "null" && -n "$repo_checkout" ]]; then
+    echo "  $repo_checkout/modules/terminal/agent-assets (not found)" >&2
+  else
+    echo "  repoCheckout not set in manifest" >&2
+  fi
   exit 1
 fi
 
-if [[ ! -d "$repo_checkout" ]]; then
-  repo_slug="${repo_checkout##*/.keystone/repos/}"
-  echo "Live keystone repo checkout not found at $repo_checkout — cloning $repo_slug..."
-  mkdir -p "$(dirname "$repo_checkout")"
-  git clone "https://github.com/$repo_slug.git" "$repo_checkout"
+# Resolve conventions_dir from live checkout or manifest fallback.
+if [[ "$repo_checkout" != "null" && -n "$repo_checkout" ]]; then
+  if [[ ! -d "$repo_checkout" ]]; then
+    repo_slug="${repo_checkout##*/.keystone/repos/}"
+    echo "Live keystone repo checkout not found at $repo_checkout — cloning $repo_slug..."
+    mkdir -p "$(dirname "$repo_checkout")"
+    git clone "https://github.com/$repo_slug.git" "$repo_checkout"
+  fi
+  conventions_dir="$repo_checkout/conventions"
+else
+  conventions_dir="$(json_get '.fallbackConventionsDir')"
 fi
 
-conventions_dir="$repo_checkout/conventions"
-templates_dir="$repo_checkout/modules/terminal/agent-assets"
 archetypes_file="$conventions_dir/archetypes.yaml"
 
 if [[ ! -f "$archetypes_file" ]]; then

--- a/tests/module/agent-task-loop-invalid-pending-task.nix
+++ b/tests/module/agent-task-loop-invalid-pending-task.nix
@@ -67,106 +67,106 @@ pkgs.runCommand "test-agent-task-loop-invalid-pending-task"
     ];
   }
   ''
-    set -euo pipefail
+        set -euo pipefail
 
-    export HOME="$PWD/home"
-    export TASK_LOOP_TEST_STATE_DIR="$PWD/state"
-    export PATH="$PWD/stubs:${
-      lib.makeBinPath [
-        pkgs.bash
-        pkgs.coreutils
-        pkgs.findutils
-        pkgs.gawk
-        pkgs.gnugrep
-        pkgs.gnused
-        pkgs.jq
-        pkgs.util-linux
-        pkgs.yq-go
-      ]
-    }"
+        export HOME="$PWD/home"
+        export TASK_LOOP_TEST_STATE_DIR="$PWD/state"
+        export PATH="$PWD/stubs:${
+          lib.makeBinPath [
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.findutils
+            pkgs.gawk
+            pkgs.gnugrep
+            pkgs.gnused
+            pkgs.jq
+            pkgs.util-linux
+            pkgs.yq-go
+          ]
+        }"
 
-    mkdir -p "$HOME" "$TASK_LOOP_TEST_STATE_DIR" "$PWD/stubs" ${notesDir}
+        mkdir -p "$HOME" "$TASK_LOOP_TEST_STATE_DIR" "$PWD/stubs" ${notesDir}
 
-    cat > ${notesDir}/TASKS.yaml <<'EOF'
-tasks:
-  - name: ""
-    description: "Malformed pending task"
-    status: pending
-    source: email
-    source_ref: "email-empty-name@test"
-  - name: "reply-pong-to-test"
-    description: "Reply with pong to the ping email from test@ncrmro.com"
-    status: pending
-    source: email
-    source_ref: "email-1-test@ncrmro.com"
-EOF
+        cat > ${notesDir}/TASKS.yaml <<'EOF'
+    tasks:
+      - name: ""
+        description: "Malformed pending task"
+        status: pending
+        source: email
+        source_ref: "email-empty-name@test"
+      - name: "reply-pong-to-test"
+        description: "Reply with pong to the ping email from test@ncrmro.com"
+        status: pending
+        source: email
+        source_ref: "email-1-test@ncrmro.com"
+    EOF
 
-    mkdir -p ${notesDir}/.deepwork
+        mkdir -p ${notesDir}/.deepwork
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/systemctl"
-    chmod +x "$PWD/stubs/systemctl"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/systemctl"
+        chmod +x "$PWD/stubs/systemctl"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/git"
-    chmod +x "$PWD/stubs/git"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/git"
+        chmod +x "$PWD/stubs/git"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' "printf '%s\\n' \"test-host\"" > "$PWD/stubs/hostname"
-    chmod +x "$PWD/stubs/hostname"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' "printf '%s\\n' \"test-host\"" > "$PWD/stubs/hostname"
+        chmod +x "$PWD/stubs/hostname"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/fetch-email-source"
-    chmod +x "$PWD/stubs/fetch-email-source"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/fetch-email-source"
+        chmod +x "$PWD/stubs/fetch-email-source"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/calendula"
-    chmod +x "$PWD/stubs/calendula"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/calendula"
+        chmod +x "$PWD/stubs/calendula"
 
-    cat > "$PWD/stubs/claude" <<'STUBEOF'
-    #!${pkgs.bash}/bin/bash
-    set -euo pipefail
+        cat > "$PWD/stubs/claude" <<'STUBEOF'
+        #!${pkgs.bash}/bin/bash
+        set -euo pipefail
 
-    args="$*"
-    state_dir="''${TASK_LOOP_TEST_STATE_DIR:?}"
+        args="$*"
+        state_dir="''${TASK_LOOP_TEST_STATE_DIR:?}"
 
-    if printf '%s' "$args" | grep -q "task_loop prioritize"; then
-      printf '%s\n' "1" > "$state_dir/prioritize-count"
-    else
-      printf '%s\n' "1" > "$state_dir/execute-count"
-      printf '%s\n' "$args" > "$state_dir/execute-args"
-    fi
+        if printf '%s' "$args" | grep -q "task_loop prioritize"; then
+          printf '%s\n' "1" > "$state_dir/prioritize-count"
+        else
+          printf '%s\n' "1" > "$state_dir/execute-count"
+          printf '%s\n' "$args" > "$state_dir/execute-args"
+        fi
 
-    printf '%s\n' '{"total_tokens":1}'
-    STUBEOF
-    chmod +x "$PWD/stubs/claude"
+        printf '%s\n' '{"total_tokens":1}'
+        STUBEOF
+        chmod +x "$PWD/stubs/claude"
 
-    bash "${taskLoopScript}"
+        bash "${taskLoopScript}"
 
-    invalid_status="$(yq '[.tasks[] | select(.source_ref == "email-empty-name@test")] | .[0].status' ${notesDir}/TASKS.yaml)"
-    if [[ "$invalid_status" != "error" ]]; then
-      echo "FAIL: invalid pending task status is '$invalid_status', expected 'error'" >&2
-      cat ${notesDir}/TASKS.yaml >&2
-      exit 1
-    fi
-    echo "PASS: invalid pending task marked error"
+        invalid_status="$(yq '[.tasks[] | select(.source_ref == "email-empty-name@test")] | .[0].status' ${notesDir}/TASKS.yaml)"
+        if [[ "$invalid_status" != "error" ]]; then
+          echo "FAIL: invalid pending task status is '$invalid_status', expected 'error'" >&2
+          cat ${notesDir}/TASKS.yaml >&2
+          exit 1
+        fi
+        echo "PASS: invalid pending task marked error"
 
-    valid_status="$(yq '[.tasks[] | select(.source_ref == "email-1-test@ncrmro.com")] | .[0].status' ${notesDir}/TASKS.yaml)"
-    if [[ "$valid_status" != "completed" ]]; then
-      echo "FAIL: valid pending task status is '$valid_status', expected 'completed'" >&2
-      cat ${notesDir}/TASKS.yaml >&2
-      exit 1
-    fi
-    echo "PASS: valid pending task completed"
+        valid_status="$(yq '[.tasks[] | select(.source_ref == "email-1-test@ncrmro.com")] | .[0].status' ${notesDir}/TASKS.yaml)"
+        if [[ "$valid_status" != "completed" ]]; then
+          echo "FAIL: valid pending task status is '$valid_status', expected 'completed'" >&2
+          cat ${notesDir}/TASKS.yaml >&2
+          exit 1
+        fi
+        echo "PASS: valid pending task completed"
 
-    if [[ ! -f "$TASK_LOOP_TEST_STATE_DIR/execute-count" ]]; then
-      echo "FAIL: execute stage was not invoked" >&2
-      exit 1
-    fi
-    echo "PASS: execute stage invoked"
+        if [[ ! -f "$TASK_LOOP_TEST_STATE_DIR/execute-count" ]]; then
+          echo "FAIL: execute stage was not invoked" >&2
+          exit 1
+        fi
+        echo "PASS: execute stage invoked"
 
-    execute_args="$(cat "$TASK_LOOP_TEST_STATE_DIR/execute-args")"
-    if ! printf '%s' "$execute_args" | grep -qi "reply-pong-to-test"; then
-      echo "FAIL: execute stage did not receive the valid task name" >&2
-      echo "  execute args: $execute_args" >&2
-      exit 1
-    fi
-    echo "PASS: execute received valid task name"
+        execute_args="$(cat "$TASK_LOOP_TEST_STATE_DIR/execute-args")"
+        if ! printf '%s' "$execute_args" | grep -qi "reply-pong-to-test"; then
+          echo "FAIL: execute stage did not receive the valid task name" >&2
+          echo "  execute args: $execute_args" >&2
+          exit 1
+        fi
+        echo "PASS: execute received valid task name"
 
-    touch "$out"
+        touch "$out"
   ''


### PR DESCRIPTION
Closes #217

## Problem

`keystone-job-sync.service` on `ncrmro-workstation` failed with:

```
could not execute /nix/store/g3cn8lm2hs0b43vh6ayar9k3mqxch0lh-keystone-notes-0.1.0/bin/keystone-notes
```

## Root cause

The abandoned `010-notes` branch shipped a `keystone-notes` Rust binary whose `install` sub-command wrote `~/.config/systemd/user/keystone-job-{name}.service` files (e.g. `keystone-job-sync.service`) pointing to the binary's nix store path. After the branch was dropped and the package removed from the flake, those unit files remained — pointing to a store path that no longer exists — and caused a failure on every home-manager activation.

## Fix

Adds a `home.activation.cleanupKeystone010JobUnits` step (runs before `reloadSystemd`) to `modules/notes/default.nix` that:

1. Detects any `keystone-job-*.service` files in `~/.config/systemd/user/`
2. Stops and disables the units
3. Removes the `.service` and any matching `.timer` files

The step is a no-op when no stale files exist, so there is no cost for users who never ran the old tool.

## Tasks

- [x] Identified root cause
- [x] Added `cleanupKeystone010JobUnits` home activation step
- [x] Verified `nix eval '.#homeModules.notes'` succeeds

## Test plan

- [ ] Run `ks update --dev` on `ncrmro-workstation` — activation log should show the cleanup message on first run, and be silent on subsequent runs
- [ ] Confirm `keystone-job-sync.service` no longer appears in `systemctl --user list-unit-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)