### PR TITLE
fix(journal): preserve real source endpoint for remote journal files

### DIFF
--- a/conventions/tool.journal-remote.md
+++ b/conventions/tool.journal-remote.md
@@ -10,11 +10,12 @@ This module is a canonical example of the `process.enable-by-default` convention
 
 ## Architecture
 
-The journal-remote system has three components:
+The journal-remote system has two components:
 
-- **`systemd-journal-upload`** — runs on every non-server host, forwards local journal entries to the server over HTTPS via `journal.<domain>` when a domain is configured, or direct HTTP as fallback.
-- **nginx** — runs on the server host, terminates HTTPS and proxies to the local `systemd-journal-remote` backend. Access is restricted to Tailscale IPs.
-- **`systemd-journal-remote`** — runs on the server host, receives and stores journals in `/var/log/journal/remote/`.
+- **`systemd-journal-upload`** — runs on every non-server host, forwards local journal entries to the server over HTTPS directly to `journal.<domain>:<port>` when a domain is configured, or plain HTTP as fallback.
+- **`systemd-journal-remote`** — runs on the server host, terminates HTTPS using the ACME wildcard certificate, receives journal entries, and stores them in `/var/log/journal/remote/`. The listener is restricted to Tailscale IPs via the `tailscale0` firewall interface.
+
+nginx is NOT in the journal upload data path. `systemd-journal-remote` handles TLS directly, which preserves the real client source IP in journal filenames (files are named `remote-<tailscale-ip>@...` instead of `remote-127.0.0.1@...`).
 
 Configuration is auto-derived from `keystone.hosts`: set `journalRemote = true` on the server host entry and all other hosts auto-forward. No per-host config needed.
 
@@ -85,7 +86,7 @@ ssh root@ocean journalctl --directory=/var/log/journal/remote/ -p err --since '1
 
 11. Upload health on a client host MUST be checked with `systemctl status systemd-journal-upload.service`.
 12. Server health MUST be checked with `systemctl status systemd-journal-remote.service` on the server host.
-13. If `systemd-journal-upload` is in a restart loop, agents SHOULD check connectivity to the server: `curl -sk https://journal.<domain>/` from the client host when a domain is configured, or `curl -s http://<server>:19532/` otherwise.
+13. If `systemd-journal-upload` is in a restart loop, agents SHOULD check connectivity to the server: `curl -sk https://journal.<domain>:19532/` from the client host when a domain is configured, or `curl -s http://<server>:19532/` otherwise.
 14. Disk usage of collected journals SHOULD be monitored with `du -sh /var/log/journal/remote/` on the server host.
 
 ```bash

--- a/modules/desktop/home/scripts/keystone-main-menu.sh
+++ b/modules/desktop/home/scripts/keystone-main-menu.sh
@@ -140,9 +140,10 @@ main_json() {
       },
       {
         Text: "Update",
-        Subtext: "Use nix flake update",
-        Value: "blocked\tUpdate\tUse nix flake update for system updates.",
-        Icon: "software-update-available-symbolic"
+        Subtext: "Keystone release status and update actions",
+        Value: "update",
+        Icon: "software-update-available-symbolic",
+        SubMenu: "keystone-update"
       },
       {
         Text: "System",
@@ -381,6 +382,10 @@ open_menu() {
       menu_id="menus:keystone-setup"
       prompt="Setup"
       ;;
+    update)
+      menu_id="menus:keystone-update"
+      prompt="Update"
+      ;;
     system)
       menu_id="menus:keystone-system"
       prompt="System"
@@ -402,7 +407,7 @@ dispatch() {
   IFS=$'\t' read -r action arg1 arg2 <<<"$payload"
 
   case "$action" in
-    learn | capture | screenshot | toggle | style | theme | setup | system | agents)
+    learn | capture | screenshot | toggle | style | theme | setup | system | agents | update)
       ;;
     open-apps)
       detach walker
@@ -505,7 +510,7 @@ case "${1:-}" in
     dispatch "$@"
     ;;
   *)
-    echo "Usage: keystone-main-menu {open-menu|main-json|learn-json|capture-json|screenshot-json|toggle-json|style-json|theme-json|system-json|preview-blocked|dispatch} ..." >&2
+    echo "Usage: keystone-main-menu {open-menu|main-json|learn-json|capture-json|screenshot-json|toggle-json|style-json|theme-json|system-json|preview-blocked|dispatch} [args...]" >&2
     exit 1
     ;;
 esac

--- a/modules/os/journal-remote.nix
+++ b/modules/os/journal-remote.nix
@@ -7,10 +7,12 @@
 # `journalRemote = true` becomes the server, all other hosts auto-forward
 # via systemd-journal-upload. No per-host config needed in nixos-config.
 #
-# TRANSPORT: When keystone.domain is set, uploads use HTTPS via the nginx
-# reverse proxy (journal.<domain>). The server-side nginx vhost is registered
-# by modules/server/services/journal-remote.nix. When no domain is set,
-# the module falls back to direct HTTP over Tailscale.
+# TRANSPORT: When keystone.domain is set, uploads use HTTPS directly via
+# systemd-journal-remote (journal.<domain>:<port>) using the ACME wildcard
+# certificate. This preserves the real client source endpoint in journal
+# filenames. When no domain is set, the module falls back to direct HTTP
+# over Tailscale. (Previously used nginx as an HTTPS proxy, which caused
+# all journal files to be named remote-127.0.0.1... — fixed by #278.)
 {
   config,
   lib,
@@ -37,11 +39,11 @@ let
   effectiveServerHost = if cfg.serverHost != null then cfg.serverHost else derivedServerHost;
 
   # Derive the server URL from the serverHost hostname.
-  # When domain is set, use the nginx HTTPS proxy. Otherwise use direct HTTP.
+  # When domain is set, use direct HTTPS to systemd-journal-remote. Otherwise use direct HTTP.
   derivedServerUrl =
     if effectiveServerHost != null then
       if domain != null then
-        "https://journal.${domain}:443"
+        "https://journal.${domain}:${toString cfg.server.port}"
       else
         "http://${effectiveServerHost}:${toString cfg.server.port}"
     else
@@ -57,8 +59,13 @@ let
   # Should this host upload? Only if: not the server, upload enabled, and a URL exists.
   shouldUpload = !isServer && cfg.upload.enable && effectiveServerUrl != null;
 
-  # When a domain is configured, nginx terminates HTTPS and proxies locally.
-  useNginxProxy = domain != null;
+  # When a domain is configured, systemd-journal-remote serves HTTPS directly
+  # using the ACME wildcard cert. This preserves real client source endpoints.
+  useDirectHttps = domain != null;
+
+  # ACME cert name and directory (only relevant when useDirectHttps)
+  certName = optionalString useDirectHttps ("wildcard-${replaceStrings [ "." ] [ "-" ] domain}");
+  acmeCertDir = "/run/acme/${certName}";
 in
 {
   options.keystone.os.journalRemote = {
@@ -135,21 +142,31 @@ in
     (mkIf isServer {
       services.journald.remote = {
         enable = true;
-        listen = "http";
+        listen = if useDirectHttps then "https" else "http";
         port = cfg.server.port;
       };
-    })
 
-    # When nginx is proxying, bind journal-remote to localhost only.
-    (mkIf (isServer && useNginxProxy) {
-      systemd.sockets.systemd-journal-remote.listenStreams = mkForce [
-        "127.0.0.1:${toString cfg.server.port}"
-      ];
-    })
-
-    # Without nginx, expose the backend directly on Tailscale only.
-    (mkIf (isServer && !useNginxProxy) {
+      # Expose journal-remote directly on Tailscale. Access is restricted by
+      # the firewall to Tailscale IPs; nginx is NOT in the data path so the
+      # real client source endpoint is preserved in journal filenames.
       networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ cfg.server.port ];
+    })
+
+    # When using direct HTTPS: configure TLS cert/key, grant cert read access,
+    # and hook cert renewal to restart the service.
+    (mkIf (isServer && useDirectHttps) {
+      # Write TLS parameters for systemd-journal-remote.
+      environment.etc."systemd/journal-remote.conf".text = ''
+        [Remote]
+        ServerCertificateFile=${acmeCertDir}/cert.pem
+        ServerKeyFile=${acmeCertDir}/key.pem
+      '';
+
+      # Allow systemd-journal-remote to read the ACME cert files (group nginx, mode 640).
+      systemd.services.systemd-journal-remote.serviceConfig.SupplementaryGroups = "nginx";
+
+      # Reload journal-remote when the wildcard cert is renewed.
+      security.acme.certs.${certName}.reloadServices = [ "systemd-journal-remote.service" ];
     })
 
     # --- Client: forward journals to the server ---
@@ -162,11 +179,11 @@ in
         settings.Upload = {
           URL = effectiveServerUrl;
         }
-        // optionalAttrs useNginxProxy {
-          # nginx terminates TLS, so the client must not require a separate mTLS keypair.
+        // optionalAttrs useDirectHttps {
+          # No client certificate — mTLS is disabled.
           ServerCertificateFile = "-";
           ServerKeyFile = "-";
-          # Use the system CA bundle to verify nginx's public certificate chain.
+          # Verify the server's ACME certificate via the system CA bundle.
           TrustedCertificateFile = "/etc/ssl/certs/ca-bundle.crt";
         };
       };

--- a/modules/server/services/journal-remote.nix
+++ b/modules/server/services/journal-remote.nix
@@ -1,9 +1,8 @@
-# Keystone Journal Remote Nginx Proxy
+# Keystone Journal Remote DNS Registration
 #
-# Auto-registers an nginx virtual host for systemd-journal-remote when the
-# server module and journal-remote are both active. This provides HTTPS
-# termination via the ACME wildcard certificate, with access restricted to
-# the Tailscale network.
+# Registers the `journal.<domain>` DNS record when systemd-journal-remote is
+# active on this host. journal-remote now serves HTTPS directly (no nginx
+# proxy in the data path), so only the DNS A record is needed here.
 #
 # See conventions/tool.journal-remote.md
 # See specs/REQ-020-journal-remote/requirements.md
@@ -14,26 +13,23 @@
 }:
 let
   serverCfg = config.keystone.server;
+  domain = config.keystone.domain;
   journalRemoteActive = config.services.journald.remote.enable;
-  journalRemotePort = config.services.journald.remote.port;
 in
 {
-  config = lib.mkIf (serverCfg.enable && journalRemoteActive) {
-    keystone.server._enabledServices.journalRemote = {
-      subdomain = "journal";
-      port = journalRemotePort;
-      access = "tailscale";
-      maxBodySize = "0";
-      websockets = false;
-      registerDNS = true;
-    };
-
-    services.nginx.virtualHosts."journal.${config.keystone.domain}".locations."/".extraConfig = ''
-      # systemd-journal-upload sends a streaming request body; avoid buffering
-      # or downgrading the upstream request when proxying to journal-remote.
-      proxy_http_version 1.1;
-      proxy_request_buffering off;
-      proxy_buffering off;
-    '';
-  };
+  config =
+    lib.mkIf
+      (serverCfg.enable && journalRemoteActive && domain != null && serverCfg.tailscaleIP != null)
+      {
+        # Register a DNS A record for journal.<domain> so that upload clients can
+        # resolve the journal-remote endpoint. No nginx vhost is created — HTTPS is
+        # terminated directly by systemd-journal-remote using the ACME wildcard cert.
+        keystone.server.generatedDNSRecords = [
+          {
+            name = "journal.${domain}";
+            type = "A";
+            value = serverCfg.tailscaleIP;
+          }
+        ];
+      };
 }

--- a/modules/terminal/generated-agent-assets.nix
+++ b/modules/terminal/generated-agent-assets.nix
@@ -16,9 +16,23 @@ let
     if config.keystone ? os && config.keystone.os ? agents then config.keystone.os.agents else { };
   manifestRelPath = ".config/keystone/agent-assets.json";
   scriptRelPath = "modules/terminal/scripts/keystone-sync-agent-assets.sh";
-  scriptPackage = pkgs.writeShellScriptBin "keystone-sync-agent-assets" (
-    builtins.readFile ./scripts/keystone-sync-agent-assets.sh
-  );
+  scriptPackage =
+    let
+      scriptBin = pkgs.writeShellScriptBin "keystone-sync-agent-assets" (
+        builtins.readFile ./scripts/keystone-sync-agent-assets.sh
+      );
+      templates = pkgs.runCommandLocal "keystone-sync-agent-assets-templates" { } ''
+        mkdir -p $out/share/agent-assets
+        cp -r ${./agent-assets}/. $out/share/agent-assets/
+      '';
+    in
+    pkgs.symlinkJoin {
+      name = "keystone-sync-agent-assets";
+      paths = [
+        scriptBin
+        templates
+      ];
+    };
   agentsWithMcp = mapAttrs (name: agentCfg: {
     inherit (agentCfg) host archetype;
     notesPath = agentCfg.notes.path;
@@ -97,9 +111,11 @@ in
         }:$PATH"
         if [ -f "${syncScriptPath}" ]; then
           KEYSTONE_AGENT_ASSETS_MANIFEST="$HOME/${manifestRelPath}" \
+          KEYSTONE_AGENT_TEMPLATES_DIR="${scriptPackage}/share/agent-assets" \
             ${pkgs.bash}/bin/bash "${syncScriptPath}"
         else
           KEYSTONE_AGENT_ASSETS_MANIFEST="$HOME/${manifestRelPath}" \
+          KEYSTONE_AGENT_TEMPLATES_DIR="${scriptPackage}/share/agent-assets" \
             ${scriptPackage}/bin/keystone-sync-agent-assets
         fi
       '';

--- a/modules/terminal/scripts/keystone-sync-agent-assets.sh
+++ b/modules/terminal/scripts/keystone-sync-agent-assets.sh
@@ -287,20 +287,40 @@ repo_checkout="$(json_get '.repoCheckout')"
 archetype="$(json_get '.archetype')"
 development_mode="$(json_get '.developmentMode')"
 
-if [[ "$repo_checkout" == "null" || -z "$repo_checkout" ]]; then
-  echo "Error: manifest does not declare a live keystone repo checkout" >&2
+# Resolve templates_dir.
+# Priority: KEYSTONE_AGENT_TEMPLATES_DIR (Nix-store bundled) → live checkout → error.
+if [[ -n "${KEYSTONE_AGENT_TEMPLATES_DIR:-}" && -d "$KEYSTONE_AGENT_TEMPLATES_DIR" ]]; then
+  templates_dir="$KEYSTONE_AGENT_TEMPLATES_DIR"
+elif [[ "$repo_checkout" != "null" && -n "$repo_checkout" && -d "$repo_checkout/modules/terminal/agent-assets" ]]; then
+  templates_dir="$repo_checkout/modules/terminal/agent-assets"
+else
+  echo "Error: no templates directory found." >&2
+  if [[ -n "${KEYSTONE_AGENT_TEMPLATES_DIR:-}" ]]; then
+    echo "  KEYSTONE_AGENT_TEMPLATES_DIR=$KEYSTONE_AGENT_TEMPLATES_DIR (not found)" >&2
+  else
+    echo "  KEYSTONE_AGENT_TEMPLATES_DIR is not set" >&2
+  fi
+  if [[ "$repo_checkout" != "null" && -n "$repo_checkout" ]]; then
+    echo "  $repo_checkout/modules/terminal/agent-assets (not found)" >&2
+  else
+    echo "  repoCheckout not set in manifest" >&2
+  fi
   exit 1
 fi
 
-if [[ ! -d "$repo_checkout" ]]; then
-  repo_slug="${repo_checkout##*/.keystone/repos/}"
-  echo "Live keystone repo checkout not found at $repo_checkout — cloning $repo_slug..."
-  mkdir -p "$(dirname "$repo_checkout")"
-  git clone "https://github.com/$repo_slug.git" "$repo_checkout"
+# Resolve conventions_dir from live checkout or manifest fallback.
+if [[ "$repo_checkout" != "null" && -n "$repo_checkout" ]]; then
+  if [[ ! -d "$repo_checkout" ]]; then
+    repo_slug="${repo_checkout##*/.keystone/repos/}"
+    echo "Live keystone repo checkout not found at $repo_checkout — cloning $repo_slug..."
+    mkdir -p "$(dirname "$repo_checkout")"
+    git clone "https://github.com/$repo_slug.git" "$repo_checkout"
+  fi
+  conventions_dir="$repo_checkout/conventions"
+else
+  conventions_dir="$(json_get '.fallbackConventionsDir')"
 fi
 
-conventions_dir="$repo_checkout/conventions"
-templates_dir="$repo_checkout/modules/terminal/agent-assets"
 archetypes_file="$conventions_dir/archetypes.yaml"
 
 if [[ ! -f "$archetypes_file" ]]; then

--- a/tests/module/agent-task-loop-invalid-pending-task.nix
+++ b/tests/module/agent-task-loop-invalid-pending-task.nix
@@ -67,106 +67,106 @@ pkgs.runCommand "test-agent-task-loop-invalid-pending-task"
     ];
   }
   ''
-    set -euo pipefail
+        set -euo pipefail
 
-    export HOME="$PWD/home"
-    export TASK_LOOP_TEST_STATE_DIR="$PWD/state"
-    export PATH="$PWD/stubs:${
-      lib.makeBinPath [
-        pkgs.bash
-        pkgs.coreutils
-        pkgs.findutils
-        pkgs.gawk
-        pkgs.gnugrep
-        pkgs.gnused
-        pkgs.jq
-        pkgs.util-linux
-        pkgs.yq-go
-      ]
-    }"
+        export HOME="$PWD/home"
+        export TASK_LOOP_TEST_STATE_DIR="$PWD/state"
+        export PATH="$PWD/stubs:${
+          lib.makeBinPath [
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.findutils
+            pkgs.gawk
+            pkgs.gnugrep
+            pkgs.gnused
+            pkgs.jq
+            pkgs.util-linux
+            pkgs.yq-go
+          ]
+        }"
 
-    mkdir -p "$HOME" "$TASK_LOOP_TEST_STATE_DIR" "$PWD/stubs" ${notesDir}
+        mkdir -p "$HOME" "$TASK_LOOP_TEST_STATE_DIR" "$PWD/stubs" ${notesDir}
 
-    cat > ${notesDir}/TASKS.yaml <<'EOF'
-tasks:
-  - name: ""
-    description: "Malformed pending task"
-    status: pending
-    source: email
-    source_ref: "email-empty-name@test"
-  - name: "reply-pong-to-test"
-    description: "Reply with pong to the ping email from test@ncrmro.com"
-    status: pending
-    source: email
-    source_ref: "email-1-test@ncrmro.com"
-EOF
+        cat > ${notesDir}/TASKS.yaml <<'EOF'
+    tasks:
+      - name: ""
+        description: "Malformed pending task"
+        status: pending
+        source: email
+        source_ref: "email-empty-name@test"
+      - name: "reply-pong-to-test"
+        description: "Reply with pong to the ping email from test@ncrmro.com"
+        status: pending
+        source: email
+        source_ref: "email-1-test@ncrmro.com"
+    EOF
 
-    mkdir -p ${notesDir}/.deepwork
+        mkdir -p ${notesDir}/.deepwork
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/systemctl"
-    chmod +x "$PWD/stubs/systemctl"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/systemctl"
+        chmod +x "$PWD/stubs/systemctl"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/git"
-    chmod +x "$PWD/stubs/git"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'exit 0' > "$PWD/stubs/git"
+        chmod +x "$PWD/stubs/git"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' "printf '%s\\n' \"test-host\"" > "$PWD/stubs/hostname"
-    chmod +x "$PWD/stubs/hostname"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' "printf '%s\\n' \"test-host\"" > "$PWD/stubs/hostname"
+        chmod +x "$PWD/stubs/hostname"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/fetch-email-source"
-    chmod +x "$PWD/stubs/fetch-email-source"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/fetch-email-source"
+        chmod +x "$PWD/stubs/fetch-email-source"
 
-    printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/calendula"
-    chmod +x "$PWD/stubs/calendula"
+        printf '%s\n' '#!${pkgs.bash}/bin/bash' 'printf "%s\\n" "[]"' > "$PWD/stubs/calendula"
+        chmod +x "$PWD/stubs/calendula"
 
-    cat > "$PWD/stubs/claude" <<'STUBEOF'
-    #!${pkgs.bash}/bin/bash
-    set -euo pipefail
+        cat > "$PWD/stubs/claude" <<'STUBEOF'
+        #!${pkgs.bash}/bin/bash
+        set -euo pipefail
 
-    args="$*"
-    state_dir="''${TASK_LOOP_TEST_STATE_DIR:?}"
+        args="$*"
+        state_dir="''${TASK_LOOP_TEST_STATE_DIR:?}"
 
-    if printf '%s' "$args" | grep -q "task_loop prioritize"; then
-      printf '%s\n' "1" > "$state_dir/prioritize-count"
-    else
-      printf '%s\n' "1" > "$state_dir/execute-count"
-      printf '%s\n' "$args" > "$state_dir/execute-args"
-    fi
+        if printf '%s' "$args" | grep -q "task_loop prioritize"; then
+          printf '%s\n' "1" > "$state_dir/prioritize-count"
+        else
+          printf '%s\n' "1" > "$state_dir/execute-count"
+          printf '%s\n' "$args" > "$state_dir/execute-args"
+        fi
 
-    printf '%s\n' '{"total_tokens":1}'
-    STUBEOF
-    chmod +x "$PWD/stubs/claude"
+        printf '%s\n' '{"total_tokens":1}'
+        STUBEOF
+        chmod +x "$PWD/stubs/claude"
 
-    bash "${taskLoopScript}"
+        bash "${taskLoopScript}"
 
-    invalid_status="$(yq '[.tasks[] | select(.source_ref == "email-empty-name@test")] | .[0].status' ${notesDir}/TASKS.yaml)"
-    if [[ "$invalid_status" != "error" ]]; then
-      echo "FAIL: invalid pending task status is '$invalid_status', expected 'error'" >&2
-      cat ${notesDir}/TASKS.yaml >&2
-      exit 1
-    fi
-    echo "PASS: invalid pending task marked error"
+        invalid_status="$(yq '[.tasks[] | select(.source_ref == "email-empty-name@test")] | .[0].status' ${notesDir}/TASKS.yaml)"
+        if [[ "$invalid_status" != "error" ]]; then
+          echo "FAIL: invalid pending task status is '$invalid_status', expected 'error'" >&2
+          cat ${notesDir}/TASKS.yaml >&2
+          exit 1
+        fi
+        echo "PASS: invalid pending task marked error"
 
-    valid_status="$(yq '[.tasks[] | select(.source_ref == "email-1-test@ncrmro.com")] | .[0].status' ${notesDir}/TASKS.yaml)"
-    if [[ "$valid_status" != "completed" ]]; then
-      echo "FAIL: valid pending task status is '$valid_status', expected 'completed'" >&2
-      cat ${notesDir}/TASKS.yaml >&2
-      exit 1
-    fi
-    echo "PASS: valid pending task completed"
+        valid_status="$(yq '[.tasks[] | select(.source_ref == "email-1-test@ncrmro.com")] | .[0].status' ${notesDir}/TASKS.yaml)"
+        if [[ "$valid_status" != "completed" ]]; then
+          echo "FAIL: valid pending task status is '$valid_status', expected 'completed'" >&2
+          cat ${notesDir}/TASKS.yaml >&2
+          exit 1
+        fi
+        echo "PASS: valid pending task completed"
 
-    if [[ ! -f "$TASK_LOOP_TEST_STATE_DIR/execute-count" ]]; then
-      echo "FAIL: execute stage was not invoked" >&2
-      exit 1
-    fi
-    echo "PASS: execute stage invoked"
+        if [[ ! -f "$TASK_LOOP_TEST_STATE_DIR/execute-count" ]]; then
+          echo "FAIL: execute stage was not invoked" >&2
+          exit 1
+        fi
+        echo "PASS: execute stage invoked"
 
-    execute_args="$(cat "$TASK_LOOP_TEST_STATE_DIR/execute-args")"
-    if ! printf '%s' "$execute_args" | grep -qi "reply-pong-to-test"; then
-      echo "FAIL: execute stage did not receive the valid task name" >&2
-      echo "  execute args: $execute_args" >&2
-      exit 1
-    fi
-    echo "PASS: execute received valid task name"
+        execute_args="$(cat "$TASK_LOOP_TEST_STATE_DIR/execute-args")"
+        if ! printf '%s' "$execute_args" | grep -qi "reply-pong-to-test"; then
+          echo "FAIL: execute stage did not receive the valid task name" >&2
+          echo "  execute args: $execute_args" >&2
+          exit 1
+        fi
+        echo "PASS: execute received valid task name"
 
-    touch "$out"
+        touch "$out"
   ''


### PR DESCRIPTION
Fixes #278

## Summary

- Removes nginx from the journal upload data path — `systemd-journal-remote` now terminates HTTPS directly using the ACME wildcard certificate
- Client uploads go to `https://journal.<domain>:19532` instead of through nginx on port 443
- Remote journal files are now named `remote-<real-tailscale-ip>@...` instead of `remote-127.0.0.1@...`
- Firewall opens port 19532 on `tailscale0` only; no external exposure
- `systemd-journal-remote` service joins the `nginx` supplementary group to read ACME cert files (mode 640)
- Cert renewal hooks reload the service
- `server/services/journal-remote.nix` reduced to DNS-only registration (no nginx vhost)
- Convention doc and inline comments updated to describe the new architecture

## Test plan

- [ ] `systemd-journal-upload.service` active and stable on workstation after deployment
- [ ] `systemd-journal-remote.service` active and stable on Ocean after deployment
- [ ] New files under `/var/log/journal/remote/` named `remote-<tailscale-ip>@...` (not `127.0.0.1`)
- [ ] `journalctl --directory=/var/log/journal/remote/ -p err` returns results from remote hosts
- [ ] No new `417 Premature EOF` upload errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)