### PR TITLE
fix(installer): tighten RC bare-metal follow-ups

### DIFF
--- a/docs/testing/iso-os-virtual-machine.md
+++ b/docs/testing/iso-os-virtual-machine.md
@@ -180,8 +180,7 @@ This loop takes 2-3 minutes instead of 15+ minutes for a full reinstall.
 
 # SSH in and drive manually:
 ssh -i .test-iso-dev-key -p 12260 keystone@localhost
-ks install --host laptop   # preview disks and best guess
-ks install --host laptop --yes   # accept the best guess and erase it
+ks install --host laptop   # previews disks and asks you to type the target path
 ```
 
 Then use snapshot commands directly to save and restore checkpoints.
@@ -218,15 +217,15 @@ Skip the TUI entirely for automated testing:
 ```bash
 # On the live ISO (via SSH):
 ks install --host laptop
-ks install --host laptop --yes
 # or pin the disk explicitly:
-ks install --host laptop --disk /dev/disk/by-id/virtio-keystone-test-disk --yes
+ks install --host laptop --disk /dev/disk/by-id/virtio-keystone-test-disk
 ```
 
-Without `--yes`, the command prints discovered disks, a best guess, and a
-destructive warning. Passing `--yes` accepts that target. Use `--disk` to
-override the best guess with an explicit `/dev/disk/by-id/...` path. Exit code
-0 means success. The `--e2e` flag in `test-iso` uses this internally.
+The command prints discovered disks, highlights the selected target, and then
+requires you to type the exact `/dev/disk/by-id/...` path before it will erase
+the disk. If `--disk` is omitted, it shows a best guess first. Exit code 0
+means success. The `--e2e` flag in `test-iso` pipes the confirmation string
+into this prompt.
 
 ## Screenshot-based reboot validation
 
@@ -432,10 +431,11 @@ TERM=xterm-256color ks
 
 ### Automated TUI driving
 
-For scripted testing, `ks install --host laptop --yes` is preferred over
-driving the TUI with `expect` or FIFO-based key injection. The headless
-install reuses the same code paths (host selection, disk discovery, disko,
-nixos-install, handoff) without needing a PTY.
+For scripted testing, `ks install --host laptop` is preferred over driving the
+TUI with `expect` or FIFO-based key injection. The headless install reuses the
+same code paths (host selection, disk discovery, disko, nixos-install,
+handoff) without needing a PTY; automation can pipe the selected disk path into
+stdin to satisfy the confirmation prompt.
 
 If TUI-level regression testing is needed (verifying screen rendering,
 navigation, key bindings), use `ks --screenshot <screen>` which renders a

--- a/docs/testing/iso-os-virtual-machine.md
+++ b/docs/testing/iso-os-virtual-machine.md
@@ -180,7 +180,8 @@ This loop takes 2-3 minutes instead of 15+ minutes for a full reinstall.
 
 # SSH in and drive manually:
 ssh -i .test-iso-dev-key -p 12260 keystone@localhost
-ks install --host laptop   # or drive the TUI with: TERM=xterm-256color ks
+ks install --host laptop   # preview disks and best guess
+ks install --host laptop --yes   # accept the best guess and erase it
 ```
 
 Then use snapshot commands directly to save and restore checkpoints.
@@ -217,10 +218,15 @@ Skip the TUI entirely for automated testing:
 ```bash
 # On the live ISO (via SSH):
 ks install --host laptop
+ks install --host laptop --yes
+# or pin the disk explicitly:
+ks install --host laptop --disk /dev/disk/by-id/virtio-keystone-test-disk --yes
 ```
 
-This auto-discovers disks, selects the first one, and streams output to stderr.
-Exit code 0 means success. The `--e2e` flag in `test-iso` uses this internally.
+Without `--yes`, the command prints discovered disks, a best guess, and a
+destructive warning. Passing `--yes` accepts that target. Use `--disk` to
+override the best guess with an explicit `/dev/disk/by-id/...` path. Exit code
+0 means success. The `--e2e` flag in `test-iso` uses this internally.
 
 ## Screenshot-based reboot validation
 
@@ -426,9 +432,9 @@ TERM=xterm-256color ks
 
 ### Automated TUI driving
 
-For scripted testing, `ks install --host laptop` is preferred over driving
-the TUI with `expect` or FIFO-based key injection. The headless install
-reuses the same code paths (host selection, disk discovery, disko,
+For scripted testing, `ks install --host laptop --yes` is preferred over
+driving the TUI with `expect` or FIFO-based key injection. The headless
+install reuses the same code paths (host selection, disk discovery, disko,
 nixos-install, handoff) without needing a PTY.
 
 If TUI-level regression testing is needed (verifying screen rendering,

--- a/packages/ks/src/cli.rs
+++ b/packages/ks/src/cli.rs
@@ -150,7 +150,11 @@ pub struct InstallArgs {
 
     /// Target disk to install to (must match a discovered /dev/disk/by-id path).
     #[arg(long)]
-    pub disk: String,
+    pub disk: Option<String>,
+
+    /// Confirm the destructive install after disk selection is resolved.
+    #[arg(long)]
+    pub yes: bool,
 }
 
 #[derive(Args)]

--- a/packages/ks/src/cli.rs
+++ b/packages/ks/src/cli.rs
@@ -151,10 +151,6 @@ pub struct InstallArgs {
     /// Target disk to install to (must match a discovered /dev/disk/by-id path).
     #[arg(long)]
     pub disk: Option<String>,
-
-    /// Confirm the destructive install after disk selection is resolved.
-    #[arg(long)]
-    pub yes: bool,
 }
 
 #[derive(Args)]

--- a/packages/ks/src/cli.rs
+++ b/packages/ks/src/cli.rs
@@ -147,6 +147,10 @@ pub struct InstallArgs {
     /// Target host to install (must match an embedded installer target).
     #[arg(long)]
     pub host: String,
+
+    /// Target disk to install to (must match a discovered /dev/disk/by-id path).
+    #[arg(long)]
+    pub disk: String,
 }
 
 #[derive(Args)]

--- a/packages/ks/src/components/install.rs
+++ b/packages/ks/src/components/install.rs
@@ -12,6 +12,7 @@
 //! 6. **Done** — Prompt to remove USB and reboot
 
 use std::collections::BTreeMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command as StdCommand, Stdio};
 
@@ -994,29 +995,46 @@ fn build_headless_confirmation_message(
         ));
     }
 
-    lines.push(format!(
-        "This will erase all data on '{}'. Pass --yes to continue.",
-        selected_disk
-    ));
+    lines.push(format!("This will erase all data on '{}'.", selected_disk));
     lines.push(String::new());
     lines.push(format_available_disks(disks, Some(selected_disk)));
     lines.push(String::new());
-    lines.push("Re-run with:".to_string());
-    if disk_was_autoselected {
-        lines.push(format!("  ks install --host {} --yes", host));
-        lines.push("Or choose a different disk explicitly:".to_string());
-        lines.push(format!(
-            "  ks install --host {} --disk <disk-by-id-path> --yes",
-            host
-        ));
-    } else {
-        lines.push(format!(
-            "  ks install --host {} --disk {} --yes",
-            host, selected_disk
+    lines.push(format!(
+        "Type '{}' to confirm installation, or anything else to cancel.",
+        selected_disk
+    ));
+
+    lines.join("\n")
+}
+
+fn confirm_headless_install(
+    host: &str,
+    selected_disk: &str,
+    disk_was_autoselected: bool,
+    disks: &[DiskEntry],
+) -> Result<(), String> {
+    eprintln!(
+        "{}",
+        build_headless_confirmation_message(host, selected_disk, disk_was_autoselected, disks)
+    );
+    eprint!("Confirmation> ");
+    std::io::stderr()
+        .flush()
+        .map_err(|error| format!("Failed to flush confirmation prompt: {}", error))?;
+
+    let mut confirmation = String::new();
+    std::io::stdin()
+        .read_line(&mut confirmation)
+        .map_err(|error| format!("Failed to read confirmation: {}", error))?;
+
+    if confirmation.trim() != selected_disk {
+        return Err(format!(
+            "Install cancelled. Expected '{}' at the confirmation prompt.",
+            selected_disk
         ));
     }
 
-    lines.join("\n")
+    Ok(())
 }
 
 impl InstallScreen {
@@ -1144,13 +1162,9 @@ impl InstallScreen {
     }
 
     /// Run the install headlessly — no TUI. Resolves disk selection using the
-    /// same best-guess policy as the TUI, but requires explicit confirmation
-    /// before destructive actions proceed.
-    pub async fn run_headless(
-        &mut self,
-        disk_path: Option<&str>,
-        confirmed: bool,
-    ) -> Result<(), String> {
+    /// same best-guess policy as the TUI, then requires an explicit
+    /// confirmation prompt before destructive actions proceed.
+    pub async fn run_headless(&mut self, disk_path: Option<&str>) -> Result<(), String> {
         // Phase 1: select host (copies repo, vendors keystone input)
         self.select_host();
         if let InstallPhase::Failed(msg) = &self.phase {
@@ -1188,14 +1202,12 @@ impl InstallScreen {
             eprintln!("Using requested disk: {}", selected_disk);
         }
 
-        if !confirmed {
-            return Err(build_headless_confirmation_message(
-                &self.config.flake_host,
-                &selected_disk,
-                disk_was_autoselected,
-                &self.available_disks,
-            ));
-        }
+        confirm_headless_install(
+            &self.config.flake_host,
+            &selected_disk,
+            disk_was_autoselected,
+            &self.available_disks,
+        )?;
 
         eprintln!(
             "Installing host '{}' headlessly to '{}'...",
@@ -3220,7 +3232,7 @@ mod tests {
 
         assert!(message.contains("No --disk was provided for host 'laptop'."));
         assert!(message.contains("This will erase all data on '/dev/disk/by-id/nvme-best'."));
-        assert!(message.contains("ks install --host laptop --yes"));
+        assert!(message.contains("Type '/dev/disk/by-id/nvme-best' to confirm installation"));
     }
 
     #[test]

--- a/packages/ks/src/components/install.rs
+++ b/packages/ks/src/components/install.rs
@@ -1042,9 +1042,31 @@ impl InstallScreen {
         self.selected_host_index = index;
     }
 
-    /// Run the install headlessly — no TUI.  Selects the pre-set host and
-    /// first available disk, then streams output to stdout.
-    pub async fn run_headless(&mut self) -> Result<(), String> {
+    fn set_disk_by_path(&mut self, disk_path: &str) -> Result<(), String> {
+        let Some(index) = self
+            .available_disks
+            .iter()
+            .position(|disk| disk.by_id_path == disk_path)
+        else {
+            let available = self
+                .available_disks
+                .iter()
+                .map(|disk| disk.by_id_path.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(format!(
+                "Requested disk '{}' was not found. Available: {}",
+                disk_path, available
+            ));
+        };
+
+        self.selected_disk_index = index;
+        Ok(())
+    }
+
+    /// Run the install headlessly — no TUI. Selects the pre-set host and a
+    /// caller-provided disk, then streams output to stdout.
+    pub async fn run_headless(&mut self, disk_path: &str) -> Result<(), String> {
         // Phase 1: select host (copies repo, vendors keystone input)
         self.select_host();
         if let InstallPhase::Failed(msg) = &self.phase {
@@ -1059,12 +1081,13 @@ impl InstallScreen {
         if disks.is_empty() {
             return Err("No disks found".to_string());
         }
+        self.available_disks = disks;
+        self.set_disk_by_path(disk_path)?;
         eprintln!(
             "Found {} disk(s), selecting: {}",
-            disks.len(),
-            disks[0].by_id_path
+            self.available_disks.len(),
+            self.available_disks[self.selected_disk_index].by_id_path
         );
-        self.available_disks = disks;
         self.phase = InstallPhase::DiskSelection;
         self.select_disk();
         if let InstallPhase::Failed(msg) = &self.phase {
@@ -3000,6 +3023,50 @@ mod tests {
 
         screen.poll();
         assert_eq!(screen.selected_disk_index(), 1);
+    }
+
+    #[test]
+    fn test_set_disk_by_path_selects_requested_disk() {
+        let mut screen = InstallScreen::new(test_config_no_disk());
+        screen.available_disks = vec![
+            DiskEntry {
+                by_id_path: "/dev/disk/by-id/ata-other".to_string(),
+                model: "Other Disk".to_string(),
+                size: "1T".to_string(),
+                transport: "sata".to_string(),
+            },
+            DiskEntry {
+                by_id_path: "/dev/disk/by-id/virtio-keystone-test-disk".to_string(),
+                model: "Fixture Disk".to_string(),
+                size: "64G".to_string(),
+                transport: "virtio".to_string(),
+            },
+        ];
+
+        screen
+            .set_disk_by_path("/dev/disk/by-id/virtio-keystone-test-disk")
+            .unwrap();
+
+        assert_eq!(screen.selected_disk_index(), 1);
+    }
+
+    #[test]
+    fn test_set_disk_by_path_errors_when_requested_disk_missing() {
+        let mut screen = InstallScreen::new(test_config_no_disk());
+        screen.available_disks = vec![DiskEntry {
+            by_id_path: "/dev/disk/by-id/ata-other".to_string(),
+            model: "Other Disk".to_string(),
+            size: "1T".to_string(),
+            transport: "sata".to_string(),
+        }];
+
+        let error = screen
+            .set_disk_by_path("/dev/disk/by-id/virtio-keystone-test-disk")
+            .unwrap_err();
+
+        assert!(error
+            .contains("Requested disk '/dev/disk/by-id/virtio-keystone-test-disk' was not found."));
+        assert!(error.contains("/dev/disk/by-id/ata-other"));
     }
 
     #[test]

--- a/packages/ks/src/components/install.rs
+++ b/packages/ks/src/components/install.rs
@@ -943,6 +943,82 @@ pub struct InstallScreen {
     discovering_disks: bool,
 }
 
+fn preferred_disk_index(disks: &[DiskEntry], preferred_disk: Option<&str>) -> usize {
+    preferred_disk
+        .and_then(|path| disks.iter().position(|disk| disk.by_id_path == path))
+        .unwrap_or(0)
+}
+
+fn format_disk_summary(disk: &DiskEntry) -> String {
+    let mut details = vec![disk.model.clone(), disk.size.clone()];
+    if !disk.transport.is_empty() {
+        details.push(disk.transport.clone());
+    }
+
+    format!("{} ({})", disk.by_id_path, details.join(", "))
+}
+
+fn format_available_disks(disks: &[DiskEntry], selected_disk: Option<&str>) -> String {
+    if disks.is_empty() {
+        return "Discovered disks: none".to_string();
+    }
+
+    let mut lines = vec!["Discovered disks:".to_string()];
+    for disk in disks {
+        let marker = if selected_disk.is_some_and(|path| path == disk.by_id_path) {
+            "*"
+        } else {
+            "-"
+        };
+        lines.push(format!("  {} {}", marker, format_disk_summary(disk)));
+    }
+
+    lines.join("\n")
+}
+
+fn build_headless_confirmation_message(
+    host: &str,
+    selected_disk: &str,
+    disk_was_autoselected: bool,
+    disks: &[DiskEntry],
+) -> String {
+    let mut lines = Vec::new();
+
+    if disk_was_autoselected {
+        lines.push(format!("No --disk was provided for host '{}'.", host));
+        lines.push(format!("Best guess: {}", selected_disk));
+    } else {
+        lines.push(format!(
+            "Headless install is ready for host '{}' on '{}'.",
+            host, selected_disk
+        ));
+    }
+
+    lines.push(format!(
+        "This will erase all data on '{}'. Pass --yes to continue.",
+        selected_disk
+    ));
+    lines.push(String::new());
+    lines.push(format_available_disks(disks, Some(selected_disk)));
+    lines.push(String::new());
+    lines.push("Re-run with:".to_string());
+    if disk_was_autoselected {
+        lines.push(format!("  ks install --host {} --yes", host));
+        lines.push("Or choose a different disk explicitly:".to_string());
+        lines.push(format!(
+            "  ks install --host {} --disk <disk-by-id-path> --yes",
+            host
+        ));
+    } else {
+        lines.push(format!(
+            "  ks install --host {} --disk {} --yes",
+            host, selected_disk
+        ));
+    }
+
+    lines.join("\n")
+}
+
 impl InstallScreen {
     pub fn new(config: InstallerConfig) -> Self {
         let (phase, available_hosts) = match &config.source {
@@ -1048,15 +1124,18 @@ impl InstallScreen {
             .iter()
             .position(|disk| disk.by_id_path == disk_path)
         else {
-            let available = self
+            let best_guess = self
                 .available_disks
-                .iter()
-                .map(|disk| disk.by_id_path.as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
+                .get(preferred_disk_index(
+                    &self.available_disks,
+                    self.config.disk_device.as_deref(),
+                ))
+                .map(|disk| disk.by_id_path.as_str());
             return Err(format!(
-                "Requested disk '{}' was not found. Available: {}",
-                disk_path, available
+                "Requested disk '{}' was not found.\n{}\nBest guess: {}",
+                disk_path,
+                format_available_disks(&self.available_disks, best_guess),
+                best_guess.unwrap_or("none")
             ));
         };
 
@@ -1064,9 +1143,14 @@ impl InstallScreen {
         Ok(())
     }
 
-    /// Run the install headlessly — no TUI. Selects the pre-set host and a
-    /// caller-provided disk, then streams output to stdout.
-    pub async fn run_headless(&mut self, disk_path: &str) -> Result<(), String> {
+    /// Run the install headlessly — no TUI. Resolves disk selection using the
+    /// same best-guess policy as the TUI, but requires explicit confirmation
+    /// before destructive actions proceed.
+    pub async fn run_headless(
+        &mut self,
+        disk_path: Option<&str>,
+        confirmed: bool,
+    ) -> Result<(), String> {
         // Phase 1: select host (copies repo, vendors keystone input)
         self.select_host();
         if let InstallPhase::Failed(msg) = &self.phase {
@@ -1082,11 +1166,40 @@ impl InstallScreen {
             return Err("No disks found".to_string());
         }
         self.available_disks = disks;
-        self.set_disk_by_path(disk_path)?;
+        let disk_was_autoselected = if let Some(disk_path) = disk_path {
+            self.set_disk_by_path(disk_path)?;
+            false
+        } else {
+            self.selected_disk_index =
+                preferred_disk_index(&self.available_disks, self.config.disk_device.as_deref());
+            true
+        };
+        let selected_disk = self.available_disks[self.selected_disk_index]
+            .by_id_path
+            .clone();
+        eprintln!("Found {} disk(s).", self.available_disks.len(),);
+        if disk_was_autoselected {
+            eprintln!(
+                "{}",
+                format_available_disks(&self.available_disks, Some(&selected_disk))
+            );
+            eprintln!("Best guess: {}", selected_disk);
+        } else {
+            eprintln!("Using requested disk: {}", selected_disk);
+        }
+
+        if !confirmed {
+            return Err(build_headless_confirmation_message(
+                &self.config.flake_host,
+                &selected_disk,
+                disk_was_autoselected,
+                &self.available_disks,
+            ));
+        }
+
         eprintln!(
-            "Found {} disk(s), selecting: {}",
-            self.available_disks.len(),
-            self.available_disks[self.selected_disk_index].by_id_path
+            "Installing host '{}' headlessly to '{}'...",
+            self.config.flake_host, selected_disk
         );
         self.phase = InstallPhase::DiskSelection;
         self.select_disk();
@@ -1471,16 +1584,11 @@ impl InstallScreen {
                 }
                 InstallMessage::DisksDiscovered(disks) => {
                     self.available_disks = disks;
-                    self.selected_disk_index = 0;
-                    if let Some(preconfigured_disk) = self.config.disk_device.as_deref() {
-                        if let Some((index, _)) = self
-                            .available_disks
-                            .iter()
-                            .enumerate()
-                            .find(|(_, disk)| disk.by_id_path == preconfigured_disk)
-                        {
-                            self.selected_disk_index = index;
-                        }
+                    if !self.available_disks.is_empty() {
+                        self.selected_disk_index = preferred_disk_index(
+                            &self.available_disks,
+                            self.config.disk_device.as_deref(),
+                        );
                     }
                     self.discovering_disks = false;
                 }
@@ -3026,6 +3134,30 @@ mod tests {
     }
 
     #[test]
+    fn test_preferred_disk_index_falls_back_to_first_disk() {
+        let disks = vec![
+            DiskEntry {
+                by_id_path: "/dev/disk/by-id/nvme-first".to_string(),
+                model: "Fast Disk".to_string(),
+                size: "1T".to_string(),
+                transport: "nvme".to_string(),
+            },
+            DiskEntry {
+                by_id_path: "/dev/disk/by-id/ata-second".to_string(),
+                model: "Slow Disk".to_string(),
+                size: "2T".to_string(),
+                transport: "sata".to_string(),
+            },
+        ];
+
+        assert_eq!(preferred_disk_index(&disks, None), 0);
+        assert_eq!(
+            preferred_disk_index(&disks, Some("/dev/disk/by-id/missing")),
+            0
+        );
+    }
+
+    #[test]
     fn test_set_disk_by_path_selects_requested_disk() {
         let mut screen = InstallScreen::new(test_config_no_disk());
         screen.available_disks = vec![
@@ -3066,7 +3198,29 @@ mod tests {
 
         assert!(error
             .contains("Requested disk '/dev/disk/by-id/virtio-keystone-test-disk' was not found."));
-        assert!(error.contains("/dev/disk/by-id/ata-other"));
+        assert!(error.contains("Discovered disks:"));
+        assert!(error.contains("Best guess: /dev/disk/by-id/ata-other"));
+    }
+
+    #[test]
+    fn test_build_headless_confirmation_message_for_auto_selected_disk() {
+        let disks = vec![DiskEntry {
+            by_id_path: "/dev/disk/by-id/nvme-best".to_string(),
+            model: "Best Disk".to_string(),
+            size: "2T".to_string(),
+            transport: "nvme".to_string(),
+        }];
+
+        let message = build_headless_confirmation_message(
+            "laptop",
+            "/dev/disk/by-id/nvme-best",
+            true,
+            &disks,
+        );
+
+        assert!(message.contains("No --disk was provided for host 'laptop'."));
+        assert!(message.contains("This will erase all data on '/dev/disk/by-id/nvme-best'."));
+        assert!(message.contains("ks install --host laptop --yes"));
     }
 
     #[test]

--- a/packages/ks/src/components/install.rs
+++ b/packages/ks/src/components/install.rs
@@ -154,7 +154,7 @@ impl InstallerConfig {
             Self::parse_configuration_nix(&effective_dir).unwrap_or((None, None));
 
         // Treat the placeholder as "no disk configured"
-        let disk_device = disk_device.filter(|d| d != "__KEYSTONE_DISK__");
+        let disk_device = disk_device.filter(|d| d != crate::template::DISK_PLACEHOLDER);
 
         Ok(Some(Self {
             source: InstallSource::PrebakedConfig,
@@ -671,6 +671,26 @@ fn push_unique(values: &mut Vec<String>, candidate: String) {
     }
 }
 
+fn is_placeholder_host_id(host_id: &str) -> bool {
+    host_id == crate::template::HOST_ID_PLACEHOLDER
+}
+
+fn is_valid_host_id(host_id: &str) -> bool {
+    host_id.len() == 8
+        && host_id.chars().all(|ch| ch.is_ascii_hexdigit())
+        && !is_placeholder_host_id(host_id)
+}
+
+fn resolve_install_host_id(current_hardware_nix: &str) -> String {
+    parse_nix_string_assignment(current_hardware_nix, "networking.hostId")
+        .filter(|host_id| is_valid_host_id(host_id))
+        .unwrap_or_else(crate::template::generate_host_id)
+}
+
+fn is_placeholder_storage_device(device: &str) -> bool {
+    device == crate::template::DISK_PLACEHOLDER || device.contains("YOUR-")
+}
+
 fn parse_nix_string_assignment(content: &str, attr: &str) -> Option<String> {
     content.lines().find_map(|line| {
         let trimmed = line.trim();
@@ -809,10 +829,12 @@ fn build_reconciled_hardware_wrapper(
 ) -> Result<String, String> {
     let system = parse_nix_string_assignment(current_hardware_nix, "system")
         .unwrap_or_else(|| "x86_64-linux".to_string());
-    let host_id = parse_nix_string_assignment(current_hardware_nix, "networking.hostId")
-        .unwrap_or_else(|| "00000000".to_string());
+    let host_id = resolve_install_host_id(current_hardware_nix);
     let mut storage_devices =
-        parse_nix_string_list_assignment(current_hardware_nix, "keystone.os.storage.devices");
+        parse_nix_string_list_assignment(current_hardware_nix, "keystone.os.storage.devices")
+            .into_iter()
+            .filter(|device| !is_placeholder_storage_device(device))
+            .collect::<Vec<_>>();
     if storage_devices.is_empty() {
         if let Some(device) = selected_disk {
             storage_devices.push(device.to_string());
@@ -1296,8 +1318,9 @@ impl InstallScreen {
         }
 
         let hardware_path = writable_repo.join(&selected.hardware_path);
-        let disk_device = parse_hardware_disk_device(&hardware_path)
-            .filter(|path| path.contains("/dev/disk/by-id/") && !path.contains("YOUR-"));
+        let disk_device = parse_hardware_disk_device(&hardware_path).filter(|path| {
+            path.contains("/dev/disk/by-id/") && !is_placeholder_storage_device(path)
+        });
 
         self.config.config_dir = writable_repo;
         self.config.flake_host = selected.flake_host;
@@ -2167,6 +2190,26 @@ async fn git_config_get(repo_dir: &Path, key: &str) -> Result<Option<String>, St
     }
 }
 
+async fn git_remote_get_url(repo_dir: &Path, remote: &str) -> Result<Option<String>, String> {
+    let output = Command::new("git")
+        .args(["remote", "get-url", remote])
+        .current_dir(repo_dir)
+        .output()
+        .await
+        .map_err(|e| format!("Failed to inspect git remote {remote}: {e}"))?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(value))
+    }
+}
+
 async fn ensure_git_identity(repo_dir: &Path, username: &str) -> Result<(), String> {
     if git_config_get(repo_dir, "user.name").await?.is_none() {
         run_command_quiet(
@@ -2375,7 +2418,75 @@ async fn create_install_commit(
         "Recorded local install commit.".to_string(),
     ));
 
+    push_install_commit(config_dir, tx).await;
+
     Ok(())
+}
+
+async fn push_install_commit(config_dir: &Path, tx: &mpsc::UnboundedSender<InstallMessage>) {
+    match git_remote_get_url(config_dir, "origin").await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            let _ = tx.send(InstallMessage::Output(
+                "No origin remote configured; leaving install commit local.".to_string(),
+            ));
+            return;
+        }
+        Err(error) => {
+            let _ = tx.send(InstallMessage::Output(format!(
+                "Warning: failed to inspect git remote origin: {}",
+                error
+            )));
+            return;
+        }
+    }
+
+    let _ = tx.send(InstallMessage::Output(
+        "Attempting to push install commit to origin/main...".to_string(),
+    ));
+
+    let output = match Command::new("git")
+        .args(["push", "-u", "origin", "main"])
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env(
+            "GIT_SSH_COMMAND",
+            "ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new",
+        )
+        .current_dir(config_dir)
+        .output()
+        .await
+    {
+        Ok(output) => output,
+        Err(error) => {
+            let _ = tx.send(InstallMessage::Output(format!(
+                "Warning: failed to start git push: {}",
+                error
+            )));
+            return;
+        }
+    };
+
+    if output.status.success() {
+        let _ = tx.send(InstallMessage::Output(
+            "Pushed install commit to origin/main.".to_string(),
+        ));
+        return;
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let details = if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        "no output".to_string()
+    };
+
+    let _ = tx.send(InstallMessage::Output(format!(
+        "Warning: failed to push install commit to origin/main: {}",
+        details
+    )));
 }
 
 /// Copy the prepared config to the installed system for the post-install onboarding flow.
@@ -3353,6 +3464,30 @@ in
         let reconciled =
             build_reconciled_hardware_wrapper(current, Some("/dev/disk/by-id/fallback")).unwrap();
 
+        assert!(reconciled.contains("\"/dev/disk/by-id/fallback\""));
+    }
+
+    #[test]
+    fn test_build_reconciled_hardware_wrapper_generates_host_id_from_placeholder() {
+        let current = r#"let
+  system = "x86_64-linux";
+in
+{
+  inherit system;
+
+  module = { ... }: {
+    networking.hostId = "00000000";
+    keystone.os.storage.devices = [
+      "__KEYSTONE_DISK__"
+    ];
+  };
+}
+"#;
+
+        let reconciled =
+            build_reconciled_hardware_wrapper(current, Some("/dev/disk/by-id/fallback")).unwrap();
+
+        assert!(!reconciled.contains("networking.hostId = \"00000000\";"));
         assert!(reconciled.contains("\"/dev/disk/by-id/fallback\""));
     }
 

--- a/packages/ks/src/main.rs
+++ b/packages/ks/src/main.rs
@@ -92,9 +92,7 @@ async fn main() -> Result<()> {
             Command::Print { args } => run_print_command(args).await,
             Command::Agent(args) => run_agent_command(args).await,
             Command::Doctor(args) => run_doctor_command(args).await,
-            Command::Install(args) => {
-                run_headless_install(&args.host, args.disk.as_deref(), args.yes).await
-            }
+            Command::Install(args) => run_headless_install(&args.host, args.disk.as_deref()).await,
         };
     }
 
@@ -127,8 +125,8 @@ async fn main() -> Result<()> {
 }
 
 /// Run the installer headlessly for a specific host, optionally selecting a
-/// target disk before an explicit destructive confirmation.
-async fn run_headless_install(host: &str, disk: Option<&str>, confirmed: bool) -> Result<()> {
+/// target disk before an explicit destructive confirmation prompt.
+async fn run_headless_install(host: &str, disk: Option<&str>) -> Result<()> {
     use components::install::InstallScreen;
 
     let installer_config = InstallerConfig::detect()?.ok_or_else(|| {
@@ -158,7 +156,7 @@ async fn run_headless_install(host: &str, disk: Option<&str>, confirmed: bool) -
     screen.set_host_index(host_idx);
 
     screen
-        .run_headless(disk, confirmed)
+        .run_headless(disk)
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))
 }

--- a/packages/ks/src/main.rs
+++ b/packages/ks/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
             Command::Print { args } => run_print_command(args).await,
             Command::Agent(args) => run_agent_command(args).await,
             Command::Doctor(args) => run_doctor_command(args).await,
-            Command::Install(args) => run_headless_install(&args.host).await,
+            Command::Install(args) => run_headless_install(&args.host, &args.disk).await,
         };
     }
 
@@ -124,9 +124,8 @@ async fn main() -> Result<()> {
     result
 }
 
-/// Run the installer headlessly for a specific host, streaming output to stderr.
-/// No TUI — auto-selects the first available disk.
-async fn run_headless_install(host: &str) -> Result<()> {
+/// Run the installer headlessly for a specific host and target disk, streaming output to stderr.
+async fn run_headless_install(host: &str, disk: &str) -> Result<()> {
     use components::install::InstallScreen;
 
     let installer_config = InstallerConfig::detect()?.ok_or_else(|| {
@@ -150,13 +149,13 @@ async fn run_headless_install(host: &str) -> Result<()> {
             )
         })?;
 
-    eprintln!("Installing host '{}' headlessly...", host);
+    eprintln!("Installing host '{}' headlessly to '{}'...", host, disk);
 
     let mut screen = InstallScreen::new(installer_config);
     screen.set_host_index(host_idx);
 
     screen
-        .run_headless()
+        .run_headless(disk)
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))
 }

--- a/packages/ks/src/main.rs
+++ b/packages/ks/src/main.rs
@@ -92,7 +92,9 @@ async fn main() -> Result<()> {
             Command::Print { args } => run_print_command(args).await,
             Command::Agent(args) => run_agent_command(args).await,
             Command::Doctor(args) => run_doctor_command(args).await,
-            Command::Install(args) => run_headless_install(&args.host, &args.disk).await,
+            Command::Install(args) => {
+                run_headless_install(&args.host, args.disk.as_deref(), args.yes).await
+            }
         };
     }
 
@@ -124,8 +126,9 @@ async fn main() -> Result<()> {
     result
 }
 
-/// Run the installer headlessly for a specific host and target disk, streaming output to stderr.
-async fn run_headless_install(host: &str, disk: &str) -> Result<()> {
+/// Run the installer headlessly for a specific host, optionally selecting a
+/// target disk before an explicit destructive confirmation.
+async fn run_headless_install(host: &str, disk: Option<&str>, confirmed: bool) -> Result<()> {
     use components::install::InstallScreen;
 
     let installer_config = InstallerConfig::detect()?.ok_or_else(|| {
@@ -149,13 +152,13 @@ async fn run_headless_install(host: &str, disk: &str) -> Result<()> {
             )
         })?;
 
-    eprintln!("Installing host '{}' headlessly to '{}'...", host, disk);
+    eprintln!("Preparing headless install for host '{}'...", host);
 
     let mut screen = InstallScreen::new(installer_config);
     screen.set_host_index(host_idx);
 
     screen
-        .run_headless(disk)
+        .run_headless(disk, confirmed)
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))
 }

--- a/packages/ks/src/template.rs
+++ b/packages/ks/src/template.rs
@@ -3,6 +3,9 @@
 //! Generates flake.nix, configuration.nix, and hardware.nix from
 //! user-provided configuration parameters.
 
+pub(crate) const DISK_PLACEHOLDER: &str = "__KEYSTONE_DISK__";
+pub(crate) const HOST_ID_PLACEHOLDER: &str = "00000000";
+
 /// Machine type determines which Keystone modules are included.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MachineType {
@@ -252,7 +255,7 @@ pub fn generate_iso_flake_nix(config: &GenerateConfig) -> String {
 /// boot modules, and firmware settings.
 pub fn generate_hardware_nix(config: &GenerateConfig) -> String {
     let host_id = generate_host_id();
-    let raw_disk = config.disk_device.as_deref().unwrap_or("__KEYSTONE_DISK__");
+    let raw_disk = config.disk_device.as_deref().unwrap_or(DISK_PLACEHOLDER);
     let disk_device = escape_nix_string(raw_disk);
 
     format!(
@@ -313,7 +316,7 @@ in
 }
 
 /// Generate a random 8-character hex host ID.
-fn generate_host_id() -> String {
+pub(crate) fn generate_host_id() -> String {
     use std::io::Read;
     let mut buf = [0u8; 4];
     if let Ok(mut f) = std::fs::File::open("/dev/urandom") {

--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -29,7 +29,9 @@ Fill in:
 - `owner.email` in `flake.nix`
 - `defaults.timeZone` in `flake.nix`
 - hostnames in `flake.nix` if `laptop`, `server-ocean`, or `macbook` should be renamed
-- `system`, `networking.hostId`, and `keystone.os.storage.devices` in Linux `hardware.nix` files
+- `system` in Linux `hardware.nix` files if the default architecture is wrong
+- `networking.hostId` only if you are not using `ks install`
+- `keystone.os.storage.devices` only if you are not using `ks install`
 
 ## File layout
 

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -254,12 +254,12 @@ ssh_cmd() {
         "${ADMIN_USERNAME}@localhost" "$@"
 }
 
-# Run the headless installer via `ks install --host --disk`.
+# Run the headless installer via `ks install --host --disk --yes`.
 run_e2e_installer() {
     local host="${E2E_HOST:-laptop}"
     log_info "E2E: running headless install for host '$host' on '$E2E_DISK_DEVICE'"
-    if ! ssh_cmd "ks install --host $host --disk $E2E_DISK_DEVICE" 2>&1; then
-        log_error "E2E: ks install --host $host --disk $E2E_DISK_DEVICE failed"
+    if ! ssh_cmd "ks install --host $host --disk $E2E_DISK_DEVICE --yes" 2>&1; then
+        log_error "E2E: ks install --host $host --disk $E2E_DISK_DEVICE --yes failed"
         return 1
     fi
     log_ok "E2E: install completed for host '$host'"

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -254,12 +254,12 @@ ssh_cmd() {
         "${ADMIN_USERNAME}@localhost" "$@"
 }
 
-# Run the headless installer via `ks install --host`.
+# Run the headless installer via `ks install --host --disk`.
 run_e2e_installer() {
     local host="${E2E_HOST:-laptop}"
-    log_info "E2E: running headless install for host '$host'"
-    if ! ssh_cmd "ks install --host $host" 2>&1; then
-        log_error "E2E: ks install --host $host failed"
+    log_info "E2E: running headless install for host '$host' on '$E2E_DISK_DEVICE'"
+    if ! ssh_cmd "ks install --host $host --disk $E2E_DISK_DEVICE" 2>&1; then
+        log_error "E2E: ks install --host $host --disk $E2E_DISK_DEVICE failed"
         return 1
     fi
     log_ok "E2E: install completed for host '$host'"
@@ -269,6 +269,7 @@ E2E_SCREENSHOT_DIR=""
 E2E_MONITOR_SOCK=""
 E2E_REBOOT_TIMEOUT=180    # seconds to wait for SSH after unlock
 E2E_DISK_PASSWORD="keystone"
+E2E_DISK_DEVICE="${E2E_DISK_DEVICE:-/dev/disk/by-id/virtio-keystone-test-disk}"
 
 # Take a screenshot via QEMU monitor screendump (headless/llvmpipe) or
 # grim over SSH (headed/virgl where screendump returns "no surface").
@@ -356,6 +357,7 @@ verify_imagemagick_available() {
 # The VM must already be running (started via --post-install-reboot).
 run_e2e_reboot_validation() {
     local ref_dir="${PROJECT_DIR}/tests/e2e/screenshots"
+    local failed=0
 
     log_info "E2E: validating rebooted installed system"
 
@@ -410,13 +412,13 @@ run_e2e_reboot_validation() {
     if [[ "$ssh_ok" == "true" ]]; then
         log_ok "E2E: SSH to installed system succeeded"
     else
-        log_warn "E2E: SSH to installed system failed (may be QEMU GPU/desktop issue)"
+        log_error "E2E: SSH to installed system failed"
+        failed=1
     fi
 
     e2e_screenshot "05-final-state"
 
     # Req 5: compare screenshots against LFS baselines (SHA-256 in pointer files)
-    local failed=0
     local has_baselines=false
     if [[ -d "$ref_dir" ]] && ls "$ref_dir"/*.png "$ref_dir"/*.ppm 2>/dev/null | grep -q .; then
         has_baselines=true
@@ -458,7 +460,7 @@ run_e2e_reboot_validation() {
     rm -f "$E2E_MONITOR_SOCK"
 
     if (( failed )); then
-        log_error "E2E: reboot validation FAILED — screenshot mismatches"
+        log_error "E2E: reboot validation FAILED — one or more checks failed"
         return 1
     fi
 
@@ -904,10 +906,10 @@ if [[ "$E2E_MODE" == "true" ]]; then
     "$VM_SCRIPT" "${reboot_args[@]}"
 
     # Req 3: verify snapshot was created by post-install-reboot
-    verify_post_install_snapshot "$VM_DISK_PATH" || true
+    verify_post_install_snapshot "$VM_DISK_PATH"
 
     # Req 4: check imagemagick before screenshot capture
-    verify_imagemagick_available || true
+    verify_imagemagick_available
 
     if run_e2e_reboot_validation; then
         log_ok "E2E: all layers passed."

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -254,12 +254,13 @@ ssh_cmd() {
         "${ADMIN_USERNAME}@localhost" "$@"
 }
 
-# Run the headless installer via `ks install --host --disk --yes`.
+# Run the headless installer via `ks install --host --disk` and feed the
+# required destructive confirmation over stdin.
 run_e2e_installer() {
     local host="${E2E_HOST:-laptop}"
     log_info "E2E: running headless install for host '$host' on '$E2E_DISK_DEVICE'"
-    if ! ssh_cmd "ks install --host $host --disk $E2E_DISK_DEVICE --yes" 2>&1; then
-        log_error "E2E: ks install --host $host --disk $E2E_DISK_DEVICE --yes failed"
+    if ! ssh_cmd "printf '%s\n' '$E2E_DISK_DEVICE' | ks install --host $host --disk $E2E_DISK_DEVICE" 2>&1; then
+        log_error "E2E: ks install --host $host --disk $E2E_DISK_DEVICE failed"
         return 1
     fi
     log_ok "E2E: install completed for host '$host'"

--- a/templates/default/flake.lock
+++ b/templates/default/flake.lock
@@ -270,11 +270,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1774975369,
-        "narHash": "sha256-WMYdpx9e8iFdNhm7q+EQWW4qqhjYb5FlNtWRYQ6PW8U=",
+        "lastModified": 1775850562,
+        "narHash": "sha256-SAJJTjKA75zSyTcfC+AVDV95Tam0rrjFWqm7fKLVtz8=",
         "owner": "Unsupervisedcom",
         "repo": "deepwork",
-        "rev": "dbf070fa239f59fd8b23589b7c61f28d620be540",
+        "rev": "92d8c661cfe8a7a65c5947dd2ae78bf633538f04",
         "type": "github"
       },
       "original": {
@@ -1100,10 +1100,12 @@
         "yazi": "yazi"
       },
       "locked": {
-        "lastModified": 1775949504,
-        "narHash": "sha256-jz9gRHl5UeyKYWc49k4Asfsigr4uj9LzQaDeIrJDz3w=",
-        "path": "/home/ncrmro/.worktrees/ncrmro/keystone/feat/installer-handoff",
-        "type": "path"
+        "lastModified": 1775952991,
+        "narHash": "sha256-RhA8sCSh534wrPE9xKTqMF+OWXEogVwZU4ZYbGjYiZk=",
+        "owner": "ncrmro",
+        "repo": "keystone",
+        "rev": "9fd2ac93947c05d512ba070d96a06916ed8b1487",
+        "type": "github"
       },
       "original": {
         "owner": "ncrmro",

--- a/templates/default/hosts/laptop/hardware.nix
+++ b/templates/default/hosts/laptop/hardware.nix
@@ -36,15 +36,18 @@ in
       # Machine identity and storage facts
       # ──────────────────────────────────────────────────────────────────────────
 
-      # Required for ZFS - unique 8-character hex string
-      # Generate with: head -c 4 /dev/urandom | od -A none -t x4 | tr -d ' '
-      networking.hostId = "00000000"; # TODO: Generate and replace this value
+      # Required for ZFS - unique 8-character hex string.
+      # `ks install` replaces this placeholder automatically during the first
+      # install commit if you leave it unchanged.
+      networking.hostId = "00000000";
 
-      # Disk device(s) - ALWAYS use /dev/disk/by-id/ paths for stability
-      # Find your disk IDs with: ls -la /dev/disk/by-id/
-      # Example: /dev/disk/by-id/nvme-Samsung_SSD_980_PRO_2TB_S6B0NL0W127373V
+      # Root disk(s) - `ks install` replaces this placeholder automatically
+      # with the disk you confirm in the installer flow.
       keystone.os.storage.devices = [
-        "/dev/disk/by-id/YOUR-DISK-ID-HERE" # TODO: Replace with your disk ID
+        "__KEYSTONE_DISK__"
+        # Add your own stable /dev/disk/by-id/... paths here if you are not
+        # using the installer flow:
+        # "/dev/disk/by-id/nvme-Samsung_SSD_980_PRO_2TB_S6B0NL0W127373V"
         # Add more disks for multi-disk configurations:
         # "/dev/disk/by-id/YOUR-SECOND-DISK-ID"
       ];

--- a/templates/default/hosts/server-ocean/hardware.nix
+++ b/templates/default/hosts/server-ocean/hardware.nix
@@ -32,12 +32,18 @@ in
         (modulesPath + "/profiles/qemu-guest.nix")
       ];
 
-      # Required for ZFS - unique 8-character hex string
-      networking.hostId = "00000000"; # TODO: Generate and replace this value
+      # Required for ZFS - unique 8-character hex string.
+      # `ks install` replaces this placeholder automatically during the first
+      # install commit if you leave it unchanged.
+      networking.hostId = "00000000";
 
-      # Root disk(s) for the server host.
+      # Root disk(s) for the server host. `ks install` replaces this placeholder
+      # automatically with the disk you confirm in the installer flow.
       keystone.os.storage.devices = [
-        "/dev/disk/by-id/YOUR-SERVER-DISK-ID-HERE" # TODO: Replace with your disk ID
+        "__KEYSTONE_DISK__"
+        # Add your own stable /dev/disk/by-id/... paths here if you are not
+        # using the installer flow:
+        # "/dev/disk/by-id/YOUR-SERVER-DISK-ID-HERE"
       ];
 
       # Set to "stripe", "mirror", or a raidz mode for multi-disk server roots.


### PR DESCRIPTION
## Summary

Tighten the small pre-tag follow-ups from PR #334 before the first bare-metal RC.

- require an explicit `--disk` for `ks install --host` instead of auto-selecting `disks[0]`
- make `test-iso --e2e` fail hard on the reboot SSH, snapshot, and ImageMagick checks that are part of the RC signal
- reset the template `flake.lock` away from a local worktree path and back to the GitHub `keystone` input

Headless CI / GPU-independent VM rendering is explicitly out of scope for this pass.

Refs #344.

## Test plan

- [x] `bash -n templates/default/bin/test-iso`
- [x] `nix develop -c cargo fmt --check --manifest-path packages/ks/Cargo.toml`
- [x] `nix develop -c cargo test --manifest-path packages/ks/Cargo.toml set_disk_by_path`
- [x] `nix develop -c cargo test --manifest-path packages/ks/Cargo.toml`
