### PR TITLE
feat(ks): unified notification, task, and project management

### DIFF
--- a/packages/ks/AGENTS.md
+++ b/packages/ks/AGENTS.md
@@ -79,6 +79,60 @@ src/
 5. If the component has a CLI subcommand, add it to `cli.rs` and wire
    `types.rs` + `run.rs` in `main.rs`.
 
+## CLI Subcommands
+
+### `ks notification` — Unified notification fetch with source-level read tracking
+
+Replaces shell-script fetchers (`fetch-email-source`, `fetch-github-sources`,
+`fetch-forgejo-sources`) with a single Rust subcommand. Fetches only unseen/unread
+items and supports marking them as read at the source after successful processing.
+
+| Command | What |
+|---------|------|
+| `ks notification` | Human-readable list of unread notifications |
+| `ks notification fetch` | Fetch unseen items, output JSON |
+| `ks notification fetch --manifest` | Also write manifest for later ack |
+| `ks notification ack <manifest>` | Mark items read at source |
+| `ks notification sources` | Show configured sources and status |
+
+Sources: email (himalaya), GitHub (gh API), Forgejo (curl + token).
+GitHub/Forgejo return metadata only (1 API call each); email enriches with body.
+
+### `ks task` — Unified task management for humans and agents
+
+CRUD on `TASKS.yaml` with AI-powered ingest and prioritization.
+Prioritization proposals include per-task rationale as JSON.
+
+| Command | What |
+|---------|------|
+| `ks task` | List tasks grouped by status |
+| `ks task add <desc>` | Create pending task (auto-slugify name) |
+| `ks task start <name>` | Mark in-progress |
+| `ks task done <name>` | Mark completed |
+| `ks task block <name>` | Mark blocked with optional reason |
+| `ks task ingest --file <json>` | Output AI prompt for notification→task conversion |
+| `ks task ingest --apply` | Apply AI ingest result from stdin |
+| `ks task prioritize` | Output AI prompt for task ranking |
+| `ks task proposal` | Show current prioritization proposal |
+| `ks task proposal --accept` | Apply proposed ordering |
+| `ks task prune [--all]` | Remove old completed tasks |
+
+### `ks project` — Project management with detection and provider overrides
+
+Projects map repos to named entities with priority and per-project provider config.
+Detection resolves notifications to projects deterministically or heuristically.
+
+| Command | What |
+|---------|------|
+| `ks project` | List all projects |
+| `ks project show <slug>` | Full project details |
+| `ks project add <slug>` | Create project (`--name`, `--repo`, `--priority`) |
+| `ks project remove <slug>` | Remove project |
+| `ks project detect --repo <url>` | Exact repo→project lookup |
+| `ks project detect --subject <text>` | Heuristic name/slug match |
+
+Detection output: `{"slug": "keystone", "confidence": "exact|heuristic|none", "method": "..."}`
+
 ## Clippy Configuration
 
 The crate enables strict clippy lint groups:

--- a/packages/ks/Cargo.lock
+++ b/packages/ks/Cargo.lock
@@ -912,6 +912,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1242,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1395,7 @@ dependencies = [
  "anyhow",
  "clap",
  "crossterm",
+ "futures",
  "git2",
  "home",
  "hostname",
@@ -1388,6 +1405,7 @@ dependencies = [
  "rnix",
  "serde",
  "serde_json",
+ "serde_yaml",
  "ssh-key",
  "sysinfo",
  "tempfile",
@@ -2460,6 +2478,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,6 +3023,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/packages/ks/Cargo.toml
+++ b/packages/ks/Cargo.toml
@@ -17,6 +17,7 @@ crossterm = "0.28"
 # Async
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "process", "fs", "io-util"] }
 tokio-util = "0.7"
+futures = "0.3"
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/packages/ks/Cargo.toml
+++ b/packages/ks/Cargo.toml
@@ -28,6 +28,9 @@ git2 = "0.19"
 # SSH keys
 ssh-key = { version = "0.6", features = ["ed25519", "std"] }
 
+# YAML
+serde_yaml = "0.9"
+
 # Nix parsing
 rnix = "0.11"
 

--- a/packages/ks/src/cli.rs
+++ b/packages/ks/src/cli.rs
@@ -2,7 +2,9 @@
 
 use clap::{Args, Parser, Subcommand};
 
-use crate::cmd::{photos::PhotosCommand, screenshots::ScreenshotsCommand};
+use crate::cmd::{
+    notifications::NotificationsArgs, photos::PhotosCommand, screenshots::ScreenshotsCommand,
+};
 
 /// Keystone CLI/TUI — NixOS infrastructure configuration and management.
 #[derive(Parser)]
@@ -140,6 +142,9 @@ pub enum Command {
 
     /// Run the installer headlessly (no TUI). Requires installer ISO context.
     Install(InstallArgs),
+
+    /// Unified notification fetch with source-level read tracking.
+    Notifications(NotificationsArgs),
 }
 
 #[derive(Args)]

--- a/packages/ks/src/cli.rs
+++ b/packages/ks/src/cli.rs
@@ -3,8 +3,8 @@
 use clap::{Args, Parser, Subcommand};
 
 use crate::cmd::{
-    notifications::NotificationsArgs, photos::PhotosCommand, screenshots::ScreenshotsCommand,
-    tasks::TasksArgs,
+    notifications::NotificationArgs, photos::PhotosCommand, projects::ProjectArgs,
+    screenshots::ScreenshotsCommand, tasks::TaskArgs,
 };
 
 /// Keystone CLI/TUI — NixOS infrastructure configuration and management.
@@ -145,10 +145,13 @@ pub enum Command {
     Install(InstallArgs),
 
     /// Unified notification fetch with source-level read tracking.
-    Notifications(NotificationsArgs),
+    Notification(NotificationArgs),
 
-    /// Manage tasks — list, add, complete, prioritize, prune.
-    Tasks(TasksArgs),
+    /// Manage tasks — list, add, start, complete, prioritize, prune.
+    Task(TaskArgs),
+
+    /// Manage projects — list, add, detect, configure provider overrides.
+    Project(ProjectArgs),
 }
 
 #[derive(Args)]

--- a/packages/ks/src/cli.rs
+++ b/packages/ks/src/cli.rs
@@ -4,6 +4,7 @@ use clap::{Args, Parser, Subcommand};
 
 use crate::cmd::{
     notifications::NotificationsArgs, photos::PhotosCommand, screenshots::ScreenshotsCommand,
+    tasks::TasksArgs,
 };
 
 /// Keystone CLI/TUI — NixOS infrastructure configuration and management.
@@ -145,6 +146,9 @@ pub enum Command {
 
     /// Unified notification fetch with source-level read tracking.
     Notifications(NotificationsArgs),
+
+    /// Manage tasks — list, add, complete, prioritize, prune.
+    Tasks(TasksArgs),
 }
 
 #[derive(Args)]

--- a/packages/ks/src/cmd/mod.rs
+++ b/packages/ks/src/cmd/mod.rs
@@ -12,14 +12,14 @@ pub mod grafana;
 pub mod hardware_key;
 pub mod notifications;
 pub mod photos;
-pub mod projects;
-pub mod tasks;
 pub mod print;
+pub mod projects;
 pub mod screenshots;
 pub mod ssh;
 pub mod switch;
 pub mod sync_agent_assets;
 pub mod sync_host_keys;
+pub mod tasks;
 pub mod update;
 pub mod util;
 

--- a/packages/ks/src/cmd/mod.rs
+++ b/packages/ks/src/cmd/mod.rs
@@ -12,6 +12,7 @@ pub mod grafana;
 pub mod hardware_key;
 pub mod notifications;
 pub mod photos;
+pub mod projects;
 pub mod tasks;
 pub mod print;
 pub mod screenshots;

--- a/packages/ks/src/cmd/mod.rs
+++ b/packages/ks/src/cmd/mod.rs
@@ -12,6 +12,7 @@ pub mod grafana;
 pub mod hardware_key;
 pub mod notifications;
 pub mod photos;
+pub mod tasks;
 pub mod print;
 pub mod screenshots;
 pub mod ssh;

--- a/packages/ks/src/cmd/mod.rs
+++ b/packages/ks/src/cmd/mod.rs
@@ -10,6 +10,7 @@ pub mod docs;
 pub mod doctor;
 pub mod grafana;
 pub mod hardware_key;
+pub mod notifications;
 pub mod photos;
 pub mod print;
 pub mod screenshots;

--- a/packages/ks/src/cmd/notifications.rs
+++ b/packages/ks/src/cmd/notifications.rs
@@ -248,15 +248,36 @@ async fn fetch_email_body(id: &str) -> Result<String> {
 
 // ── GitHub source ──────────────────────────────────────────────────────
 
-/// Fetch unread GitHub notifications and enrich with issue/PR details.
+/// Parse owner/repo and number from a REST API URL like
+/// `https://api.github.com/repos/owner/repo/issues/123`
+fn parse_subject_url(url: &str) -> Option<(String, String, u64)> {
+    let parts: Vec<&str> = url.rsplitn(2, '/').collect();
+    let number: u64 = parts.first()?.parse().ok()?;
+    // URL pattern: .../repos/{owner}/{repo}/issues/{n} or .../repos/{owner}/{repo}/pulls/{n}
+    let segments: Vec<&str> = url.split('/').collect();
+    // Find "repos" index, then owner and repo follow
+    let repos_idx = segments.iter().position(|&s| s == "repos")?;
+    let owner = segments.get(repos_idx + 1)?.to_string();
+    let repo = segments.get(repos_idx + 2)?.to_string();
+    Some((owner, repo, number))
+}
+
+/// Notification metadata extracted from REST API, before GraphQL enrichment.
+struct NotifMeta {
+    owner: String,
+    repo: String,
+    number: u64,
+    subject_type: String, // "Issue" or "PullRequest"
+    reason: String,
+}
+
+/// Fetch unread GitHub notifications and enrich via a single GraphQL query.
 /// ISSUE-REQ-3: Does NOT pass `all=true` — only unread notifications.
+/// Uses 2 API calls total: 1 REST (notifications) + 1 GraphQL (enrichment).
 async fn fetch_github(username: &str) -> Result<(SourceEntry, Vec<String>)> {
-    // Phase 1: Fetch unread notifications (no all=true)
+    // ── Call 1: REST — fetch unread notifications ────────────────────
     let output = Command::new("gh")
-        .args([
-            "api",
-            "/notifications?participating=true&per_page=100",
-        ])
+        .args(["api", "/notifications?participating=true&per_page=100"])
         .output()
         .await
         .context("failed to run gh api")?;
@@ -271,102 +292,275 @@ async fn fetch_github(username: &str) -> Result<(SourceEntry, Vec<String>)> {
     let raw: Vec<serde_json::Value> =
         serde_json::from_slice(&output.stdout).unwrap_or_default();
 
-    // Collect thread IDs for manifest
+    // Collect thread IDs for manifest (ack needs these)
     let thread_ids: Vec<String> = raw
         .iter()
         .filter_map(|n| n.get("id").and_then(|v| v.as_str()).map(String::from))
         .collect();
 
-    // Deduplicate by subject URL, keep most recent
-    let notifications = dedup_notifications(&raw);
+    // Deduplicate and extract metadata
+    let mut seen = std::collections::HashSet::new();
+    let mut metas: Vec<NotifMeta> = Vec::new();
 
-    // Phase 2-4: Enrich (issues, PRs, reviews) — parallel, mirrors fetch-github-sources
-    enum EnrichResult {
-        Issue(serde_json::Value, Option<serde_json::Value>),
-        Pr(serde_json::Value),
-        Reviews(Vec<serde_json::Value>),
+    for notif in &raw {
+        let subject_type = notif
+            .get("subject")
+            .and_then(|s| s.get("type"))
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
+        let subject_url = notif
+            .get("subject")
+            .and_then(|s| s.get("url"))
+            .and_then(|u| u.as_str())
+            .unwrap_or("");
+        let reason = notif
+            .get("reason")
+            .and_then(|r| r.as_str())
+            .unwrap_or("");
+
+        if subject_type != "Issue" && subject_type != "PullRequest" {
+            continue;
+        }
+        if subject_url.is_empty() || !seen.insert(subject_url.to_string()) {
+            continue;
+        }
+
+        if let Some((owner, repo, number)) = parse_subject_url(subject_url) {
+            metas.push(NotifMeta {
+                owner,
+                repo,
+                number,
+                subject_type: subject_type.to_string(),
+                reason: reason.to_string(),
+            });
+        }
     }
 
-    let enrich_futures: Vec<_> = notifications
-        .iter()
-        .filter_map(|notif| {
-            let subject_type = notif
-                .get("subject")
-                .and_then(|s| s.get("type"))
-                .and_then(|t| t.as_str())
-                .unwrap_or("")
-                .to_string();
-            let subject_url = notif
-                .get("subject")
-                .and_then(|s| s.get("url"))
-                .and_then(|u| u.as_str())
-                .unwrap_or("")
-                .to_string();
-            let repo = notif
-                .get("repository")
-                .and_then(|r| r.get("full_name"))
-                .and_then(|n| n.as_str())
-                .unwrap_or("")
-                .to_string();
-            let reason = notif
-                .get("reason")
-                .and_then(|r| r.as_str())
-                .unwrap_or("")
-                .to_string();
+    if metas.is_empty() {
+        return Ok((
+            SourceEntry {
+                source: "github".to_string(),
+                data: serde_json::json!({
+                    "github-issues": [],
+                    "github-prs": [],
+                    "github-pr-reviews": [],
+                    "github-issue-comments": [],
+                }),
+            },
+            thread_ids,
+        ));
+    }
 
-            if subject_url.is_empty() {
-                return None;
-            }
+    // ── Call 2: GraphQL — enrich all notifications in one query ──────
+    // Build aliased fragments for each notification
+    let mut fragments = Vec::new();
+    for (i, meta) in metas.iter().enumerate() {
+        let alias = format!("n{i}");
+        if meta.subject_type == "Issue" {
+            fragments.push(format!(
+                r#"{alias}: repository(owner: "{owner}", name: "{repo}") {{
+  issue(number: {number}) {{
+    number
+    title
+    url
+    state
+    createdAt
+    assignees(first: 10) {{ nodes {{ login }} }}
+    labels(first: 10) {{ nodes {{ name }} }}
+    comments(last: 1) {{ nodes {{ databaseId author {{ login }} body createdAt }} }}
+  }}
+}}"#,
+                alias = alias,
+                owner = meta.owner,
+                repo = meta.repo,
+                number = meta.number
+            ));
+        } else {
+            // PullRequest — fetch PR details + reviews with comments
+            fragments.push(format!(
+                r#"{alias}: repository(owner: "{owner}", name: "{repo}") {{
+  pullRequest(number: {number}) {{
+    number
+    title
+    url
+    createdAt
+    author {{ login }}
+    headRefName
+    reviews(last: 20) {{
+      nodes {{
+        databaseId
+        author {{ login }}
+        state
+        comments(first: 20) {{ nodes {{ databaseId path body }} }}
+      }}
+    }}
+  }}
+}}"#,
+                alias = alias,
+                owner = meta.owner,
+                repo = meta.repo,
+                number = meta.number
+            ));
+        }
+    }
 
-            let notif = notif.clone();
-            let username = username.to_string();
+    let query = format!("{{ {} }}", fragments.join("\n"));
+    let output = Command::new("gh")
+        .args(["api", "graphql", "-f", &format!("query={query}")])
+        .output()
+        .await
+        .context("failed to run gh api graphql")?;
 
-            Some(async move {
-                match subject_type.as_str() {
-                    "Issue" => {
-                        if let Ok(issue) = enrich_issue(&subject_url, &repo, &notif).await {
-                            let comment =
-                                enrich_issue_comment(&notif, &repo, &issue).await;
-                            Some(EnrichResult::Issue(issue, comment))
-                        } else {
-                            None
-                        }
-                    }
-                    "PullRequest" if reason == "review_requested" => {
-                        enrich_pr(&subject_url, &repo)
-                            .await
-                            .ok()
-                            .map(EnrichResult::Pr)
-                    }
-                    "PullRequest" if reason == "author" => {
-                        enrich_reviews(&subject_url, &repo, &username)
-                            .await
-                            .ok()
-                            .map(EnrichResult::Reviews)
-                    }
-                    _ => None,
-                }
-            })
-        })
-        .collect();
+    let gql_data: serde_json::Value = if output.status.success() {
+        let resp: serde_json::Value =
+            serde_json::from_slice(&output.stdout).unwrap_or_default();
+        resp.get("data").cloned().unwrap_or(serde_json::json!({}))
+    } else {
+        eprintln!(
+            "warning: GraphQL enrichment failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::json!({})
+    };
 
-    let results = futures::future::join_all(enrich_futures).await;
-
+    // ── Transform GraphQL response into sources.json schema ─────────
     let mut issues = Vec::new();
     let mut prs = Vec::new();
     let mut reviews = Vec::new();
     let mut issue_comments = Vec::new();
 
-    for result in results.into_iter().flatten() {
-        match result {
-            EnrichResult::Issue(issue, comment) => {
-                issues.push(issue);
-                if let Some(c) = comment {
-                    issue_comments.push(c);
+    for (i, meta) in metas.iter().enumerate() {
+        let alias = format!("n{i}");
+        let repo_full = format!("{}/{}", meta.owner, meta.repo);
+        let repo_data = match gql_data.get(&alias) {
+            Some(d) => d,
+            None => continue,
+        };
+
+        if meta.subject_type == "Issue" {
+            let issue = match repo_data.get("issue") {
+                Some(i) => i,
+                None => continue,
+            };
+            let state = issue.get("state").and_then(|s| s.as_str()).unwrap_or("");
+            if state != "OPEN" {
+                continue;
+            }
+
+            let assignees: Vec<&str> = issue
+                .pointer("/assignees/nodes")
+                .and_then(|a| a.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|n| n.get("login").and_then(|l| l.as_str()))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let labels: Vec<&str> = issue
+                .pointer("/labels/nodes")
+                .and_then(|a| a.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|n| n.get("name").and_then(|l| l.as_str()))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            issues.push(serde_json::json!({
+                "repo": repo_full,
+                "number": issue.get("number"),
+                "title": issue.get("title"),
+                "url": issue.get("url"),
+                "assignees": assignees,
+                "labels": labels,
+                "created_at": issue.get("createdAt"),
+            }));
+
+            // Latest comment
+            if let Some(comment) = issue
+                .pointer("/comments/nodes/0")
+                .filter(|c| !c.is_null())
+            {
+                issue_comments.push(serde_json::json!({
+                    "repo": repo_full,
+                    "issue_number": issue.get("number"),
+                    "comment_id": comment.get("databaseId"),
+                    "author": comment.pointer("/author/login"),
+                    "body": comment.get("body"),
+                    "created_at": comment.get("createdAt"),
+                }));
+            }
+        } else {
+            // PullRequest
+            let pr = match repo_data.get("pullRequest") {
+                Some(p) => p,
+                None => continue,
+            };
+
+            if meta.reason == "review_requested" {
+                prs.push(serde_json::json!({
+                    "repo": repo_full,
+                    "number": pr.get("number"),
+                    "title": pr.get("title"),
+                    "url": pr.get("url"),
+                    "author": pr.pointer("/author/login"),
+                    "created_at": pr.get("createdAt"),
+                }));
+            } else if meta.reason == "author" {
+                // Extract reviews from others with actionable states
+                let review_nodes = pr
+                    .pointer("/reviews/nodes")
+                    .and_then(|n| n.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+
+                for review in &review_nodes {
+                    let reviewer = review
+                        .pointer("/author/login")
+                        .and_then(|l| l.as_str())
+                        .unwrap_or("");
+                    let state = review
+                        .get("state")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("");
+
+                    if reviewer == username {
+                        continue;
+                    }
+                    if state != "CHANGES_REQUESTED" && state != "COMMENTED" {
+                        continue;
+                    }
+
+                    let comments: Vec<serde_json::Value> = review
+                        .pointer("/comments/nodes")
+                        .and_then(|n| n.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .map(|c| {
+                                    serde_json::json!({
+                                        "id": c.get("databaseId"),
+                                        "path": c.get("path"),
+                                        "body": c.get("body"),
+                                    })
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+
+                    reviews.push(serde_json::json!({
+                        "repo": repo_full,
+                        "pr_number": pr.get("number"),
+                        "pr_title": pr.get("title"),
+                        "pr_url": pr.get("url"),
+                        "pr_branch": pr.get("headRefName"),
+                        "review_id": review.get("databaseId"),
+                        "reviewer": reviewer,
+                        "review_state": state,
+                        "comments": comments,
+                    }));
                 }
             }
-            EnrichResult::Pr(pr) => prs.push(pr),
-            EnrichResult::Reviews(mut revs) => reviews.append(&mut revs),
         }
     }
 
@@ -384,227 +578,6 @@ async fn fetch_github(username: &str) -> Result<(SourceEntry, Vec<String>)> {
         },
         thread_ids,
     ))
-}
-
-fn dedup_notifications(raw: &[serde_json::Value]) -> Vec<serde_json::Value> {
-    use std::collections::HashMap;
-    let mut seen: HashMap<String, &serde_json::Value> = HashMap::new();
-
-    // Sort by updated_at descending is implicit — we just keep first occurrence
-    for notif in raw {
-        let subject_url = notif
-            .get("subject")
-            .and_then(|s| s.get("url"))
-            .and_then(|u| u.as_str())
-            .unwrap_or("");
-        let subject_type = notif
-            .get("subject")
-            .and_then(|s| s.get("type"))
-            .and_then(|t| t.as_str())
-            .unwrap_or("");
-
-        if subject_type != "Issue" && subject_type != "PullRequest" {
-            continue;
-        }
-
-        if !subject_url.is_empty() {
-            seen.entry(subject_url.to_string()).or_insert(notif);
-        }
-    }
-
-    seen.into_values().cloned().collect()
-}
-
-async fn enrich_issue(
-    subject_url: &str,
-    repo: &str,
-    _notif: &serde_json::Value,
-) -> Result<serde_json::Value> {
-    let output = Command::new("gh")
-        .args(["api", subject_url])
-        .output()
-        .await?;
-
-    if !output.status.success() {
-        anyhow::bail!("gh api failed for {subject_url}");
-    }
-
-    let issue: serde_json::Value = serde_json::from_slice(&output.stdout)?;
-    let state = issue.get("state").and_then(|s| s.as_str()).unwrap_or("");
-    if state != "open" {
-        anyhow::bail!("issue is not open");
-    }
-
-    Ok(serde_json::json!({
-        "repo": repo,
-        "number": issue.get("number"),
-        "title": issue.get("title"),
-        "url": issue.get("html_url"),
-        "assignees": issue.get("assignees").and_then(|a| a.as_array()).map(|arr|
-            arr.iter().filter_map(|a| a.get("login").and_then(|l| l.as_str())).collect::<Vec<_>>()
-        ).unwrap_or_default(),
-        "labels": issue.get("labels").and_then(|l| l.as_array()).map(|arr|
-            arr.iter().filter_map(|l| l.get("name").and_then(|n| n.as_str())).collect::<Vec<_>>()
-        ).unwrap_or_default(),
-        "created_at": issue.get("created_at"),
-    }))
-}
-
-async fn enrich_issue_comment(
-    notif: &serde_json::Value,
-    repo: &str,
-    issue: &serde_json::Value,
-) -> Option<serde_json::Value> {
-    let comment_url = notif
-        .get("subject")
-        .and_then(|s| s.get("latest_comment_url"))
-        .and_then(|u| u.as_str())?;
-
-    if comment_url == "null" || comment_url.is_empty() {
-        return None;
-    }
-
-    let output = Command::new("gh")
-        .args(["api", comment_url])
-        .output()
-        .await
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let comment: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
-    let number = issue.get("number");
-
-    Some(serde_json::json!({
-        "repo": repo,
-        "issue_number": number,
-        "comment_id": comment.get("id"),
-        "author": comment.get("user").and_then(|u| u.get("login")),
-        "body": comment.get("body"),
-        "created_at": comment.get("created_at"),
-    }))
-}
-
-async fn enrich_pr(subject_url: &str, repo: &str) -> Result<serde_json::Value> {
-    let output = Command::new("gh")
-        .args(["api", subject_url])
-        .output()
-        .await?;
-
-    if !output.status.success() {
-        anyhow::bail!("gh api failed for {subject_url}");
-    }
-
-    let pr: serde_json::Value = serde_json::from_slice(&output.stdout)?;
-
-    Ok(serde_json::json!({
-        "repo": repo,
-        "number": pr.get("number"),
-        "title": pr.get("title"),
-        "url": pr.get("html_url"),
-        "author": pr.get("user").and_then(|u| u.get("login")),
-        "created_at": pr.get("created_at"),
-    }))
-}
-
-async fn enrich_reviews(
-    subject_url: &str,
-    repo: &str,
-    username: &str,
-) -> Result<Vec<serde_json::Value>> {
-    let output = Command::new("gh")
-        .args(["api", subject_url])
-        .output()
-        .await?;
-
-    if !output.status.success() {
-        anyhow::bail!("gh api failed for {subject_url}");
-    }
-
-    let pr: serde_json::Value = serde_json::from_slice(&output.stdout)?;
-    let pr_number = pr.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
-    let pr_title = pr.get("title").and_then(|t| t.as_str()).unwrap_or("");
-    let pr_url = pr.get("html_url").and_then(|u| u.as_str()).unwrap_or("");
-    let pr_branch = pr
-        .get("head")
-        .and_then(|h| h.get("ref"))
-        .and_then(|r| r.as_str())
-        .unwrap_or("");
-
-    let reviews_url = format!("repos/{repo}/pulls/{pr_number}/reviews");
-    let output = Command::new("gh")
-        .args(["api", &reviews_url])
-        .output()
-        .await?;
-
-    let reviews_raw: Vec<serde_json::Value> = if output.status.success() {
-        serde_json::from_slice(&output.stdout).unwrap_or_default()
-    } else {
-        return Ok(vec![]);
-    };
-
-    let mut results = Vec::new();
-
-    for review in &reviews_raw {
-        let reviewer = review
-            .get("user")
-            .and_then(|u| u.get("login"))
-            .and_then(|l| l.as_str())
-            .unwrap_or("");
-        let state = review
-            .get("state")
-            .and_then(|s| s.as_str())
-            .unwrap_or("");
-
-        if reviewer == username {
-            continue;
-        }
-        if state != "CHANGES_REQUESTED" && state != "COMMENTED" {
-            continue;
-        }
-
-        let review_id = review.get("id").and_then(|i| i.as_u64()).unwrap_or(0);
-
-        // Fetch review comments
-        let comments_url =
-            format!("repos/{repo}/pulls/{pr_number}/reviews/{review_id}/comments");
-        let comments = match Command::new("gh")
-            .args(["api", &comments_url])
-            .output()
-            .await
-        {
-            Ok(out) if out.status.success() => {
-                let raw: Vec<serde_json::Value> =
-                    serde_json::from_slice(&out.stdout).unwrap_or_default();
-                raw.iter()
-                    .map(|c| {
-                        serde_json::json!({
-                            "id": c.get("id"),
-                            "path": c.get("path"),
-                            "body": c.get("body"),
-                        })
-                    })
-                    .collect::<Vec<_>>()
-            }
-            _ => vec![],
-        };
-
-        results.push(serde_json::json!({
-            "repo": repo,
-            "pr_number": pr_number,
-            "pr_title": pr_title,
-            "pr_url": pr_url,
-            "pr_branch": pr_branch,
-            "review_id": review_id,
-            "reviewer": reviewer,
-            "review_state": state,
-            "comments": comments,
-        }));
-    }
-
-    Ok(results)
 }
 
 // ── Ack ────────────────────────────────────────────────────────────────

--- a/packages/ks/src/cmd/notifications.rs
+++ b/packages/ks/src/cmd/notifications.rs
@@ -1,0 +1,784 @@
+//! `ks notifications` — unified notification fetch with source-level read tracking.
+//!
+//! Replaces shell-script fetchers (fetch-email-source, fetch-github-sources) with
+//! a single Rust subcommand that only returns unseen items and supports marking them
+//! as read at the source after successful ingest (ISSUE-REQ-1 through ISSUE-REQ-12).
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+/// State directory for notification manifests.
+fn state_dir() -> PathBuf {
+    let base = std::env::var("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            home::home_dir()
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join(".local/state")
+        });
+    base.join("ks/notifications")
+}
+
+// ── CLI definitions ────────────────────────────────────────────────────
+
+#[derive(Args)]
+pub struct NotificationsArgs {
+    #[command(subcommand)]
+    pub command: Option<NotificationsCommand>,
+
+    /// Output as JSON instead of human-readable table.
+    #[arg(long, global = true)]
+    pub json: bool,
+}
+
+#[derive(Subcommand)]
+pub enum NotificationsCommand {
+    /// Fetch unseen notifications, output JSON (machine-readable).
+    Fetch {
+        /// Write a manifest file for later ack.
+        #[arg(long)]
+        manifest: bool,
+
+        /// Only fetch from specific sources (comma-separated: email,github).
+        #[arg(long)]
+        sources: Option<String>,
+    },
+
+    /// Mark items in a manifest as read at their source.
+    Ack {
+        /// Path to the manifest file produced by `fetch --manifest`.
+        manifest: PathBuf,
+    },
+
+    /// Show configured sources and connection status.
+    Sources,
+}
+
+// ── Data types ─────────────────────────────────────────────────────────
+
+/// A single source entry in the sources.json array consumed by the task loop.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SourceEntry {
+    pub source: String,
+    pub data: serde_json::Value,
+}
+
+/// Manifest tracking fetched item IDs per source for later ack.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Manifest {
+    pub created_at: String,
+    pub sources: Vec<ManifestSource>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ManifestSource {
+    pub source: String,
+    pub ids: Vec<String>,
+}
+
+/// Email envelope from himalaya JSON output.
+#[derive(Debug, Serialize, Deserialize)]
+struct EmailEnvelope {
+    id: String,
+    #[serde(flatten)]
+    rest: serde_json::Map<String, serde_json::Value>,
+}
+
+// ── Entrypoint ─────────────────────────────────────────────────────────
+
+pub async fn execute(args: &NotificationsArgs) -> Result<()> {
+    match &args.command {
+        Some(NotificationsCommand::Fetch { manifest, sources }) => {
+            let filter: Option<Vec<&str>> = sources
+                .as_ref()
+                .map(|s| s.split(',').map(|s| s.trim()).collect());
+            execute_fetch(*manifest, filter.as_deref(), args.json).await
+        }
+        Some(NotificationsCommand::Ack { manifest }) => execute_ack(manifest).await,
+        Some(NotificationsCommand::Sources) => execute_sources(args.json).await,
+        None => execute_list(args.json).await,
+    }
+}
+
+// ── Fetch ──────────────────────────────────────────────────────────────
+
+async fn execute_fetch(
+    write_manifest: bool,
+    source_filter: Option<&[&str]>,
+    _json_output: bool,
+) -> Result<()> {
+    let mut entries: Vec<SourceEntry> = Vec::new();
+    let mut manifest_sources: Vec<ManifestSource> = Vec::new();
+
+    let should_fetch = |name: &str| -> bool {
+        source_filter
+            .map(|f| f.contains(&name))
+            .unwrap_or(true)
+    };
+
+    // ISSUE-REQ-2: Email — fetch only UNSEEN via himalaya filter
+    if should_fetch("email") {
+        match fetch_email().await {
+            Ok((entry, ids)) => {
+                if !ids.is_empty() {
+                    manifest_sources.push(ManifestSource {
+                        source: "email".to_string(),
+                        ids,
+                    });
+                }
+                if entry.data != serde_json::Value::Array(vec![]) {
+                    entries.push(entry);
+                }
+            }
+            Err(e) => eprintln!("warning: email fetch failed: {e}"),
+        }
+    }
+
+    // ISSUE-REQ-3: GitHub — fetch only unread (no all=true)
+    if should_fetch("github") {
+        let username = std::env::var("GITHUB_USERNAME").ok();
+        if let Some(ref user) = username {
+            match fetch_github(user).await {
+                Ok((entry, ids)) => {
+                    if !ids.is_empty() {
+                        manifest_sources.push(ManifestSource {
+                            source: "github".to_string(),
+                            ids,
+                        });
+                    }
+                    if entry.data != serde_json::json!({}) {
+                        entries.push(entry);
+                    }
+                }
+                Err(e) => eprintln!("warning: github fetch failed: {e}"),
+            }
+        }
+    }
+
+    // ISSUE-REQ-8: Write manifest for later ack
+    if write_manifest && !manifest_sources.is_empty() {
+        let manifest = Manifest {
+            created_at: chrono_now(),
+            sources: manifest_sources,
+        };
+        let dir = state_dir();
+        tokio::fs::create_dir_all(&dir).await?;
+        let path = dir.join(format!("manifest-{}.json", timestamp_slug()));
+        let content = serde_json::to_string_pretty(&manifest)?;
+        tokio::fs::write(&path, &content).await?;
+        eprintln!("manifest: {}", path.display());
+    }
+
+    // ISSUE-REQ-5: Output JSON in sources.json schema
+    let output = serde_json::to_string_pretty(&entries)?;
+    println!("{output}");
+
+    Ok(())
+}
+
+// ── Email source ───────────────────────────────────────────────────────
+
+/// Fetch unseen email envelopes and enrich with bodies.
+/// ISSUE-REQ-2: Uses `--filter "NOT SEEN"` to exclude already-read messages.
+async fn fetch_email() -> Result<(SourceEntry, Vec<String>)> {
+    // Fetch only unseen envelopes
+    let output = Command::new("himalaya")
+        .args(["envelope", "list", "--filter", "NOT SEEN", "-o", "json", "--page-size", "50"])
+        .output()
+        .await
+        .context("failed to run himalaya")?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "himalaya envelope list failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let envelopes: Vec<EmailEnvelope> =
+        serde_json::from_slice(&output.stdout).unwrap_or_default();
+
+    let ids: Vec<String> = envelopes.iter().map(|e| e.id.clone()).collect();
+
+    // Enrich each envelope with its body
+    let mut enriched = Vec::new();
+    for env in &envelopes {
+        let body = fetch_email_body(&env.id).await.unwrap_or_default();
+        let mut obj = serde_json::Map::new();
+        obj.insert("id".to_string(), serde_json::Value::String(env.id.clone()));
+        for (k, v) in &env.rest {
+            obj.insert(k.clone(), v.clone());
+        }
+        obj.insert("body".to_string(), serde_json::Value::String(body));
+        enriched.push(serde_json::Value::Object(obj));
+    }
+
+    Ok((
+        SourceEntry {
+            source: "email".to_string(),
+            data: serde_json::Value::Array(enriched),
+        },
+        ids,
+    ))
+}
+
+async fn fetch_email_body(id: &str) -> Result<String> {
+    let output = Command::new("himalaya")
+        .args(["message", "read", "-p", id])
+        .output()
+        .await?;
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+// ── GitHub source ──────────────────────────────────────────────────────
+
+/// Fetch unread GitHub notifications and enrich with issue/PR details.
+/// ISSUE-REQ-3: Does NOT pass `all=true` — only unread notifications.
+async fn fetch_github(username: &str) -> Result<(SourceEntry, Vec<String>)> {
+    // Phase 1: Fetch unread notifications (no all=true)
+    let output = Command::new("gh")
+        .args([
+            "api",
+            "/notifications?participating=true&per_page=100",
+        ])
+        .output()
+        .await
+        .context("failed to run gh api")?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "gh api notifications failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let raw: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).unwrap_or_default();
+
+    // Collect thread IDs for manifest
+    let thread_ids: Vec<String> = raw
+        .iter()
+        .filter_map(|n| n.get("id").and_then(|v| v.as_str()).map(String::from))
+        .collect();
+
+    // Deduplicate by subject URL, keep most recent
+    let notifications = dedup_notifications(&raw);
+
+    // Phase 2-4: Enrich (issues, PRs, reviews) — mirrors fetch-github-sources
+    let mut issues = Vec::new();
+    let mut prs = Vec::new();
+    let mut reviews = Vec::new();
+    let mut issue_comments = Vec::new();
+
+    for notif in &notifications {
+        let subject_type = notif
+            .get("subject")
+            .and_then(|s| s.get("type"))
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
+        let subject_url = notif
+            .get("subject")
+            .and_then(|s| s.get("url"))
+            .and_then(|u| u.as_str())
+            .unwrap_or("");
+        let repo = notif
+            .get("repository")
+            .and_then(|r| r.get("full_name"))
+            .and_then(|n| n.as_str())
+            .unwrap_or("");
+        let reason = notif
+            .get("reason")
+            .and_then(|r| r.as_str())
+            .unwrap_or("");
+
+        if subject_url.is_empty() {
+            continue;
+        }
+
+        match subject_type {
+            "Issue" => {
+                if let Ok(issue) = enrich_issue(subject_url, repo, notif).await {
+                    if let Some(comment) =
+                        enrich_issue_comment(notif, repo, &issue).await
+                    {
+                        issue_comments.push(comment);
+                    }
+                    issues.push(issue);
+                }
+            }
+            "PullRequest" if reason == "review_requested" => {
+                if let Ok(pr) = enrich_pr(subject_url, repo).await {
+                    prs.push(pr);
+                }
+            }
+            "PullRequest" if reason == "author" => {
+                if let Ok(mut rev) = enrich_reviews(subject_url, repo, username).await {
+                    reviews.append(&mut rev);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let data = serde_json::json!({
+        "github-issues": issues,
+        "github-prs": prs,
+        "github-pr-reviews": reviews,
+        "github-issue-comments": issue_comments,
+    });
+
+    Ok((
+        SourceEntry {
+            source: "github".to_string(),
+            data,
+        },
+        thread_ids,
+    ))
+}
+
+fn dedup_notifications(raw: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    use std::collections::HashMap;
+    let mut seen: HashMap<String, &serde_json::Value> = HashMap::new();
+
+    // Sort by updated_at descending is implicit — we just keep first occurrence
+    for notif in raw {
+        let subject_url = notif
+            .get("subject")
+            .and_then(|s| s.get("url"))
+            .and_then(|u| u.as_str())
+            .unwrap_or("");
+        let subject_type = notif
+            .get("subject")
+            .and_then(|s| s.get("type"))
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
+
+        if subject_type != "Issue" && subject_type != "PullRequest" {
+            continue;
+        }
+
+        if !subject_url.is_empty() {
+            seen.entry(subject_url.to_string()).or_insert(notif);
+        }
+    }
+
+    seen.into_values().cloned().collect()
+}
+
+async fn enrich_issue(
+    subject_url: &str,
+    repo: &str,
+    _notif: &serde_json::Value,
+) -> Result<serde_json::Value> {
+    let output = Command::new("gh")
+        .args(["api", subject_url])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        anyhow::bail!("gh api failed for {subject_url}");
+    }
+
+    let issue: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    let state = issue.get("state").and_then(|s| s.as_str()).unwrap_or("");
+    if state != "open" {
+        anyhow::bail!("issue is not open");
+    }
+
+    Ok(serde_json::json!({
+        "repo": repo,
+        "number": issue.get("number"),
+        "title": issue.get("title"),
+        "url": issue.get("html_url"),
+        "assignees": issue.get("assignees").and_then(|a| a.as_array()).map(|arr|
+            arr.iter().filter_map(|a| a.get("login").and_then(|l| l.as_str())).collect::<Vec<_>>()
+        ).unwrap_or_default(),
+        "labels": issue.get("labels").and_then(|l| l.as_array()).map(|arr|
+            arr.iter().filter_map(|l| l.get("name").and_then(|n| n.as_str())).collect::<Vec<_>>()
+        ).unwrap_or_default(),
+        "created_at": issue.get("created_at"),
+    }))
+}
+
+async fn enrich_issue_comment(
+    notif: &serde_json::Value,
+    repo: &str,
+    issue: &serde_json::Value,
+) -> Option<serde_json::Value> {
+    let comment_url = notif
+        .get("subject")
+        .and_then(|s| s.get("latest_comment_url"))
+        .and_then(|u| u.as_str())?;
+
+    if comment_url == "null" || comment_url.is_empty() {
+        return None;
+    }
+
+    let output = Command::new("gh")
+        .args(["api", comment_url])
+        .output()
+        .await
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let comment: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let number = issue.get("number");
+
+    Some(serde_json::json!({
+        "repo": repo,
+        "issue_number": number,
+        "comment_id": comment.get("id"),
+        "author": comment.get("user").and_then(|u| u.get("login")),
+        "body": comment.get("body"),
+        "created_at": comment.get("created_at"),
+    }))
+}
+
+async fn enrich_pr(subject_url: &str, repo: &str) -> Result<serde_json::Value> {
+    let output = Command::new("gh")
+        .args(["api", subject_url])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        anyhow::bail!("gh api failed for {subject_url}");
+    }
+
+    let pr: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+
+    Ok(serde_json::json!({
+        "repo": repo,
+        "number": pr.get("number"),
+        "title": pr.get("title"),
+        "url": pr.get("html_url"),
+        "author": pr.get("user").and_then(|u| u.get("login")),
+        "created_at": pr.get("created_at"),
+    }))
+}
+
+async fn enrich_reviews(
+    subject_url: &str,
+    repo: &str,
+    username: &str,
+) -> Result<Vec<serde_json::Value>> {
+    let output = Command::new("gh")
+        .args(["api", subject_url])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        anyhow::bail!("gh api failed for {subject_url}");
+    }
+
+    let pr: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    let pr_number = pr.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
+    let pr_title = pr.get("title").and_then(|t| t.as_str()).unwrap_or("");
+    let pr_url = pr.get("html_url").and_then(|u| u.as_str()).unwrap_or("");
+    let pr_branch = pr
+        .get("head")
+        .and_then(|h| h.get("ref"))
+        .and_then(|r| r.as_str())
+        .unwrap_or("");
+
+    let reviews_url = format!("repos/{repo}/pulls/{pr_number}/reviews");
+    let output = Command::new("gh")
+        .args(["api", &reviews_url])
+        .output()
+        .await?;
+
+    let reviews_raw: Vec<serde_json::Value> = if output.status.success() {
+        serde_json::from_slice(&output.stdout).unwrap_or_default()
+    } else {
+        return Ok(vec![]);
+    };
+
+    let mut results = Vec::new();
+
+    for review in &reviews_raw {
+        let reviewer = review
+            .get("user")
+            .and_then(|u| u.get("login"))
+            .and_then(|l| l.as_str())
+            .unwrap_or("");
+        let state = review
+            .get("state")
+            .and_then(|s| s.as_str())
+            .unwrap_or("");
+
+        if reviewer == username {
+            continue;
+        }
+        if state != "CHANGES_REQUESTED" && state != "COMMENTED" {
+            continue;
+        }
+
+        let review_id = review.get("id").and_then(|i| i.as_u64()).unwrap_or(0);
+
+        // Fetch review comments
+        let comments_url =
+            format!("repos/{repo}/pulls/{pr_number}/reviews/{review_id}/comments");
+        let comments = match Command::new("gh")
+            .args(["api", &comments_url])
+            .output()
+            .await
+        {
+            Ok(out) if out.status.success() => {
+                let raw: Vec<serde_json::Value> =
+                    serde_json::from_slice(&out.stdout).unwrap_or_default();
+                raw.iter()
+                    .map(|c| {
+                        serde_json::json!({
+                            "id": c.get("id"),
+                            "path": c.get("path"),
+                            "body": c.get("body"),
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            }
+            _ => vec![],
+        };
+
+        results.push(serde_json::json!({
+            "repo": repo,
+            "pr_number": pr_number,
+            "pr_title": pr_title,
+            "pr_url": pr_url,
+            "pr_branch": pr_branch,
+            "review_id": review_id,
+            "reviewer": reviewer,
+            "review_state": state,
+            "comments": comments,
+        }));
+    }
+
+    Ok(results)
+}
+
+// ── Ack ────────────────────────────────────────────────────────────────
+
+/// ISSUE-REQ-6: Mark items as read at the source.
+async fn execute_ack(manifest_path: &PathBuf) -> Result<()> {
+    let content = tokio::fs::read_to_string(manifest_path)
+        .await
+        .context("failed to read manifest")?;
+    let manifest: Manifest = serde_json::from_str(&content)?;
+
+    for source in &manifest.sources {
+        match source.source.as_str() {
+            "email" => ack_email(&source.ids).await?,
+            "github" => ack_github(&source.ids).await?,
+            other => eprintln!("warning: unknown source in manifest: {other}"),
+        }
+    }
+
+    // Delete manifest after successful ack
+    tokio::fs::remove_file(manifest_path).await.ok();
+    eprintln!("ack complete, manifest removed");
+
+    Ok(())
+}
+
+/// Mark emails as seen via himalaya flag add.
+async fn ack_email(ids: &[String]) -> Result<()> {
+    for id in ids {
+        let status = Command::new("himalaya")
+            .args(["flag", "add", id, "Seen"])
+            .status()
+            .await?;
+
+        if !status.success() {
+            eprintln!("warning: failed to mark email {id} as seen");
+        }
+    }
+    Ok(())
+}
+
+/// Mark GitHub notification threads as read.
+async fn ack_github(thread_ids: &[String]) -> Result<()> {
+    for id in thread_ids {
+        let url = format!("/notifications/threads/{id}");
+        let status = Command::new("gh")
+            .args(["api", "-X", "PATCH", &url])
+            .status()
+            .await?;
+
+        if !status.success() {
+            eprintln!("warning: failed to mark GitHub thread {id} as read");
+        }
+    }
+    Ok(())
+}
+
+// ── Human-readable list ────────────────────────────────────────────────
+
+/// ISSUE-REQ-11: Display human-readable summary grouped by source.
+async fn execute_list(json: bool) -> Result<()> {
+    let entries = fetch_all_sources().await;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&entries)?);
+        return Ok(());
+    }
+
+    if entries.is_empty() {
+        println!("No unread notifications.");
+        return Ok(());
+    }
+
+    for entry in &entries {
+        println!("\n── {} ──", entry.source.to_uppercase());
+
+        match entry.source.as_str() {
+            "email" => {
+                if let Some(arr) = entry.data.as_array() {
+                    for item in arr {
+                        let from = item.get("from").and_then(|f| f.as_str()).unwrap_or("unknown");
+                        let subject = item.get("subject").and_then(|s| s.as_str()).unwrap_or("(no subject)");
+                        let id = item.get("id").and_then(|i| i.as_str()).unwrap_or("");
+                        println!("  [{id}] {from}: {subject}");
+                    }
+                }
+            }
+            "github" => {
+                if let Some(issues) = entry.data.get("github-issues").and_then(|v| v.as_array()) {
+                    if !issues.is_empty() {
+                        println!("  Issues:");
+                        for issue in issues {
+                            let repo = issue.get("repo").and_then(|r| r.as_str()).unwrap_or("");
+                            let number = issue.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
+                            let title = issue.get("title").and_then(|t| t.as_str()).unwrap_or("");
+                            println!("    {repo}#{number}: {title}");
+                        }
+                    }
+                }
+                if let Some(prs) = entry.data.get("github-prs").and_then(|v| v.as_array()) {
+                    if !prs.is_empty() {
+                        println!("  PRs requesting review:");
+                        for pr in prs {
+                            let repo = pr.get("repo").and_then(|r| r.as_str()).unwrap_or("");
+                            let number = pr.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
+                            let title = pr.get("title").and_then(|t| t.as_str()).unwrap_or("");
+                            println!("    {repo}#{number}: {title}");
+                        }
+                    }
+                }
+                if let Some(reviews) = entry.data.get("github-pr-reviews").and_then(|v| v.as_array()) {
+                    if !reviews.is_empty() {
+                        println!("  Reviews on your PRs:");
+                        for rev in reviews {
+                            let repo = rev.get("repo").and_then(|r| r.as_str()).unwrap_or("");
+                            let pr_number = rev.get("pr_number").and_then(|n| n.as_u64()).unwrap_or(0);
+                            let reviewer = rev.get("reviewer").and_then(|r| r.as_str()).unwrap_or("");
+                            let state = rev.get("review_state").and_then(|s| s.as_str()).unwrap_or("");
+                            println!("    {repo}#{pr_number}: {reviewer} ({state})");
+                        }
+                    }
+                }
+            }
+            _ => {
+                println!("  {}", serde_json::to_string_pretty(&entry.data)?);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Fetch from all available sources (used by both list and fetch).
+async fn fetch_all_sources() -> Vec<SourceEntry> {
+    let mut entries = Vec::new();
+
+    if let Ok((entry, _)) = fetch_email().await {
+        if entry.data != serde_json::Value::Array(vec![]) {
+            entries.push(entry);
+        }
+    }
+
+    if let Ok(ref user) = std::env::var("GITHUB_USERNAME") {
+        if let Ok((entry, _)) = fetch_github(user).await {
+            if entry.data != serde_json::json!({}) {
+                entries.push(entry);
+            }
+        }
+    }
+
+    entries
+}
+
+// ── Sources status ─────────────────────────────────────────────────────
+
+/// ISSUE-REQ-12: Show configured sources and connection status.
+async fn execute_sources(json: bool) -> Result<()> {
+    let mut sources = Vec::new();
+
+    // Check email (himalaya)
+    let email_ok = Command::new("himalaya")
+        .args(["account", "list", "-o", "json"])
+        .output()
+        .await
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    sources.push(serde_json::json!({
+        "source": "email",
+        "tool": "himalaya",
+        "available": email_ok,
+    }));
+
+    // Check GitHub (gh)
+    let gh_ok = Command::new("gh")
+        .args(["auth", "status"])
+        .output()
+        .await
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    sources.push(serde_json::json!({
+        "source": "github",
+        "tool": "gh",
+        "available": gh_ok,
+        "username": std::env::var("GITHUB_USERNAME").unwrap_or_default(),
+    }));
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&sources)?);
+    } else {
+        println!("Notification sources:\n");
+        for s in &sources {
+            let name = s.get("source").and_then(|n| n.as_str()).unwrap_or("");
+            let tool = s.get("tool").and_then(|t| t.as_str()).unwrap_or("");
+            let ok = s.get("available").and_then(|a| a.as_bool()).unwrap_or(false);
+            let status = if ok { "connected" } else { "unavailable" };
+            println!("  {name:<10} ({tool}) — {status}");
+        }
+    }
+
+    Ok(())
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+fn chrono_now() -> String {
+    // Use system time formatted as ISO 8601
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format!("{now}")
+}
+
+fn timestamp_slug() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format!("{now}")
+}

--- a/packages/ks/src/cmd/notifications.rs
+++ b/packages/ks/src/cmd/notifications.rs
@@ -248,34 +248,22 @@ async fn fetch_email_body(id: &str) -> Result<String> {
 
 // ── GitHub source ──────────────────────────────────────────────────────
 
-/// Parse owner/repo and number from a REST API URL like
+/// Parse number from a REST API URL like
 /// `https://api.github.com/repos/owner/repo/issues/123`
-fn parse_subject_url(url: &str) -> Option<(String, String, u64)> {
-    let parts: Vec<&str> = url.rsplitn(2, '/').collect();
-    let number: u64 = parts.first()?.parse().ok()?;
-    // URL pattern: .../repos/{owner}/{repo}/issues/{n} or .../repos/{owner}/{repo}/pulls/{n}
-    let segments: Vec<&str> = url.split('/').collect();
-    // Find "repos" index, then owner and repo follow
-    let repos_idx = segments.iter().position(|&s| s == "repos")?;
-    let owner = segments.get(repos_idx + 1)?.to_string();
-    let repo = segments.get(repos_idx + 2)?.to_string();
-    Some((owner, repo, number))
+fn parse_number_from_url(url: &str) -> Option<u64> {
+    url.rsplit('/').next()?.parse().ok()
 }
 
-/// Notification metadata extracted from REST API, before GraphQL enrichment.
-struct NotifMeta {
-    owner: String,
-    repo: String,
-    number: u64,
-    subject_type: String, // "Issue" or "PullRequest"
-    reason: String,
+/// Construct HTML URL from repo + subject type + number.
+fn github_html_url(repo: &str, subject_type: &str, number: u64) -> String {
+    let kind = if subject_type == "PullRequest" { "pull" } else { "issues" };
+    format!("https://github.com/{repo}/{kind}/{number}")
 }
 
-/// Fetch unread GitHub notifications and enrich via a single GraphQL query.
+/// Fetch unread GitHub notifications — metadata only, no enrichment.
 /// ISSUE-REQ-3: Does NOT pass `all=true` — only unread notifications.
-/// Uses 2 API calls total: 1 REST (notifications) + 1 GraphQL (enrichment).
-async fn fetch_github(username: &str) -> Result<(SourceEntry, Vec<String>)> {
-    // ── Call 1: REST — fetch unread notifications ────────────────────
+/// Uses exactly 1 API call. Agent fetches full details JIT during task execution.
+async fn fetch_github(_username: &str) -> Result<(SourceEntry, Vec<String>)> {
     let output = Command::new("gh")
         .args(["api", "/notifications?participating=true&per_page=100"])
         .output()
@@ -298,278 +286,58 @@ async fn fetch_github(username: &str) -> Result<(SourceEntry, Vec<String>)> {
         .filter_map(|n| n.get("id").and_then(|v| v.as_str()).map(String::from))
         .collect();
 
-    // Deduplicate and extract metadata
+    // Deduplicate by subject URL, extract metadata from notification envelope
     let mut seen = std::collections::HashSet::new();
-    let mut metas: Vec<NotifMeta> = Vec::new();
+    let mut items = Vec::new();
 
     for notif in &raw {
         let subject_type = notif
-            .get("subject")
-            .and_then(|s| s.get("type"))
+            .pointer("/subject/type")
             .and_then(|t| t.as_str())
             .unwrap_or("");
         let subject_url = notif
-            .get("subject")
-            .and_then(|s| s.get("url"))
+            .pointer("/subject/url")
             .and_then(|u| u.as_str())
+            .unwrap_or("");
+        let title = notif
+            .pointer("/subject/title")
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
+        let repo = notif
+            .pointer("/repository/full_name")
+            .and_then(|n| n.as_str())
             .unwrap_or("");
         let reason = notif
             .get("reason")
             .and_then(|r| r.as_str())
             .unwrap_or("");
+        let updated_at = notif
+            .get("updated_at")
+            .and_then(|u| u.as_str())
+            .unwrap_or("");
 
-        if subject_type != "Issue" && subject_type != "PullRequest" {
+        if (subject_type != "Issue" && subject_type != "PullRequest")
+            || subject_url.is_empty()
+            || !seen.insert(subject_url.to_string())
+        {
             continue;
         }
-        if subject_url.is_empty() || !seen.insert(subject_url.to_string()) {
-            continue;
-        }
 
-        if let Some((owner, repo, number)) = parse_subject_url(subject_url) {
-            metas.push(NotifMeta {
-                owner,
-                repo,
-                number,
-                subject_type: subject_type.to_string(),
-                reason: reason.to_string(),
-            });
-        }
+        let number = parse_number_from_url(subject_url).unwrap_or(0);
+        let url = github_html_url(repo, subject_type, number);
+
+        items.push(serde_json::json!({
+            "repo": repo,
+            "number": number,
+            "title": title,
+            "url": url,
+            "type": subject_type,
+            "reason": reason,
+            "updated_at": updated_at,
+        }));
     }
 
-    if metas.is_empty() {
-        return Ok((
-            SourceEntry {
-                source: "github".to_string(),
-                data: serde_json::json!({
-                    "github-issues": [],
-                    "github-prs": [],
-                    "github-pr-reviews": [],
-                    "github-issue-comments": [],
-                }),
-            },
-            thread_ids,
-        ));
-    }
-
-    // ── Call 2: GraphQL — enrich all notifications in one query ──────
-    // Build aliased fragments for each notification
-    let mut fragments = Vec::new();
-    for (i, meta) in metas.iter().enumerate() {
-        let alias = format!("n{i}");
-        if meta.subject_type == "Issue" {
-            fragments.push(format!(
-                r#"{alias}: repository(owner: "{owner}", name: "{repo}") {{
-  issue(number: {number}) {{
-    number
-    title
-    url
-    state
-    createdAt
-    assignees(first: 10) {{ nodes {{ login }} }}
-    labels(first: 10) {{ nodes {{ name }} }}
-    comments(last: 1) {{ nodes {{ databaseId author {{ login }} body createdAt }} }}
-  }}
-}}"#,
-                alias = alias,
-                owner = meta.owner,
-                repo = meta.repo,
-                number = meta.number
-            ));
-        } else {
-            // PullRequest — fetch PR details + reviews with comments
-            fragments.push(format!(
-                r#"{alias}: repository(owner: "{owner}", name: "{repo}") {{
-  pullRequest(number: {number}) {{
-    number
-    title
-    url
-    createdAt
-    author {{ login }}
-    headRefName
-    reviews(last: 20) {{
-      nodes {{
-        databaseId
-        author {{ login }}
-        state
-        comments(first: 20) {{ nodes {{ databaseId path body }} }}
-      }}
-    }}
-  }}
-}}"#,
-                alias = alias,
-                owner = meta.owner,
-                repo = meta.repo,
-                number = meta.number
-            ));
-        }
-    }
-
-    let query = format!("{{ {} }}", fragments.join("\n"));
-    let output = Command::new("gh")
-        .args(["api", "graphql", "-f", &format!("query={query}")])
-        .output()
-        .await
-        .context("failed to run gh api graphql")?;
-
-    let gql_data: serde_json::Value = if output.status.success() {
-        let resp: serde_json::Value =
-            serde_json::from_slice(&output.stdout).unwrap_or_default();
-        resp.get("data").cloned().unwrap_or(serde_json::json!({}))
-    } else {
-        eprintln!(
-            "warning: GraphQL enrichment failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        serde_json::json!({})
-    };
-
-    // ── Transform GraphQL response into sources.json schema ─────────
-    let mut issues = Vec::new();
-    let mut prs = Vec::new();
-    let mut reviews = Vec::new();
-    let mut issue_comments = Vec::new();
-
-    for (i, meta) in metas.iter().enumerate() {
-        let alias = format!("n{i}");
-        let repo_full = format!("{}/{}", meta.owner, meta.repo);
-        let repo_data = match gql_data.get(&alias) {
-            Some(d) => d,
-            None => continue,
-        };
-
-        if meta.subject_type == "Issue" {
-            let issue = match repo_data.get("issue") {
-                Some(i) => i,
-                None => continue,
-            };
-            let state = issue.get("state").and_then(|s| s.as_str()).unwrap_or("");
-            if state != "OPEN" {
-                continue;
-            }
-
-            let assignees: Vec<&str> = issue
-                .pointer("/assignees/nodes")
-                .and_then(|a| a.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|n| n.get("login").and_then(|l| l.as_str()))
-                        .collect()
-                })
-                .unwrap_or_default();
-
-            let labels: Vec<&str> = issue
-                .pointer("/labels/nodes")
-                .and_then(|a| a.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|n| n.get("name").and_then(|l| l.as_str()))
-                        .collect()
-                })
-                .unwrap_or_default();
-
-            issues.push(serde_json::json!({
-                "repo": repo_full,
-                "number": issue.get("number"),
-                "title": issue.get("title"),
-                "url": issue.get("url"),
-                "assignees": assignees,
-                "labels": labels,
-                "created_at": issue.get("createdAt"),
-            }));
-
-            // Latest comment
-            if let Some(comment) = issue
-                .pointer("/comments/nodes/0")
-                .filter(|c| !c.is_null())
-            {
-                issue_comments.push(serde_json::json!({
-                    "repo": repo_full,
-                    "issue_number": issue.get("number"),
-                    "comment_id": comment.get("databaseId"),
-                    "author": comment.pointer("/author/login"),
-                    "body": comment.get("body"),
-                    "created_at": comment.get("createdAt"),
-                }));
-            }
-        } else {
-            // PullRequest
-            let pr = match repo_data.get("pullRequest") {
-                Some(p) => p,
-                None => continue,
-            };
-
-            if meta.reason == "review_requested" {
-                prs.push(serde_json::json!({
-                    "repo": repo_full,
-                    "number": pr.get("number"),
-                    "title": pr.get("title"),
-                    "url": pr.get("url"),
-                    "author": pr.pointer("/author/login"),
-                    "created_at": pr.get("createdAt"),
-                }));
-            } else if meta.reason == "author" {
-                // Extract reviews from others with actionable states
-                let review_nodes = pr
-                    .pointer("/reviews/nodes")
-                    .and_then(|n| n.as_array())
-                    .cloned()
-                    .unwrap_or_default();
-
-                for review in &review_nodes {
-                    let reviewer = review
-                        .pointer("/author/login")
-                        .and_then(|l| l.as_str())
-                        .unwrap_or("");
-                    let state = review
-                        .get("state")
-                        .and_then(|s| s.as_str())
-                        .unwrap_or("");
-
-                    if reviewer == username {
-                        continue;
-                    }
-                    if state != "CHANGES_REQUESTED" && state != "COMMENTED" {
-                        continue;
-                    }
-
-                    let comments: Vec<serde_json::Value> = review
-                        .pointer("/comments/nodes")
-                        .and_then(|n| n.as_array())
-                        .map(|arr| {
-                            arr.iter()
-                                .map(|c| {
-                                    serde_json::json!({
-                                        "id": c.get("databaseId"),
-                                        "path": c.get("path"),
-                                        "body": c.get("body"),
-                                    })
-                                })
-                                .collect()
-                        })
-                        .unwrap_or_default();
-
-                    reviews.push(serde_json::json!({
-                        "repo": repo_full,
-                        "pr_number": pr.get("number"),
-                        "pr_title": pr.get("title"),
-                        "pr_url": pr.get("url"),
-                        "pr_branch": pr.get("headRefName"),
-                        "review_id": review.get("databaseId"),
-                        "reviewer": reviewer,
-                        "review_state": state,
-                        "comments": comments,
-                    }));
-                }
-            }
-        }
-    }
-
-    let data = serde_json::json!({
-        "github-issues": issues,
-        "github-prs": prs,
-        "github-pr-reviews": reviews,
-        "github-issue-comments": issue_comments,
-    });
+    let data = serde_json::Value::Array(items);
 
     Ok((
         SourceEntry {
@@ -582,9 +350,21 @@ async fn fetch_github(username: &str) -> Result<(SourceEntry, Vec<String>)> {
 
 // ── Forgejo source ────────────────────────────────────────────────────
 
-/// Forgejo API helper — authenticated GET via curl.
-async fn forgejo_api_get(host: &str, token: &str, path: &str) -> Result<serde_json::Value> {
-    let url = format!("{host}/api/v1{path}");
+/// Construct Forgejo HTML URL from host + repo + subject type + number.
+fn forgejo_html_url(host: &str, repo: &str, subject_type: &str, number: u64) -> String {
+    let kind = if subject_type == "Pull" { "pulls" } else { "issues" };
+    format!("{host}/{repo}/{kind}/{number}")
+}
+
+/// Fetch unread Forgejo notifications — metadata only, no enrichment.
+/// ISSUE-REQ-4: Uses unread-only notifications endpoint.
+/// Uses exactly 1 API call. Agent fetches full details JIT during task execution.
+async fn fetch_forgejo(
+    host: &str,
+    token: &str,
+    _username: &str,
+) -> Result<(SourceEntry, Vec<String>)> {
+    let url = format!("{host}/api/v1/notifications?limit=100");
     let output = Command::new("curl")
         .args([
             "-sf",
@@ -594,42 +374,26 @@ async fn forgejo_api_get(host: &str, token: &str, path: &str) -> Result<serde_js
         ])
         .output()
         .await
-        .context("failed to run curl")?;
+        .context("failed to fetch forgejo notifications")?;
 
     if !output.status.success() {
-        anyhow::bail!("forgejo API request failed: {path}");
+        anyhow::bail!("forgejo notifications API failed");
     }
 
-    Ok(serde_json::from_slice(&output.stdout).unwrap_or(serde_json::json!([])))
-}
-
-/// Fetch unread Forgejo notifications and enrich with issue/PR details.
-/// ISSUE-REQ-4: Uses unread-only notifications endpoint.
-async fn fetch_forgejo(
-    host: &str,
-    token: &str,
-    username: &str,
-) -> Result<(SourceEntry, Vec<String>)> {
-    // Fetch unread notifications only (default — no status-types=read param)
-    let raw = forgejo_api_get(host, token, "/notifications?limit=100").await?;
-    let notifications = raw.as_array().cloned().unwrap_or_default();
+    let raw: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).unwrap_or_default();
 
     // Collect thread IDs for ack manifest
-    let thread_ids: Vec<String> = notifications
+    let thread_ids: Vec<String> = raw
         .iter()
         .filter_map(|n| n.get("id").and_then(|v| v.as_u64()).map(|id| id.to_string()))
         .collect();
 
-    // Deduplicate by subject URL
+    // Deduplicate by subject URL, extract metadata from notification envelope
     let mut seen = std::collections::HashSet::new();
-    struct FjNotif {
-        subject_url: String,
-        repo: String,
-        subject_type: String, // "Issue" or "Pull"
-    }
+    let mut items = Vec::new();
 
-    let mut deduped: Vec<FjNotif> = Vec::new();
-    for notif in &notifications {
+    for notif in &raw {
         let subject_type = notif
             .pointer("/subject/type")
             .and_then(|t| t.as_str())
@@ -638,9 +402,17 @@ async fn fetch_forgejo(
             .pointer("/subject/url")
             .and_then(|u| u.as_str())
             .unwrap_or("");
+        let title = notif
+            .pointer("/subject/title")
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
         let repo = notif
             .pointer("/repository/full_name")
             .and_then(|n| n.as_str())
+            .unwrap_or("");
+        let updated_at = notif
+            .get("updated_at")
+            .and_then(|u| u.as_str())
             .unwrap_or("");
 
         if (subject_type != "Issue" && subject_type != "Pull")
@@ -650,173 +422,20 @@ async fn fetch_forgejo(
             continue;
         }
 
-        deduped.push(FjNotif {
-            subject_url: subject_url.to_string(),
-            repo: repo.to_string(),
-            subject_type: subject_type.to_string(),
-        });
+        let number = parse_number_from_url(subject_url).unwrap_or(0);
+        let html_url = forgejo_html_url(host, repo, subject_type, number);
+
+        items.push(serde_json::json!({
+            "repo": repo,
+            "number": number,
+            "title": title,
+            "url": html_url,
+            "type": subject_type,
+            "updated_at": updated_at,
+        }));
     }
 
-    // Parallel enrichment
-    enum FjResult {
-        Issue(serde_json::Value),
-        Pr(serde_json::Value),
-        Reviews(Vec<serde_json::Value>),
-    }
-
-    let enrich_futures: Vec<_> = deduped
-        .into_iter()
-        .map(|notif| {
-            let host = host.to_string();
-            let token = token.to_string();
-            let username = username.to_string();
-
-            async move {
-                let raw = forgejo_api_get(&host, &token, "")
-                    .await
-                    .ok(); // dummy — we use the full subject_url directly
-
-                // Forgejo subject URLs are full API URLs already
-                let item_raw = {
-                    let output = Command::new("curl")
-                        .args([
-                            "-sf",
-                            "-H", "Accept: application/json",
-                            "-H", &format!("Authorization: token {token}"),
-                            &notif.subject_url,
-                        ])
-                        .output()
-                        .await
-                        .ok()?;
-                    if !output.status.success() {
-                        return None;
-                    }
-                    serde_json::from_slice::<serde_json::Value>(&output.stdout).ok()?
-                };
-                drop(raw);
-
-                let state = item_raw.get("state").and_then(|s| s.as_str()).unwrap_or("");
-                if state != "open" {
-                    return None;
-                }
-
-                match notif.subject_type.as_str() {
-                    "Issue" => {
-                        Some(FjResult::Issue(serde_json::json!({
-                            "repo": notif.repo,
-                            "number": item_raw.get("number"),
-                            "title": item_raw.get("title"),
-                            "url": item_raw.get("html_url"),
-                            "assignee": item_raw.pointer("/assignee/login"),
-                            "labels": item_raw.get("labels").and_then(|l| l.as_array()).map(|arr|
-                                arr.iter().filter_map(|l| l.get("name").and_then(|n| n.as_str())).collect::<Vec<_>>()
-                            ).unwrap_or_default(),
-                            "created_at": item_raw.get("created_at"),
-                        })))
-                    }
-                    "Pull" => {
-                        let pr_author = item_raw.pointer("/user/login").and_then(|l| l.as_str()).unwrap_or("");
-                        let pr_number = item_raw.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
-                        let pr_title = item_raw.get("title").and_then(|t| t.as_str()).unwrap_or("");
-                        let pr_url = item_raw.get("html_url").and_then(|u| u.as_str()).unwrap_or("");
-                        let pr_branch = item_raw.pointer("/head/ref").and_then(|r| r.as_str()).unwrap_or("");
-
-                        if pr_author != username {
-                            // Check if we're a requested reviewer
-                            let is_reviewer = item_raw
-                                .get("requested_reviewers")
-                                .and_then(|r| r.as_array())
-                                .map(|arr| arr.iter().any(|r| r.get("login").and_then(|l| l.as_str()) == Some(&username)))
-                                .unwrap_or(false);
-
-                            if is_reviewer {
-                                return Some(FjResult::Pr(serde_json::json!({
-                                    "repo": notif.repo,
-                                    "number": pr_number,
-                                    "title": pr_title,
-                                    "url": pr_url,
-                                    "author": pr_author,
-                                    "created_at": item_raw.get("created_at"),
-                                })));
-                            }
-                            return None;
-                        }
-
-                        // Author's PR — fetch reviews
-                        let (owner, name) = notif.repo.split_once('/').unwrap_or(("", ""));
-                        let reviews_path = format!("/repos/{owner}/{name}/pulls/{pr_number}/reviews");
-                        let reviews_raw = forgejo_api_get(&host, &token, &reviews_path).await.ok()?;
-                        let reviews_arr = reviews_raw.as_array().cloned().unwrap_or_default();
-
-                        let mut results = Vec::new();
-                        for review in &reviews_arr {
-                            let reviewer = review.pointer("/user/login").and_then(|l| l.as_str()).unwrap_or("");
-                            let review_state = review.get("state").and_then(|s| s.as_str()).unwrap_or("");
-
-                            if reviewer == username {
-                                continue;
-                            }
-                            // Forgejo uses REQUEST_CHANGES and COMMENT
-                            if review_state != "REQUEST_CHANGES" && review_state != "COMMENT" {
-                                continue;
-                            }
-
-                            let review_id = review.get("id").and_then(|i| i.as_u64()).unwrap_or(0);
-                            let comments_path = format!("/repos/{owner}/{name}/pulls/{pr_number}/reviews/{review_id}/comments");
-                            let comments_raw = forgejo_api_get(&host, &token, &comments_path).await.unwrap_or(serde_json::json!([]));
-                            let comments: Vec<serde_json::Value> = comments_raw
-                                .as_array()
-                                .map(|arr| {
-                                    arr.iter()
-                                        .map(|c| serde_json::json!({
-                                            "id": c.get("id"),
-                                            "path": c.get("path"),
-                                            "body": c.get("body"),
-                                        }))
-                                        .collect()
-                                })
-                                .unwrap_or_default();
-
-                            results.push(serde_json::json!({
-                                "repo": notif.repo,
-                                "pr_number": pr_number,
-                                "pr_title": pr_title,
-                                "pr_url": pr_url,
-                                "pr_branch": pr_branch,
-                                "review_id": review_id,
-                                "reviewer": reviewer,
-                                "review_state": review_state,
-                                "comments": comments,
-                            }));
-                        }
-
-                        if results.is_empty() { None } else { Some(FjResult::Reviews(results)) }
-                    }
-                    _ => None,
-                }
-            }
-        })
-        .collect();
-
-    let results = futures::future::join_all(enrich_futures).await;
-
-    let mut issues = Vec::new();
-    let mut prs = Vec::new();
-    let mut reviews = Vec::new();
-
-    for result in results.into_iter().flatten() {
-        match result {
-            FjResult::Issue(i) => issues.push(i),
-            FjResult::Pr(p) => prs.push(p),
-            FjResult::Reviews(mut r) => reviews.append(&mut r),
-        }
-    }
-
-    let data = serde_json::json!({
-        "forgejo-issues": issues,
-        "forgejo-prs": prs,
-        "forgejo-pr-reviews": reviews,
-    });
+    let data = serde_json::Value::Array(items);
 
     Ok((
         SourceEntry {
@@ -949,75 +568,25 @@ async fn execute_list(json: bool) -> Result<()> {
                     }
                 }
             }
-            "github" => {
-                if let Some(issues) = entry.data.get("github-issues").and_then(|v| v.as_array()) {
-                    if !issues.is_empty() {
-                        println!("  Issues:");
-                        for issue in issues {
-                            let repo = issue.get("repo").and_then(|r| r.as_str()).unwrap_or("");
-                            let number = issue.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
-                            let title = issue.get("title").and_then(|t| t.as_str()).unwrap_or("");
-                            println!("    {repo}#{number}: {title}");
-                        }
-                    }
-                }
-                if let Some(prs) = entry.data.get("github-prs").and_then(|v| v.as_array()) {
-                    if !prs.is_empty() {
-                        println!("  PRs requesting review:");
-                        for pr in prs {
-                            let repo = pr.get("repo").and_then(|r| r.as_str()).unwrap_or("");
-                            let number = pr.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
-                            let title = pr.get("title").and_then(|t| t.as_str()).unwrap_or("");
-                            println!("    {repo}#{number}: {title}");
-                        }
-                    }
-                }
-                if let Some(reviews) = entry.data.get("github-pr-reviews").and_then(|v| v.as_array()) {
-                    if !reviews.is_empty() {
-                        println!("  Reviews on your PRs:");
-                        for rev in reviews {
-                            let repo = rev.get("repo").and_then(|r| r.as_str()).unwrap_or("");
-                            let pr_number = rev.get("pr_number").and_then(|n| n.as_u64()).unwrap_or(0);
-                            let reviewer = rev.get("reviewer").and_then(|r| r.as_str()).unwrap_or("");
-                            let state = rev.get("review_state").and_then(|s| s.as_str()).unwrap_or("");
-                            println!("    {repo}#{pr_number}: {reviewer} ({state})");
-                        }
-                    }
-                }
-            }
-            "forgejo" => {
-                if let Some(issues) = entry.data.get("forgejo-issues").and_then(|v| v.as_array()) {
-                    if !issues.is_empty() {
-                        println!("  Issues:");
-                        for issue in issues {
-                            let repo = issue.get("repo").and_then(|r| r.as_str()).unwrap_or("");
-                            let number = issue.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
-                            let title = issue.get("title").and_then(|t| t.as_str()).unwrap_or("");
-                            println!("    {repo}#{number}: {title}");
-                        }
-                    }
-                }
-                if let Some(prs) = entry.data.get("forgejo-prs").and_then(|v| v.as_array()) {
-                    if !prs.is_empty() {
-                        println!("  PRs requesting review:");
-                        for pr in prs {
-                            let repo = pr.get("repo").and_then(|r| r.as_str()).unwrap_or("");
-                            let number = pr.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
-                            let title = pr.get("title").and_then(|t| t.as_str()).unwrap_or("");
-                            println!("    {repo}#{number}: {title}");
-                        }
-                    }
-                }
-                if let Some(reviews) = entry.data.get("forgejo-pr-reviews").and_then(|v| v.as_array()) {
-                    if !reviews.is_empty() {
-                        println!("  Reviews on your PRs:");
-                        for rev in reviews {
-                            let repo = rev.get("repo").and_then(|r| r.as_str()).unwrap_or("");
-                            let pr_number = rev.get("pr_number").and_then(|n| n.as_u64()).unwrap_or(0);
-                            let reviewer = rev.get("reviewer").and_then(|r| r.as_str()).unwrap_or("");
-                            let state = rev.get("review_state").and_then(|s| s.as_str()).unwrap_or("");
-                            println!("    {repo}#{pr_number}: {reviewer} ({state})");
-                        }
+            "github" | "forgejo" => {
+                if let Some(items) = entry.data.as_array() {
+                    for item in items {
+                        let repo = item.get("repo").and_then(|r| r.as_str()).unwrap_or("");
+                        let number = item.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
+                        let title = item.get("title").and_then(|t| t.as_str()).unwrap_or("");
+                        let kind = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                        let reason = item.get("reason").and_then(|r| r.as_str()).unwrap_or("");
+                        let suffix = if !reason.is_empty() {
+                            format!(" ({reason})")
+                        } else {
+                            String::new()
+                        };
+                        let icon = match kind {
+                            "Issue" => "I",
+                            "PullRequest" | "Pull" => "P",
+                            _ => "?",
+                        };
+                        println!("  [{icon}] {repo}#{number}: {title}{suffix}");
                     }
                 }
             }

--- a/packages/ks/src/cmd/notifications.rs
+++ b/packages/ks/src/cmd/notifications.rs
@@ -1,4 +1,4 @@
-//! `ks notifications` — unified notification fetch with source-level read tracking.
+//! `ks notification` — unified notification fetch with source-level read tracking.
 //!
 //! Replaces shell-script fetchers (fetch-email-source, fetch-github-sources) with
 //! a single Rust subcommand that only returns unseen items and supports marking them
@@ -106,6 +106,19 @@ pub async fn execute(args: &NotificationArgs) -> Result<()> {
 
 // ── Fetch ──────────────────────────────────────────────────────────────
 
+/// Resolve GitHub username from env var or gh CLI.
+fn resolve_github_username() -> Option<String> {
+    std::env::var("GITHUB_USERNAME").ok().or_else(|| {
+        std::process::Command::new("gh")
+            .args(["api", "/user", "--jq", ".login"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .filter(|s| !s.is_empty())
+    })
+}
+
 /// Collect a source fetch result into entries and manifest.
 fn collect_source(
     result: Result<(SourceEntry, Vec<String>)>,
@@ -152,32 +165,23 @@ async fn execute_fetch(
     }
 
     if should_fetch("github") {
-        let username = std::env::var("GITHUB_USERNAME").ok().or_else(|| {
-            std::process::Command::new("gh")
-                .args(["api", "/user", "--jq", ".login"])
-                .output()
-                .ok()
-                .filter(|o| o.status.success())
-                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-                .filter(|s| !s.is_empty())
-        });
-        if let Some(ref user) = username {
-            collect_source(
-                fetch_github(user).await,
-                "github",
-                &mut entries,
-                &mut manifest_sources,
-            );
-        }
+        // Username not required for fetch — only used for filtering reviews
+        let username = resolve_github_username();
+        collect_source(
+            fetch_github(username.as_deref().unwrap_or("")).await,
+            "github",
+            &mut entries,
+            &mut manifest_sources,
+        );
     }
 
     if should_fetch("forgejo") {
         let fj_host = std::env::var("FORGEJO_HOST").ok();
         let fj_token = std::env::var("FORGEJO_TOKEN").ok();
-        let fj_user = std::env::var("FORGEJO_USERNAME").ok();
-        if let (Some(ref host), Some(ref token), Some(ref user)) = (&fj_host, &fj_token, &fj_user) {
+        // Username not required — only host + token needed for notification fetch
+        if let (Some(ref host), Some(ref token)) = (&fj_host, &fj_token) {
             collect_source(
-                fetch_forgejo(host, token, user).await,
+                fetch_forgejo(host, token, "").await,
                 "forgejo",
                 &mut entries,
                 &mut manifest_sources,
@@ -270,6 +274,11 @@ async fn fetch_email_body(id: &str) -> Result<String> {
         .output()
         .await?;
 
+    if !output.status.success() {
+        eprintln!("warning: failed to read email body for id {id}");
+        return Ok(String::new());
+    }
+
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
@@ -310,15 +319,10 @@ async fn fetch_github(_username: &str) -> Result<(SourceEntry, Vec<String>)> {
 
     let raw: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap_or_default();
 
-    // Collect thread IDs for manifest (ack needs these)
-    let thread_ids: Vec<String> = raw
-        .iter()
-        .filter_map(|n| n.get("id").and_then(|v| v.as_str()).map(String::from))
-        .collect();
-
-    // Deduplicate by subject URL, extract metadata from notification envelope
+    // Deduplicate by subject URL, extract metadata, and track only emitted thread IDs
     let mut seen = std::collections::HashSet::new();
     let mut items = Vec::new();
+    let mut thread_ids: Vec<String> = Vec::new();
 
     for notif in &raw {
         let subject_type = notif
@@ -329,6 +333,18 @@ async fn fetch_github(_username: &str) -> Result<(SourceEntry, Vec<String>)> {
             .pointer("/subject/url")
             .and_then(|u| u.as_str())
             .unwrap_or("");
+
+        if (subject_type != "Issue" && subject_type != "PullRequest")
+            || subject_url.is_empty()
+            || !seen.insert(subject_url.to_string())
+        {
+            continue;
+        }
+
+        let Some(number) = parse_number_from_url(subject_url) else {
+            continue; // Skip unparseable URLs rather than emitting number=0
+        };
+
         let title = notif
             .pointer("/subject/title")
             .and_then(|t| t.as_str())
@@ -342,15 +358,6 @@ async fn fetch_github(_username: &str) -> Result<(SourceEntry, Vec<String>)> {
             .get("updated_at")
             .and_then(|u| u.as_str())
             .unwrap_or("");
-
-        if (subject_type != "Issue" && subject_type != "PullRequest")
-            || subject_url.is_empty()
-            || !seen.insert(subject_url.to_string())
-        {
-            continue;
-        }
-
-        let number = parse_number_from_url(subject_url).unwrap_or(0);
         let url = github_html_url(repo, subject_type, number);
 
         items.push(serde_json::json!({
@@ -362,6 +369,11 @@ async fn fetch_github(_username: &str) -> Result<(SourceEntry, Vec<String>)> {
             "reason": reason,
             "updated_at": updated_at,
         }));
+
+        // Only track thread IDs for items we actually emit
+        if let Some(id) = notif.get("id").and_then(|v| v.as_str()) {
+            thread_ids.push(id.to_string());
+        }
     }
 
     let data = serde_json::Value::Array(items);
@@ -656,30 +668,21 @@ async fn fetch_all_sources() -> Vec<SourceEntry> {
         }
     }
 
-    let gh_user = std::env::var("GITHUB_USERNAME").ok().or_else(|| {
-        std::process::Command::new("gh")
-            .args(["api", "/user", "--jq", ".login"])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-            .filter(|s| !s.is_empty())
-    });
-    if let Some(ref user) = gh_user {
-        if let Ok((entry, _)) = fetch_github(user).await {
-            if entry.data != serde_json::json!({}) {
-                entries.push(entry);
-            }
+    let gh_user = resolve_github_username();
+    if let Ok((entry, _)) = fetch_github(gh_user.as_deref().unwrap_or("")).await {
+        let empty = serde_json::Value::Array(vec![]);
+        if entry.data != empty {
+            entries.push(entry);
         }
     }
 
-    // Forgejo
+    // Forgejo — only host + token required
     let fj_host = std::env::var("FORGEJO_HOST").ok();
     let fj_token = std::env::var("FORGEJO_TOKEN").ok();
-    let fj_user = std::env::var("FORGEJO_USERNAME").ok();
-    if let (Some(ref host), Some(ref token), Some(ref user)) = (&fj_host, &fj_token, &fj_user) {
-        if let Ok((entry, _)) = fetch_forgejo(host, token, user).await {
-            if entry.data != serde_json::json!({}) {
+    if let (Some(ref host), Some(ref token)) = (&fj_host, &fj_token) {
+        if let Ok((entry, _)) = fetch_forgejo(host, token, "").await {
+            let empty = serde_json::Value::Array(vec![]);
+            if entry.data != empty {
                 entries.push(entry);
             }
         }

--- a/packages/ks/src/cmd/notifications.rs
+++ b/packages/ks/src/cmd/notifications.rs
@@ -26,9 +26,9 @@ fn state_dir() -> PathBuf {
 // ── CLI definitions ────────────────────────────────────────────────────
 
 #[derive(Args)]
-pub struct NotificationsArgs {
+pub struct NotificationArgs {
     #[command(subcommand)]
-    pub command: Option<NotificationsCommand>,
+    pub command: Option<NotificationCommand>,
 
     /// Output as JSON instead of human-readable table.
     #[arg(long, global = true)]
@@ -36,7 +36,7 @@ pub struct NotificationsArgs {
 }
 
 #[derive(Subcommand)]
-pub enum NotificationsCommand {
+pub enum NotificationCommand {
     /// Fetch unseen notifications, output JSON (machine-readable).
     Fetch {
         /// Write a manifest file for later ack.
@@ -90,16 +90,16 @@ struct EmailEnvelope {
 
 // ── Entrypoint ─────────────────────────────────────────────────────────
 
-pub async fn execute(args: &NotificationsArgs) -> Result<()> {
+pub async fn execute(args: &NotificationArgs) -> Result<()> {
     match &args.command {
-        Some(NotificationsCommand::Fetch { manifest, sources }) => {
+        Some(NotificationCommand::Fetch { manifest, sources }) => {
             let filter: Option<Vec<&str>> = sources
                 .as_ref()
                 .map(|s| s.split(',').map(|s| s.trim()).collect());
             execute_fetch(*manifest, filter.as_deref(), args.json).await
         }
-        Some(NotificationsCommand::Ack { manifest }) => execute_ack(manifest).await,
-        Some(NotificationsCommand::Sources) => execute_sources(args.json).await,
+        Some(NotificationCommand::Ack { manifest }) => execute_ack(manifest).await,
+        Some(NotificationCommand::Sources) => execute_sources(args.json).await,
         None => execute_list(args.json).await,
     }
 }
@@ -155,6 +155,29 @@ async fn execute_fetch(
                     }
                 }
                 Err(e) => eprintln!("warning: github fetch failed: {e}"),
+            }
+        }
+    }
+
+    // ISSUE-REQ-4: Forgejo — fetch only unread
+    if should_fetch("forgejo") {
+        let fj_host = std::env::var("FORGEJO_HOST").ok();
+        let fj_token = std::env::var("FORGEJO_TOKEN").ok();
+        let fj_user = std::env::var("FORGEJO_USERNAME").ok();
+        if let (Some(ref host), Some(ref token), Some(ref user)) = (&fj_host, &fj_token, &fj_user) {
+            match fetch_forgejo(host, token, user).await {
+                Ok((entry, ids)) => {
+                    if !ids.is_empty() {
+                        manifest_sources.push(ManifestSource {
+                            source: "forgejo".to_string(),
+                            ids,
+                        });
+                    }
+                    if entry.data != serde_json::Value::Array(vec![]) {
+                        entries.push(entry);
+                    }
+                }
+                Err(e) => eprintln!("warning: forgejo fetch failed: {e}"),
             }
         }
     }
@@ -726,12 +749,7 @@ async fn execute_sources(json: bool) -> Result<()> {
 // ── Helpers ────────────────────────────────────────────────────────────
 
 fn chrono_now() -> String {
-    // Use system time formatted as ISO 8601
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    format!("{now}")
+    crate::cmd::tasks::iso_now()
 }
 
 fn timestamp_slug() -> String {

--- a/packages/ks/src/cmd/notifications.rs
+++ b/packages/ks/src/cmd/notifications.rs
@@ -183,11 +183,11 @@ async fn execute_fetch(
 // ── Email source ───────────────────────────────────────────────────────
 
 /// Fetch unseen email envelopes and enrich with bodies.
-/// ISSUE-REQ-2: Uses `--filter "NOT SEEN"` to exclude already-read messages.
+/// ISSUE-REQ-2: Uses `not flag seen` query to exclude already-read messages.
 async fn fetch_email() -> Result<(SourceEntry, Vec<String>)> {
     // Fetch only unseen envelopes
     let output = Command::new("himalaya")
-        .args(["envelope", "list", "--filter", "NOT SEEN", "-o", "json", "--page-size", "50"])
+        .args(["envelope", "list", "-o", "json", "-s", "50", "not", "flag", "seen"])
         .output()
         .await
         .context("failed to run himalaya")?;
@@ -702,7 +702,16 @@ async fn fetch_all_sources() -> Vec<SourceEntry> {
         }
     }
 
-    if let Ok(ref user) = std::env::var("GITHUB_USERNAME") {
+    let gh_user = std::env::var("GITHUB_USERNAME").ok().or_else(|| {
+        std::process::Command::new("gh")
+            .args(["api", "/user", "--jq", ".login"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .filter(|s| !s.is_empty())
+    });
+    if let Some(ref user) = gh_user {
         if let Ok((entry, _)) = fetch_github(user).await {
             if entry.data != serde_json::json!({}) {
                 entries.push(entry);

--- a/packages/ks/src/cmd/notifications.rs
+++ b/packages/ks/src/cmd/notifications.rs
@@ -204,10 +204,21 @@ async fn fetch_email() -> Result<(SourceEntry, Vec<String>)> {
 
     let ids: Vec<String> = envelopes.iter().map(|e| e.id.clone()).collect();
 
-    // Enrich each envelope with its body
+    // Enrich each envelope with its body — parallel fetches
+    let body_futures: Vec<_> = envelopes
+        .iter()
+        .map(|env| {
+            let id = env.id.clone();
+            async move {
+                let body = fetch_email_body(&id).await.unwrap_or_default();
+                (id, body)
+            }
+        })
+        .collect();
+    let bodies: Vec<_> = futures::future::join_all(body_futures).await;
+
     let mut enriched = Vec::new();
-    for env in &envelopes {
-        let body = fetch_email_body(&env.id).await.unwrap_or_default();
+    for (env, (_id, body)) in envelopes.iter().zip(bodies.into_iter()) {
         let mut obj = serde_json::Map::new();
         obj.insert("id".to_string(), serde_json::Value::String(env.id.clone()));
         for (k, v) in &env.rest {
@@ -269,59 +280,93 @@ async fn fetch_github(username: &str) -> Result<(SourceEntry, Vec<String>)> {
     // Deduplicate by subject URL, keep most recent
     let notifications = dedup_notifications(&raw);
 
-    // Phase 2-4: Enrich (issues, PRs, reviews) — mirrors fetch-github-sources
+    // Phase 2-4: Enrich (issues, PRs, reviews) — parallel, mirrors fetch-github-sources
+    enum EnrichResult {
+        Issue(serde_json::Value, Option<serde_json::Value>),
+        Pr(serde_json::Value),
+        Reviews(Vec<serde_json::Value>),
+    }
+
+    let enrich_futures: Vec<_> = notifications
+        .iter()
+        .filter_map(|notif| {
+            let subject_type = notif
+                .get("subject")
+                .and_then(|s| s.get("type"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("")
+                .to_string();
+            let subject_url = notif
+                .get("subject")
+                .and_then(|s| s.get("url"))
+                .and_then(|u| u.as_str())
+                .unwrap_or("")
+                .to_string();
+            let repo = notif
+                .get("repository")
+                .and_then(|r| r.get("full_name"))
+                .and_then(|n| n.as_str())
+                .unwrap_or("")
+                .to_string();
+            let reason = notif
+                .get("reason")
+                .and_then(|r| r.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            if subject_url.is_empty() {
+                return None;
+            }
+
+            let notif = notif.clone();
+            let username = username.to_string();
+
+            Some(async move {
+                match subject_type.as_str() {
+                    "Issue" => {
+                        if let Ok(issue) = enrich_issue(&subject_url, &repo, &notif).await {
+                            let comment =
+                                enrich_issue_comment(&notif, &repo, &issue).await;
+                            Some(EnrichResult::Issue(issue, comment))
+                        } else {
+                            None
+                        }
+                    }
+                    "PullRequest" if reason == "review_requested" => {
+                        enrich_pr(&subject_url, &repo)
+                            .await
+                            .ok()
+                            .map(EnrichResult::Pr)
+                    }
+                    "PullRequest" if reason == "author" => {
+                        enrich_reviews(&subject_url, &repo, &username)
+                            .await
+                            .ok()
+                            .map(EnrichResult::Reviews)
+                    }
+                    _ => None,
+                }
+            })
+        })
+        .collect();
+
+    let results = futures::future::join_all(enrich_futures).await;
+
     let mut issues = Vec::new();
     let mut prs = Vec::new();
     let mut reviews = Vec::new();
     let mut issue_comments = Vec::new();
 
-    for notif in &notifications {
-        let subject_type = notif
-            .get("subject")
-            .and_then(|s| s.get("type"))
-            .and_then(|t| t.as_str())
-            .unwrap_or("");
-        let subject_url = notif
-            .get("subject")
-            .and_then(|s| s.get("url"))
-            .and_then(|u| u.as_str())
-            .unwrap_or("");
-        let repo = notif
-            .get("repository")
-            .and_then(|r| r.get("full_name"))
-            .and_then(|n| n.as_str())
-            .unwrap_or("");
-        let reason = notif
-            .get("reason")
-            .and_then(|r| r.as_str())
-            .unwrap_or("");
-
-        if subject_url.is_empty() {
-            continue;
-        }
-
-        match subject_type {
-            "Issue" => {
-                if let Ok(issue) = enrich_issue(subject_url, repo, notif).await {
-                    if let Some(comment) =
-                        enrich_issue_comment(notif, repo, &issue).await
-                    {
-                        issue_comments.push(comment);
-                    }
-                    issues.push(issue);
+    for result in results.into_iter().flatten() {
+        match result {
+            EnrichResult::Issue(issue, comment) => {
+                issues.push(issue);
+                if let Some(c) = comment {
+                    issue_comments.push(c);
                 }
             }
-            "PullRequest" if reason == "review_requested" => {
-                if let Ok(pr) = enrich_pr(subject_url, repo).await {
-                    prs.push(pr);
-                }
-            }
-            "PullRequest" if reason == "author" => {
-                if let Ok(mut rev) = enrich_reviews(subject_url, repo, username).await {
-                    reviews.append(&mut rev);
-                }
-            }
-            _ => {}
+            EnrichResult::Pr(pr) => prs.push(pr),
+            EnrichResult::Reviews(mut revs) => reviews.append(&mut revs),
         }
     }
 

--- a/packages/ks/src/cmd/notifications.rs
+++ b/packages/ks/src/cmd/notifications.rs
@@ -580,6 +580,253 @@ async fn fetch_github(username: &str) -> Result<(SourceEntry, Vec<String>)> {
     ))
 }
 
+// ── Forgejo source ────────────────────────────────────────────────────
+
+/// Forgejo API helper — authenticated GET via curl.
+async fn forgejo_api_get(host: &str, token: &str, path: &str) -> Result<serde_json::Value> {
+    let url = format!("{host}/api/v1{path}");
+    let output = Command::new("curl")
+        .args([
+            "-sf",
+            "-H", "Accept: application/json",
+            "-H", &format!("Authorization: token {token}"),
+            &url,
+        ])
+        .output()
+        .await
+        .context("failed to run curl")?;
+
+    if !output.status.success() {
+        anyhow::bail!("forgejo API request failed: {path}");
+    }
+
+    Ok(serde_json::from_slice(&output.stdout).unwrap_or(serde_json::json!([])))
+}
+
+/// Fetch unread Forgejo notifications and enrich with issue/PR details.
+/// ISSUE-REQ-4: Uses unread-only notifications endpoint.
+async fn fetch_forgejo(
+    host: &str,
+    token: &str,
+    username: &str,
+) -> Result<(SourceEntry, Vec<String>)> {
+    // Fetch unread notifications only (default — no status-types=read param)
+    let raw = forgejo_api_get(host, token, "/notifications?limit=100").await?;
+    let notifications = raw.as_array().cloned().unwrap_or_default();
+
+    // Collect thread IDs for ack manifest
+    let thread_ids: Vec<String> = notifications
+        .iter()
+        .filter_map(|n| n.get("id").and_then(|v| v.as_u64()).map(|id| id.to_string()))
+        .collect();
+
+    // Deduplicate by subject URL
+    let mut seen = std::collections::HashSet::new();
+    struct FjNotif {
+        subject_url: String,
+        repo: String,
+        subject_type: String, // "Issue" or "Pull"
+    }
+
+    let mut deduped: Vec<FjNotif> = Vec::new();
+    for notif in &notifications {
+        let subject_type = notif
+            .pointer("/subject/type")
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
+        let subject_url = notif
+            .pointer("/subject/url")
+            .and_then(|u| u.as_str())
+            .unwrap_or("");
+        let repo = notif
+            .pointer("/repository/full_name")
+            .and_then(|n| n.as_str())
+            .unwrap_or("");
+
+        if (subject_type != "Issue" && subject_type != "Pull")
+            || subject_url.is_empty()
+            || !seen.insert(subject_url.to_string())
+        {
+            continue;
+        }
+
+        deduped.push(FjNotif {
+            subject_url: subject_url.to_string(),
+            repo: repo.to_string(),
+            subject_type: subject_type.to_string(),
+        });
+    }
+
+    // Parallel enrichment
+    enum FjResult {
+        Issue(serde_json::Value),
+        Pr(serde_json::Value),
+        Reviews(Vec<serde_json::Value>),
+    }
+
+    let enrich_futures: Vec<_> = deduped
+        .into_iter()
+        .map(|notif| {
+            let host = host.to_string();
+            let token = token.to_string();
+            let username = username.to_string();
+
+            async move {
+                let raw = forgejo_api_get(&host, &token, "")
+                    .await
+                    .ok(); // dummy — we use the full subject_url directly
+
+                // Forgejo subject URLs are full API URLs already
+                let item_raw = {
+                    let output = Command::new("curl")
+                        .args([
+                            "-sf",
+                            "-H", "Accept: application/json",
+                            "-H", &format!("Authorization: token {token}"),
+                            &notif.subject_url,
+                        ])
+                        .output()
+                        .await
+                        .ok()?;
+                    if !output.status.success() {
+                        return None;
+                    }
+                    serde_json::from_slice::<serde_json::Value>(&output.stdout).ok()?
+                };
+                drop(raw);
+
+                let state = item_raw.get("state").and_then(|s| s.as_str()).unwrap_or("");
+                if state != "open" {
+                    return None;
+                }
+
+                match notif.subject_type.as_str() {
+                    "Issue" => {
+                        Some(FjResult::Issue(serde_json::json!({
+                            "repo": notif.repo,
+                            "number": item_raw.get("number"),
+                            "title": item_raw.get("title"),
+                            "url": item_raw.get("html_url"),
+                            "assignee": item_raw.pointer("/assignee/login"),
+                            "labels": item_raw.get("labels").and_then(|l| l.as_array()).map(|arr|
+                                arr.iter().filter_map(|l| l.get("name").and_then(|n| n.as_str())).collect::<Vec<_>>()
+                            ).unwrap_or_default(),
+                            "created_at": item_raw.get("created_at"),
+                        })))
+                    }
+                    "Pull" => {
+                        let pr_author = item_raw.pointer("/user/login").and_then(|l| l.as_str()).unwrap_or("");
+                        let pr_number = item_raw.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
+                        let pr_title = item_raw.get("title").and_then(|t| t.as_str()).unwrap_or("");
+                        let pr_url = item_raw.get("html_url").and_then(|u| u.as_str()).unwrap_or("");
+                        let pr_branch = item_raw.pointer("/head/ref").and_then(|r| r.as_str()).unwrap_or("");
+
+                        if pr_author != username {
+                            // Check if we're a requested reviewer
+                            let is_reviewer = item_raw
+                                .get("requested_reviewers")
+                                .and_then(|r| r.as_array())
+                                .map(|arr| arr.iter().any(|r| r.get("login").and_then(|l| l.as_str()) == Some(&username)))
+                                .unwrap_or(false);
+
+                            if is_reviewer {
+                                return Some(FjResult::Pr(serde_json::json!({
+                                    "repo": notif.repo,
+                                    "number": pr_number,
+                                    "title": pr_title,
+                                    "url": pr_url,
+                                    "author": pr_author,
+                                    "created_at": item_raw.get("created_at"),
+                                })));
+                            }
+                            return None;
+                        }
+
+                        // Author's PR — fetch reviews
+                        let (owner, name) = notif.repo.split_once('/').unwrap_or(("", ""));
+                        let reviews_path = format!("/repos/{owner}/{name}/pulls/{pr_number}/reviews");
+                        let reviews_raw = forgejo_api_get(&host, &token, &reviews_path).await.ok()?;
+                        let reviews_arr = reviews_raw.as_array().cloned().unwrap_or_default();
+
+                        let mut results = Vec::new();
+                        for review in &reviews_arr {
+                            let reviewer = review.pointer("/user/login").and_then(|l| l.as_str()).unwrap_or("");
+                            let review_state = review.get("state").and_then(|s| s.as_str()).unwrap_or("");
+
+                            if reviewer == username {
+                                continue;
+                            }
+                            // Forgejo uses REQUEST_CHANGES and COMMENT
+                            if review_state != "REQUEST_CHANGES" && review_state != "COMMENT" {
+                                continue;
+                            }
+
+                            let review_id = review.get("id").and_then(|i| i.as_u64()).unwrap_or(0);
+                            let comments_path = format!("/repos/{owner}/{name}/pulls/{pr_number}/reviews/{review_id}/comments");
+                            let comments_raw = forgejo_api_get(&host, &token, &comments_path).await.unwrap_or(serde_json::json!([]));
+                            let comments: Vec<serde_json::Value> = comments_raw
+                                .as_array()
+                                .map(|arr| {
+                                    arr.iter()
+                                        .map(|c| serde_json::json!({
+                                            "id": c.get("id"),
+                                            "path": c.get("path"),
+                                            "body": c.get("body"),
+                                        }))
+                                        .collect()
+                                })
+                                .unwrap_or_default();
+
+                            results.push(serde_json::json!({
+                                "repo": notif.repo,
+                                "pr_number": pr_number,
+                                "pr_title": pr_title,
+                                "pr_url": pr_url,
+                                "pr_branch": pr_branch,
+                                "review_id": review_id,
+                                "reviewer": reviewer,
+                                "review_state": review_state,
+                                "comments": comments,
+                            }));
+                        }
+
+                        if results.is_empty() { None } else { Some(FjResult::Reviews(results)) }
+                    }
+                    _ => None,
+                }
+            }
+        })
+        .collect();
+
+    let results = futures::future::join_all(enrich_futures).await;
+
+    let mut issues = Vec::new();
+    let mut prs = Vec::new();
+    let mut reviews = Vec::new();
+
+    for result in results.into_iter().flatten() {
+        match result {
+            FjResult::Issue(i) => issues.push(i),
+            FjResult::Pr(p) => prs.push(p),
+            FjResult::Reviews(mut r) => reviews.append(&mut r),
+        }
+    }
+
+    let data = serde_json::json!({
+        "forgejo-issues": issues,
+        "forgejo-prs": prs,
+        "forgejo-pr-reviews": reviews,
+    });
+
+    Ok((
+        SourceEntry {
+            source: "forgejo".to_string(),
+            data,
+        },
+        thread_ids,
+    ))
+}
+
 // ── Ack ────────────────────────────────────────────────────────────────
 
 /// ISSUE-REQ-6: Mark items as read at the source.
@@ -593,6 +840,7 @@ async fn execute_ack(manifest_path: &PathBuf) -> Result<()> {
         match source.source.as_str() {
             "email" => ack_email(&source.ids).await?,
             "github" => ack_github(&source.ids).await?,
+            "forgejo" => ack_forgejo(&source.ids).await?,
             other => eprintln!("warning: unknown source in manifest: {other}"),
         }
     }
@@ -632,6 +880,42 @@ async fn ack_github(thread_ids: &[String]) -> Result<()> {
             eprintln!("warning: failed to mark GitHub thread {id} as read");
         }
     }
+    Ok(())
+}
+
+/// Mark Forgejo notification threads as read.
+async fn ack_forgejo(thread_ids: &[String]) -> Result<()> {
+    let host = std::env::var("FORGEJO_HOST").unwrap_or_else(|_| "https://git.ncrmro.com".to_string());
+    let token = std::env::var("FORGEJO_TOKEN").unwrap_or_default();
+    if token.is_empty() {
+        eprintln!("warning: FORGEJO_TOKEN not set, skipping forgejo ack");
+        return Ok(());
+    }
+
+    let futures: Vec<_> = thread_ids
+        .iter()
+        .map(|id| {
+            let url = format!("{host}/api/v1/notifications/threads/{id}");
+            let token = token.clone();
+            async move {
+                let status = Command::new("curl")
+                    .args([
+                        "-sf", "-X", "PATCH",
+                        "-H", "Accept: application/json",
+                        "-H", &format!("Authorization: token {token}"),
+                        &url,
+                    ])
+                    .status()
+                    .await;
+
+                if status.map(|s| !s.success()).unwrap_or(true) {
+                    eprintln!("warning: failed to mark Forgejo thread {id} as read");
+                }
+            }
+        })
+        .collect();
+
+    futures::future::join_all(futures).await;
     Ok(())
 }
 
@@ -701,6 +985,42 @@ async fn execute_list(json: bool) -> Result<()> {
                     }
                 }
             }
+            "forgejo" => {
+                if let Some(issues) = entry.data.get("forgejo-issues").and_then(|v| v.as_array()) {
+                    if !issues.is_empty() {
+                        println!("  Issues:");
+                        for issue in issues {
+                            let repo = issue.get("repo").and_then(|r| r.as_str()).unwrap_or("");
+                            let number = issue.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
+                            let title = issue.get("title").and_then(|t| t.as_str()).unwrap_or("");
+                            println!("    {repo}#{number}: {title}");
+                        }
+                    }
+                }
+                if let Some(prs) = entry.data.get("forgejo-prs").and_then(|v| v.as_array()) {
+                    if !prs.is_empty() {
+                        println!("  PRs requesting review:");
+                        for pr in prs {
+                            let repo = pr.get("repo").and_then(|r| r.as_str()).unwrap_or("");
+                            let number = pr.get("number").and_then(|n| n.as_u64()).unwrap_or(0);
+                            let title = pr.get("title").and_then(|t| t.as_str()).unwrap_or("");
+                            println!("    {repo}#{number}: {title}");
+                        }
+                    }
+                }
+                if let Some(reviews) = entry.data.get("forgejo-pr-reviews").and_then(|v| v.as_array()) {
+                    if !reviews.is_empty() {
+                        println!("  Reviews on your PRs:");
+                        for rev in reviews {
+                            let repo = rev.get("repo").and_then(|r| r.as_str()).unwrap_or("");
+                            let pr_number = rev.get("pr_number").and_then(|n| n.as_u64()).unwrap_or(0);
+                            let reviewer = rev.get("reviewer").and_then(|r| r.as_str()).unwrap_or("");
+                            let state = rev.get("review_state").and_then(|s| s.as_str()).unwrap_or("");
+                            println!("    {repo}#{pr_number}: {reviewer} ({state})");
+                        }
+                    }
+                }
+            }
             _ => {
                 println!("  {}", serde_json::to_string_pretty(&entry.data)?);
             }
@@ -731,6 +1051,18 @@ async fn fetch_all_sources() -> Vec<SourceEntry> {
     });
     if let Some(ref user) = gh_user {
         if let Ok((entry, _)) = fetch_github(user).await {
+            if entry.data != serde_json::json!({}) {
+                entries.push(entry);
+            }
+        }
+    }
+
+    // Forgejo
+    let fj_host = std::env::var("FORGEJO_HOST").ok();
+    let fj_token = std::env::var("FORGEJO_TOKEN").ok();
+    let fj_user = std::env::var("FORGEJO_USERNAME").ok();
+    if let (Some(ref host), Some(ref token), Some(ref user)) = (&fj_host, &fj_token, &fj_user) {
+        if let Ok((entry, _)) = fetch_forgejo(host, token, user).await {
             if entry.data != serde_json::json!({}) {
                 entries.push(entry);
             }
@@ -773,6 +1105,37 @@ async fn execute_sources(json: bool) -> Result<()> {
         "tool": "gh",
         "available": gh_ok,
         "username": std::env::var("GITHUB_USERNAME").unwrap_or_default(),
+    }));
+
+    // Check Forgejo
+    let fj_host = std::env::var("FORGEJO_HOST").unwrap_or_default();
+    let fj_token = std::env::var("FORGEJO_TOKEN").ok();
+    let fj_ok = if let Some(ref token) = fj_token {
+        if !fj_host.is_empty() {
+            Command::new("curl")
+                .args([
+                    "-sf",
+                    "-H", "Accept: application/json",
+                    "-H", &format!("Authorization: token {token}"),
+                    &format!("{fj_host}/api/v1/user"),
+                ])
+                .output()
+                .await
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    sources.push(serde_json::json!({
+        "source": "forgejo",
+        "tool": "curl",
+        "available": fj_ok,
+        "host": fj_host,
+        "username": std::env::var("FORGEJO_USERNAME").unwrap_or_default(),
     }));
 
     if json {

--- a/packages/ks/src/cmd/notifications.rs
+++ b/packages/ks/src/cmd/notifications.rs
@@ -106,6 +106,31 @@ pub async fn execute(args: &NotificationArgs) -> Result<()> {
 
 // ── Fetch ──────────────────────────────────────────────────────────────
 
+/// Collect a source fetch result into entries and manifest.
+fn collect_source(
+    result: Result<(SourceEntry, Vec<String>)>,
+    source_name: &str,
+    entries: &mut Vec<SourceEntry>,
+    manifest_sources: &mut Vec<ManifestSource>,
+) {
+    match result {
+        Ok((entry, ids)) => {
+            if !ids.is_empty() {
+                manifest_sources.push(ManifestSource {
+                    source: source_name.to_string(),
+                    ids,
+                });
+            }
+            let empty_array = serde_json::Value::Array(vec![]);
+            let empty_object = serde_json::json!({});
+            if entry.data != empty_array && entry.data != empty_object {
+                entries.push(entry);
+            }
+        }
+        Err(e) => eprintln!("warning: {source_name} fetch failed: {e}"),
+    }
+}
+
 async fn execute_fetch(
     write_manifest: bool,
     source_filter: Option<&[&str]>,
@@ -114,71 +139,49 @@ async fn execute_fetch(
     let mut entries: Vec<SourceEntry> = Vec::new();
     let mut manifest_sources: Vec<ManifestSource> = Vec::new();
 
-    let should_fetch = |name: &str| -> bool {
-        source_filter
-            .map(|f| f.contains(&name))
-            .unwrap_or(true)
-    };
+    let should_fetch =
+        |name: &str| -> bool { source_filter.map(|f| f.contains(&name)).unwrap_or(true) };
 
-    // ISSUE-REQ-2: Email — fetch only UNSEEN via himalaya filter
     if should_fetch("email") {
-        match fetch_email().await {
-            Ok((entry, ids)) => {
-                if !ids.is_empty() {
-                    manifest_sources.push(ManifestSource {
-                        source: "email".to_string(),
-                        ids,
-                    });
-                }
-                if entry.data != serde_json::Value::Array(vec![]) {
-                    entries.push(entry);
-                }
-            }
-            Err(e) => eprintln!("warning: email fetch failed: {e}"),
-        }
+        collect_source(
+            fetch_email().await,
+            "email",
+            &mut entries,
+            &mut manifest_sources,
+        );
     }
 
-    // ISSUE-REQ-3: GitHub — fetch only unread (no all=true)
     if should_fetch("github") {
-        let username = std::env::var("GITHUB_USERNAME").ok();
+        let username = std::env::var("GITHUB_USERNAME").ok().or_else(|| {
+            std::process::Command::new("gh")
+                .args(["api", "/user", "--jq", ".login"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                .filter(|s| !s.is_empty())
+        });
         if let Some(ref user) = username {
-            match fetch_github(user).await {
-                Ok((entry, ids)) => {
-                    if !ids.is_empty() {
-                        manifest_sources.push(ManifestSource {
-                            source: "github".to_string(),
-                            ids,
-                        });
-                    }
-                    if entry.data != serde_json::json!({}) {
-                        entries.push(entry);
-                    }
-                }
-                Err(e) => eprintln!("warning: github fetch failed: {e}"),
-            }
+            collect_source(
+                fetch_github(user).await,
+                "github",
+                &mut entries,
+                &mut manifest_sources,
+            );
         }
     }
 
-    // ISSUE-REQ-4: Forgejo — fetch only unread
     if should_fetch("forgejo") {
         let fj_host = std::env::var("FORGEJO_HOST").ok();
         let fj_token = std::env::var("FORGEJO_TOKEN").ok();
         let fj_user = std::env::var("FORGEJO_USERNAME").ok();
         if let (Some(ref host), Some(ref token), Some(ref user)) = (&fj_host, &fj_token, &fj_user) {
-            match fetch_forgejo(host, token, user).await {
-                Ok((entry, ids)) => {
-                    if !ids.is_empty() {
-                        manifest_sources.push(ManifestSource {
-                            source: "forgejo".to_string(),
-                            ids,
-                        });
-                    }
-                    if entry.data != serde_json::Value::Array(vec![]) {
-                        entries.push(entry);
-                    }
-                }
-                Err(e) => eprintln!("warning: forgejo fetch failed: {e}"),
-            }
+            collect_source(
+                fetch_forgejo(host, token, user).await,
+                "forgejo",
+                &mut entries,
+                &mut manifest_sources,
+            );
         }
     }
 
@@ -210,7 +213,9 @@ async fn execute_fetch(
 async fn fetch_email() -> Result<(SourceEntry, Vec<String>)> {
     // Fetch only unseen envelopes
     let output = Command::new("himalaya")
-        .args(["envelope", "list", "-o", "json", "-s", "50", "not", "flag", "seen"])
+        .args([
+            "envelope", "list", "-o", "json", "-s", "50", "not", "flag", "seen",
+        ])
         .output()
         .await
         .context("failed to run himalaya")?;
@@ -222,8 +227,7 @@ async fn fetch_email() -> Result<(SourceEntry, Vec<String>)> {
         );
     }
 
-    let envelopes: Vec<EmailEnvelope> =
-        serde_json::from_slice(&output.stdout).unwrap_or_default();
+    let envelopes: Vec<EmailEnvelope> = serde_json::from_slice(&output.stdout).unwrap_or_default();
 
     let ids: Vec<String> = envelopes.iter().map(|e| e.id.clone()).collect();
 
@@ -279,7 +283,11 @@ fn parse_number_from_url(url: &str) -> Option<u64> {
 
 /// Construct HTML URL from repo + subject type + number.
 fn github_html_url(repo: &str, subject_type: &str, number: u64) -> String {
-    let kind = if subject_type == "PullRequest" { "pull" } else { "issues" };
+    let kind = if subject_type == "PullRequest" {
+        "pull"
+    } else {
+        "issues"
+    };
     format!("https://github.com/{repo}/{kind}/{number}")
 }
 
@@ -300,8 +308,7 @@ async fn fetch_github(_username: &str) -> Result<(SourceEntry, Vec<String>)> {
         );
     }
 
-    let raw: Vec<serde_json::Value> =
-        serde_json::from_slice(&output.stdout).unwrap_or_default();
+    let raw: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap_or_default();
 
     // Collect thread IDs for manifest (ack needs these)
     let thread_ids: Vec<String> = raw
@@ -330,10 +337,7 @@ async fn fetch_github(_username: &str) -> Result<(SourceEntry, Vec<String>)> {
             .pointer("/repository/full_name")
             .and_then(|n| n.as_str())
             .unwrap_or("");
-        let reason = notif
-            .get("reason")
-            .and_then(|r| r.as_str())
-            .unwrap_or("");
+        let reason = notif.get("reason").and_then(|r| r.as_str()).unwrap_or("");
         let updated_at = notif
             .get("updated_at")
             .and_then(|u| u.as_str())
@@ -375,7 +379,11 @@ async fn fetch_github(_username: &str) -> Result<(SourceEntry, Vec<String>)> {
 
 /// Construct Forgejo HTML URL from host + repo + subject type + number.
 fn forgejo_html_url(host: &str, repo: &str, subject_type: &str, number: u64) -> String {
-    let kind = if subject_type == "Pull" { "pulls" } else { "issues" };
+    let kind = if subject_type == "Pull" {
+        "pulls"
+    } else {
+        "issues"
+    };
     format!("{host}/{repo}/{kind}/{number}")
 }
 
@@ -391,8 +399,10 @@ async fn fetch_forgejo(
     let output = Command::new("curl")
         .args([
             "-sf",
-            "-H", "Accept: application/json",
-            "-H", &format!("Authorization: token {token}"),
+            "-H",
+            "Accept: application/json",
+            "-H",
+            &format!("Authorization: token {token}"),
             &url,
         ])
         .output()
@@ -403,13 +413,16 @@ async fn fetch_forgejo(
         anyhow::bail!("forgejo notifications API failed");
     }
 
-    let raw: Vec<serde_json::Value> =
-        serde_json::from_slice(&output.stdout).unwrap_or_default();
+    let raw: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap_or_default();
 
     // Collect thread IDs for ack manifest
     let thread_ids: Vec<String> = raw
         .iter()
-        .filter_map(|n| n.get("id").and_then(|v| v.as_u64()).map(|id| id.to_string()))
+        .filter_map(|n| {
+            n.get("id")
+                .and_then(|v| v.as_u64())
+                .map(|id| id.to_string())
+        })
         .collect();
 
     // Deduplicate by subject URL, extract metadata from notification envelope
@@ -527,7 +540,8 @@ async fn ack_github(thread_ids: &[String]) -> Result<()> {
 
 /// Mark Forgejo notification threads as read.
 async fn ack_forgejo(thread_ids: &[String]) -> Result<()> {
-    let host = std::env::var("FORGEJO_HOST").unwrap_or_else(|_| "https://git.ncrmro.com".to_string());
+    let host =
+        std::env::var("FORGEJO_HOST").unwrap_or_else(|_| "https://git.ncrmro.com".to_string());
     let token = std::env::var("FORGEJO_TOKEN").unwrap_or_default();
     if token.is_empty() {
         eprintln!("warning: FORGEJO_TOKEN not set, skipping forgejo ack");
@@ -542,9 +556,13 @@ async fn ack_forgejo(thread_ids: &[String]) -> Result<()> {
             async move {
                 let status = Command::new("curl")
                     .args([
-                        "-sf", "-X", "PATCH",
-                        "-H", "Accept: application/json",
-                        "-H", &format!("Authorization: token {token}"),
+                        "-sf",
+                        "-X",
+                        "PATCH",
+                        "-H",
+                        "Accept: application/json",
+                        "-H",
+                        &format!("Authorization: token {token}"),
                         &url,
                     ])
                     .status()
@@ -584,8 +602,14 @@ async fn execute_list(json: bool) -> Result<()> {
             "email" => {
                 if let Some(arr) = entry.data.as_array() {
                     for item in arr {
-                        let from = item.get("from").and_then(|f| f.as_str()).unwrap_or("unknown");
-                        let subject = item.get("subject").and_then(|s| s.as_str()).unwrap_or("(no subject)");
+                        let from = item
+                            .get("from")
+                            .and_then(|f| f.as_str())
+                            .unwrap_or("unknown");
+                        let subject = item
+                            .get("subject")
+                            .and_then(|s| s.as_str())
+                            .unwrap_or("(no subject)");
                         let id = item.get("id").and_then(|i| i.as_str()).unwrap_or("");
                         println!("  [{id}] {from}: {subject}");
                     }
@@ -707,8 +731,10 @@ async fn execute_sources(json: bool) -> Result<()> {
             Command::new("curl")
                 .args([
                     "-sf",
-                    "-H", "Accept: application/json",
-                    "-H", &format!("Authorization: token {token}"),
+                    "-H",
+                    "Accept: application/json",
+                    "-H",
+                    &format!("Authorization: token {token}"),
                     &format!("{fj_host}/api/v1/user"),
                 ])
                 .output()
@@ -737,7 +763,10 @@ async fn execute_sources(json: bool) -> Result<()> {
         for s in &sources {
             let name = s.get("source").and_then(|n| n.as_str()).unwrap_or("");
             let tool = s.get("tool").and_then(|t| t.as_str()).unwrap_or("");
-            let ok = s.get("available").and_then(|a| a.as_bool()).unwrap_or(false);
+            let ok = s
+                .get("available")
+                .and_then(|a| a.as_bool())
+                .unwrap_or(false);
             let status = if ok { "connected" } else { "unavailable" };
             println!("  {name:<10} ({tool}) — {status}");
         }

--- a/packages/ks/src/cmd/projects.rs
+++ b/packages/ks/src/cmd/projects.rs
@@ -145,8 +145,7 @@ pub fn save_projects_to(pf: &ProjectFile, path: &PathBuf) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).ok();
     }
-    std::fs::write(path, output)
-        .with_context(|| format!("failed to write {}", path.display()))?;
+    std::fs::write(path, output).with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
 }
 
@@ -173,7 +172,10 @@ pub fn normalize_repo(url: &str) -> String {
     // Strip .git suffix
     let s = s.strip_suffix(".git").unwrap_or(s);
     // SSH format: git@host:owner/repo
-    if let Some(after_colon) = s.strip_prefix("git@").and_then(|s| s.split_once(':').map(|(_, r)| r)) {
+    if let Some(after_colon) = s
+        .strip_prefix("git@")
+        .and_then(|s| s.split_once(':').map(|(_, r)| r))
+    {
         return after_colon.to_string();
     }
     // HTTPS format: https://host/owner/repo
@@ -219,7 +221,9 @@ pub fn detect_by_subject(pf: &ProjectFile, subject: &str) -> DetectionResult {
 
     for project in &pf.projects {
         let slug_match = lower.contains(&project.slug.to_lowercase());
-        let name_match = project.name.as_ref()
+        let name_match = project
+            .name
+            .as_ref()
             .map(|n| lower.contains(&n.to_lowercase()))
             .unwrap_or(false);
 
@@ -259,9 +263,12 @@ pub async fn execute(args: &ProjectArgs) -> Result<()> {
     match &args.command {
         None => execute_list(args.json),
         Some(ProjectCommand::Show { slug }) => execute_show(slug, args.json),
-        Some(ProjectCommand::Add { slug, name, repo, priority }) => {
-            execute_add(slug, name.as_deref(), repo, *priority)
-        }
+        Some(ProjectCommand::Add {
+            slug,
+            name,
+            repo,
+            priority,
+        }) => execute_add(slug, name.as_deref(), repo, *priority),
         Some(ProjectCommand::Remove { slug }) => execute_remove(slug),
         Some(ProjectCommand::Detect { repo, subject }) => {
             execute_detect(repo.as_deref(), subject.as_deref())
@@ -287,7 +294,10 @@ fn execute_list(json: bool) -> Result<()> {
 
     for p in &pf.projects {
         let name = p.name.as_deref().unwrap_or(&p.slug);
-        let pri = p.priority.map(|n| format!(" (pri: {n})")).unwrap_or_default();
+        let pri = p
+            .priority
+            .map(|n| format!(" (pri: {n})"))
+            .unwrap_or_default();
         let repos = if p.repos.is_empty() {
             String::new()
         } else {
@@ -309,7 +319,10 @@ fn execute_show(slug: &str, json: bool) -> Result<()> {
             if json {
                 println!("{}", serde_json::to_string_pretty(project)?);
             } else {
-                println!("Project: {}", project.name.as_deref().unwrap_or(&project.slug));
+                println!(
+                    "Project: {}",
+                    project.name.as_deref().unwrap_or(&project.slug)
+                );
                 if let Some(desc) = &project.description {
                     println!("  {desc}");
                 }
@@ -334,10 +347,17 @@ fn execute_show(slug: &str, json: bool) -> Result<()> {
 
 // ── Add ───────────────────────────────────────────────────────────────
 
-fn execute_add(slug: &str, name: Option<&str>, repos: &[String], priority: Option<u32>) -> Result<()> {
+fn execute_add(
+    slug: &str,
+    name: Option<&str>,
+    repos: &[String],
+    priority: Option<u32>,
+) -> Result<()> {
     // Validate slug: kebab-case (lowercase alphanumeric + hyphens, no leading/trailing hyphen)
     let valid = !slug.is_empty()
-        && slug.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && slug
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
         && !slug.starts_with('-')
         && !slug.ends_with('-')
         && !slug.contains("--");
@@ -451,14 +471,18 @@ mod tests {
 
     #[test]
     fn test_add_project_dedup() {
-        let mut pf = ProjectFile { projects: vec![make_project("keystone", &[])] };
+        let mut pf = ProjectFile {
+            projects: vec![make_project("keystone", &[])],
+        };
         assert!(!add_project(&mut pf, make_project("keystone", &[])));
         assert_eq!(pf.projects.len(), 1);
     }
 
     #[test]
     fn test_remove_project() {
-        let mut pf = ProjectFile { projects: vec![make_project("keystone", &[])] };
+        let mut pf = ProjectFile {
+            projects: vec![make_project("keystone", &[])],
+        };
         assert!(remove_project(&mut pf, "keystone"));
         assert!(pf.projects.is_empty());
     }
@@ -505,7 +529,10 @@ mod tests {
     #[test]
     fn test_detect_repo_exact() {
         let pf = ProjectFile {
-            projects: vec![make_project("keystone", &["ncrmro/keystone", "ncrmro/nixos-config"])],
+            projects: vec![make_project(
+                "keystone",
+                &["ncrmro/keystone", "ncrmro/nixos-config"],
+            )],
         };
         let result = detect_by_repo(&pf, "ncrmro/keystone");
         assert_eq!(result.slug, Some("keystone".to_string()));
@@ -549,20 +576,14 @@ mod tests {
 
     #[test]
     fn test_detect_subject_ambiguous() {
-        let pf = ProjectFile {
-            projects: vec![
-                make_project("keystone", &[]),
-                make_project("keystone-infra", &[]),
-            ],
-        };
-        // Both slugs "keystone" and "keystone-infra" contain "keystone",
-        // but "keystone-infra" does not appear in "keystone issue".
-        // Use names that both substring-match the subject.
+        // Use names that both substring-match the subject
         let mut p1 = make_project("proj-a", &[]);
         p1.name = Some("Cloud Platform".to_string());
         let mut p2 = make_project("proj-b", &[]);
         p2.name = Some("Cloud Storage".to_string());
-        let pf = ProjectFile { projects: vec![p1, p2] };
+        let pf = ProjectFile {
+            projects: vec![p1, p2],
+        };
         // "cloud" matches both names
         let result = detect_by_subject(&pf, "cloud migration plan");
         assert_eq!(result.slug, None);
@@ -601,7 +622,10 @@ mod tests {
         };
         let map = build_repo_map(&pf);
         assert_eq!(map.get("ncrmro/keystone"), Some(&"keystone".to_string()));
-        assert_eq!(map.get("ncrmro/plant-caravan"), Some(&"caravan".to_string()));
+        assert_eq!(
+            map.get("ncrmro/plant-caravan"),
+            Some(&"caravan".to_string())
+        );
         assert_eq!(map.len(), 3);
     }
 }

--- a/packages/ks/src/cmd/projects.rs
+++ b/packages/ks/src/cmd/projects.rs
@@ -143,7 +143,7 @@ pub fn save_projects_to(pf: &ProjectFile, path: &PathBuf) -> Result<()> {
     let content = serde_yaml::to_string(pf)?;
     let output = format!("---\n{content}");
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).ok();
+        std::fs::create_dir_all(parent).context("failed to create parent directory")?;
     }
     std::fs::write(path, output).with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
@@ -168,7 +168,7 @@ pub fn remove_project(pf: &mut ProjectFile, slug: &str) -> bool {
 /// Normalize a repo URL to "owner/repo" format.
 /// Handles: https://github.com/owner/repo.git, git@github.com:owner/repo, owner/repo
 pub fn normalize_repo(url: &str) -> String {
-    let s = url.trim();
+    let s = url.trim().trim_end_matches('/');
     // Strip .git suffix
     let s = s.strip_suffix(".git").unwrap_or(s);
     // SSH format: git@host:owner/repo

--- a/packages/ks/src/cmd/projects.rs
+++ b/packages/ks/src/cmd/projects.rs
@@ -1,0 +1,607 @@
+//! `ks project` — project management with provider overrides and detection.
+//!
+//! Projects map repos to named entities with priority and per-project
+//! provider/model configuration. Detection resolves notifications to
+//! projects deterministically (repo match) or heuristically (subject match).
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+
+// ── CLI definition ────────────────────────────────────────────────────
+
+#[derive(Args)]
+pub struct ProjectArgs {
+    #[command(subcommand)]
+    pub command: Option<ProjectCommand>,
+
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Subcommand)]
+pub enum ProjectCommand {
+    /// Show full details for a project.
+    Show {
+        /// Project slug.
+        slug: String,
+    },
+
+    /// Add a new project.
+    Add {
+        /// Project slug (kebab-case).
+        slug: String,
+
+        /// Display name.
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Associated repo (repeatable, "owner/repo" format).
+        #[arg(long, action = clap::ArgAction::Append)]
+        repo: Vec<String>,
+
+        /// Priority (lower = higher priority).
+        #[arg(long)]
+        priority: Option<u32>,
+    },
+
+    /// Remove a project.
+    Remove {
+        /// Project slug.
+        slug: String,
+    },
+
+    /// Detect which project a notification belongs to.
+    Detect {
+        /// Match by repo ("owner/repo" or full URL).
+        #[arg(long)]
+        repo: Option<String>,
+
+        /// Match by subject text (heuristic).
+        #[arg(long)]
+        subject: Option<String>,
+    },
+}
+
+// ── Data model ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProjectFile {
+    pub projects: Vec<Project>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Project {
+    pub slug: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repos: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sources: Vec<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<ProjectProvider>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProjectProvider {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+/// Detection result with confidence level.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DetectionResult {
+    pub slug: Option<String>,
+    pub confidence: String, // "exact", "heuristic", "none"
+    pub method: String,
+}
+
+// ── Paths ─────────────────────────────────────────────────────────────
+
+fn projects_file_path() -> PathBuf {
+    if let Ok(p) = std::env::var("KS_PROJECTS_FILE") {
+        return PathBuf::from(p);
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    let home_path = PathBuf::from(&home).join("PROJECTS.yaml");
+    if home_path.exists() {
+        return home_path;
+    }
+    let cwd_path = PathBuf::from("PROJECTS.yaml");
+    if cwd_path.exists() {
+        return cwd_path;
+    }
+    home_path
+}
+
+// ── Core operations ───────────────────────────────────────────────────
+
+pub fn load_projects_from(path: &PathBuf) -> Result<ProjectFile> {
+    if !path.exists() {
+        return Ok(ProjectFile { projects: vec![] });
+    }
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let pf: ProjectFile = serde_yaml::from_str(&content)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(pf)
+}
+
+pub fn save_projects_to(pf: &ProjectFile, path: &PathBuf) -> Result<()> {
+    let content = serde_yaml::to_string(pf)?;
+    let output = format!("---\n{content}");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    std::fs::write(path, output)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+/// Add a project. Returns false if slug already exists.
+pub fn add_project(pf: &mut ProjectFile, project: Project) -> bool {
+    if pf.projects.iter().any(|p| p.slug == project.slug) {
+        return false;
+    }
+    pf.projects.push(project);
+    true
+}
+
+/// Remove a project by slug. Returns true if found and removed.
+pub fn remove_project(pf: &mut ProjectFile, slug: &str) -> bool {
+    let before = pf.projects.len();
+    pf.projects.retain(|p| p.slug != slug);
+    pf.projects.len() < before
+}
+
+/// Normalize a repo URL to "owner/repo" format.
+/// Handles: https://github.com/owner/repo.git, git@github.com:owner/repo, owner/repo
+pub fn normalize_repo(url: &str) -> String {
+    let s = url.trim();
+    // Strip .git suffix
+    let s = s.strip_suffix(".git").unwrap_or(s);
+    // SSH format: git@host:owner/repo
+    if let Some(after_colon) = s.strip_prefix("git@").and_then(|s| s.split_once(':').map(|(_, r)| r)) {
+        return after_colon.to_string();
+    }
+    // HTTPS format: https://host/owner/repo
+    if s.contains("://") {
+        let parts: Vec<&str> = s.split('/').collect();
+        if parts.len() >= 2 {
+            let repo = parts[parts.len() - 1];
+            let owner = parts[parts.len() - 2];
+            if !owner.is_empty() && !repo.is_empty() {
+                return format!("{owner}/{repo}");
+            }
+        }
+    }
+    // Already normalized or bare owner/repo
+    s.to_string()
+}
+
+/// Detect project from a repo identifier. Exact match against project repos.
+pub fn detect_by_repo(pf: &ProjectFile, repo_input: &str) -> DetectionResult {
+    let normalized = normalize_repo(repo_input);
+    for project in &pf.projects {
+        for repo in &project.repos {
+            if normalize_repo(repo) == normalized {
+                return DetectionResult {
+                    slug: Some(project.slug.clone()),
+                    confidence: "exact".to_string(),
+                    method: "repo-match".to_string(),
+                };
+            }
+        }
+    }
+    DetectionResult {
+        slug: None,
+        confidence: "none".to_string(),
+        method: "repo-match".to_string(),
+    }
+}
+
+/// Detect project from subject text. Heuristic substring match.
+pub fn detect_by_subject(pf: &ProjectFile, subject: &str) -> DetectionResult {
+    let lower = subject.to_lowercase();
+    let mut matches: Vec<&str> = Vec::new();
+
+    for project in &pf.projects {
+        let slug_match = lower.contains(&project.slug.to_lowercase());
+        let name_match = project.name.as_ref()
+            .map(|n| lower.contains(&n.to_lowercase()))
+            .unwrap_or(false);
+
+        if slug_match || name_match {
+            matches.push(&project.slug);
+        }
+    }
+
+    match matches.len() {
+        1 => DetectionResult {
+            slug: Some(matches[0].to_string()),
+            confidence: "heuristic".to_string(),
+            method: "subject-match".to_string(),
+        },
+        _ => DetectionResult {
+            slug: None,
+            confidence: "none".to_string(),
+            method: "subject-match".to_string(),
+        },
+    }
+}
+
+/// Build a repo→project mapping for bulk detection.
+pub fn build_repo_map(pf: &ProjectFile) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    for project in &pf.projects {
+        for repo in &project.repos {
+            map.insert(normalize_repo(repo), project.slug.clone());
+        }
+    }
+    map
+}
+
+// ── Entry point ───────────────────────────────────────────────────────
+
+pub async fn execute(args: &ProjectArgs) -> Result<()> {
+    match &args.command {
+        None => execute_list(args.json),
+        Some(ProjectCommand::Show { slug }) => execute_show(slug, args.json),
+        Some(ProjectCommand::Add { slug, name, repo, priority }) => {
+            execute_add(slug, name.as_deref(), repo, *priority)
+        }
+        Some(ProjectCommand::Remove { slug }) => execute_remove(slug),
+        Some(ProjectCommand::Detect { repo, subject }) => {
+            execute_detect(repo.as_deref(), subject.as_deref())
+        }
+    }
+}
+
+// ── List ──────────────────────────────────────────────────────────────
+
+fn execute_list(json: bool) -> Result<()> {
+    let path = projects_file_path();
+    let pf = load_projects_from(&path)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&pf.projects)?);
+        return Ok(());
+    }
+
+    if pf.projects.is_empty() {
+        println!("No projects.");
+        return Ok(());
+    }
+
+    for p in &pf.projects {
+        let name = p.name.as_deref().unwrap_or(&p.slug);
+        let pri = p.priority.map(|n| format!(" (pri: {n})")).unwrap_or_default();
+        let repos = if p.repos.is_empty() {
+            String::new()
+        } else {
+            format!(" — {} repos", p.repos.len())
+        };
+        println!("  {}{pri}{repos}", name);
+    }
+    Ok(())
+}
+
+// ── Show ──────────────────────────────────────────────────────────────
+
+fn execute_show(slug: &str, json: bool) -> Result<()> {
+    let path = projects_file_path();
+    let pf = load_projects_from(&path)?;
+
+    match pf.projects.iter().find(|p| p.slug == slug) {
+        Some(project) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(project)?);
+            } else {
+                println!("Project: {}", project.name.as_deref().unwrap_or(&project.slug));
+                if let Some(desc) = &project.description {
+                    println!("  {desc}");
+                }
+                if let Some(pri) = project.priority {
+                    println!("  Priority: {pri}");
+                }
+                if !project.repos.is_empty() {
+                    println!("  Repos:");
+                    for r in &project.repos {
+                        println!("    {r}");
+                    }
+                }
+                if let Some(prov) = &project.provider {
+                    println!("  Provider: {:?}", prov);
+                }
+            }
+        }
+        None => eprintln!("Project '{slug}' not found."),
+    }
+    Ok(())
+}
+
+// ── Add ───────────────────────────────────────────────────────────────
+
+fn execute_add(slug: &str, name: Option<&str>, repos: &[String], priority: Option<u32>) -> Result<()> {
+    // Validate slug: kebab-case (lowercase alphanumeric + hyphens, no leading/trailing hyphen)
+    let valid = !slug.is_empty()
+        && slug.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && !slug.starts_with('-')
+        && !slug.ends_with('-')
+        && !slug.contains("--");
+    if !valid {
+        anyhow::bail!("Invalid slug '{slug}': must be kebab-case (e.g., 'my-project')");
+    }
+
+    let path = projects_file_path();
+    let mut pf = load_projects_from(&path)?;
+
+    let project = Project {
+        slug: slug.to_string(),
+        name: name.map(String::from),
+        description: None,
+        priority,
+        repos: repos.iter().map(|r| normalize_repo(r)).collect(),
+        sources: vec![],
+        provider: None,
+    };
+
+    if add_project(&mut pf, project) {
+        save_projects_to(&pf, &path)?;
+        println!("Added: {slug}");
+    } else {
+        eprintln!("Project '{slug}' already exists.");
+    }
+    Ok(())
+}
+
+// ── Remove ────────────────────────────────────────────────────────────
+
+fn execute_remove(slug: &str) -> Result<()> {
+    let path = projects_file_path();
+    let mut pf = load_projects_from(&path)?;
+
+    if remove_project(&mut pf, slug) {
+        save_projects_to(&pf, &path)?;
+        println!("Removed: {slug}");
+    } else {
+        eprintln!("Project '{slug}' not found.");
+    }
+    Ok(())
+}
+
+// ── Detect ────────────────────────────────────────────────────────────
+
+fn execute_detect(repo: Option<&str>, subject: Option<&str>) -> Result<()> {
+    let path = projects_file_path();
+    let pf = load_projects_from(&path)?;
+
+    let result = if let Some(r) = repo {
+        detect_by_repo(&pf, r)
+    } else if let Some(s) = subject {
+        detect_by_subject(&pf, s)
+    } else {
+        anyhow::bail!("Provide --repo or --subject for detection");
+    };
+
+    println!("{}", serde_json::to_string_pretty(&result)?);
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    fn make_project(slug: &str, repos: &[&str]) -> Project {
+        Project {
+            slug: slug.to_string(),
+            name: Some(slug.replace('-', " ").to_string()),
+            description: None,
+            priority: None,
+            repos: repos.iter().map(|r| r.to_string()).collect(),
+            sources: vec![],
+            provider: None,
+        }
+    }
+
+    // ── YAML round-trip ───────────────────────────────────────────
+
+    #[test]
+    fn test_yaml_round_trip() {
+        let pf = ProjectFile {
+            projects: vec![make_project("keystone", &["ncrmro/keystone"])],
+        };
+        let tmp = NamedTempFile::new().unwrap();
+        save_projects_to(&pf, &tmp.path().to_path_buf()).unwrap();
+        let loaded = load_projects_from(&tmp.path().to_path_buf()).unwrap();
+        assert_eq!(loaded.projects.len(), 1);
+        assert_eq!(loaded.projects[0].slug, "keystone");
+    }
+
+    #[test]
+    fn test_load_missing_file() {
+        let path = PathBuf::from("/tmp/nonexistent-ks-projects.yaml");
+        let result = load_projects_from(&path).unwrap();
+        assert!(result.projects.is_empty());
+    }
+
+    // ── add / remove ──────────────────────────────────────────────
+
+    #[test]
+    fn test_add_project() {
+        let mut pf = ProjectFile { projects: vec![] };
+        assert!(add_project(&mut pf, make_project("keystone", &[])));
+        assert_eq!(pf.projects.len(), 1);
+    }
+
+    #[test]
+    fn test_add_project_dedup() {
+        let mut pf = ProjectFile { projects: vec![make_project("keystone", &[])] };
+        assert!(!add_project(&mut pf, make_project("keystone", &[])));
+        assert_eq!(pf.projects.len(), 1);
+    }
+
+    #[test]
+    fn test_remove_project() {
+        let mut pf = ProjectFile { projects: vec![make_project("keystone", &[])] };
+        assert!(remove_project(&mut pf, "keystone"));
+        assert!(pf.projects.is_empty());
+    }
+
+    #[test]
+    fn test_remove_project_not_found() {
+        let mut pf = ProjectFile { projects: vec![] };
+        assert!(!remove_project(&mut pf, "missing"));
+    }
+
+    // ── normalize_repo ────────────────────────────────────────────
+
+    #[test]
+    fn test_normalize_bare() {
+        assert_eq!(normalize_repo("ncrmro/keystone"), "ncrmro/keystone");
+    }
+
+    #[test]
+    fn test_normalize_https() {
+        assert_eq!(
+            normalize_repo("https://github.com/ncrmro/keystone.git"),
+            "ncrmro/keystone"
+        );
+    }
+
+    #[test]
+    fn test_normalize_ssh() {
+        assert_eq!(
+            normalize_repo("git@github.com:ncrmro/keystone.git"),
+            "ncrmro/keystone"
+        );
+    }
+
+    #[test]
+    fn test_normalize_https_no_git() {
+        assert_eq!(
+            normalize_repo("https://github.com/ncrmro/keystone"),
+            "ncrmro/keystone"
+        );
+    }
+
+    // ── detect_by_repo ────────────────────────────────────────────
+
+    #[test]
+    fn test_detect_repo_exact() {
+        let pf = ProjectFile {
+            projects: vec![make_project("keystone", &["ncrmro/keystone", "ncrmro/nixos-config"])],
+        };
+        let result = detect_by_repo(&pf, "ncrmro/keystone");
+        assert_eq!(result.slug, Some("keystone".to_string()));
+        assert_eq!(result.confidence, "exact");
+    }
+
+    #[test]
+    fn test_detect_repo_normalized_url() {
+        let pf = ProjectFile {
+            projects: vec![make_project("keystone", &["ncrmro/keystone"])],
+        };
+        let result = detect_by_repo(&pf, "https://github.com/ncrmro/keystone.git");
+        assert_eq!(result.slug, Some("keystone".to_string()));
+        assert_eq!(result.confidence, "exact");
+    }
+
+    #[test]
+    fn test_detect_repo_no_match() {
+        let pf = ProjectFile {
+            projects: vec![make_project("keystone", &["ncrmro/keystone"])],
+        };
+        let result = detect_by_repo(&pf, "other/repo");
+        assert_eq!(result.slug, None);
+        assert_eq!(result.confidence, "none");
+    }
+
+    // ── detect_by_subject ─────────────────────────────────────────
+
+    #[test]
+    fn test_detect_subject_single_match() {
+        let pf = ProjectFile {
+            projects: vec![
+                make_project("keystone", &[]),
+                make_project("plant-caravan", &[]),
+            ],
+        };
+        let result = detect_by_subject(&pf, "Fix keystone build failure");
+        assert_eq!(result.slug, Some("keystone".to_string()));
+        assert_eq!(result.confidence, "heuristic");
+    }
+
+    #[test]
+    fn test_detect_subject_ambiguous() {
+        let pf = ProjectFile {
+            projects: vec![
+                make_project("keystone", &[]),
+                make_project("keystone-infra", &[]),
+            ],
+        };
+        // Both slugs "keystone" and "keystone-infra" contain "keystone",
+        // but "keystone-infra" does not appear in "keystone issue".
+        // Use names that both substring-match the subject.
+        let mut p1 = make_project("proj-a", &[]);
+        p1.name = Some("Cloud Platform".to_string());
+        let mut p2 = make_project("proj-b", &[]);
+        p2.name = Some("Cloud Storage".to_string());
+        let pf = ProjectFile { projects: vec![p1, p2] };
+        // "cloud" matches both names
+        let result = detect_by_subject(&pf, "cloud migration plan");
+        assert_eq!(result.slug, None);
+        assert_eq!(result.confidence, "none");
+    }
+
+    #[test]
+    fn test_detect_subject_no_match() {
+        let pf = ProjectFile {
+            projects: vec![make_project("keystone", &[])],
+        };
+        let result = detect_by_subject(&pf, "unrelated topic");
+        assert_eq!(result.slug, None);
+        assert_eq!(result.confidence, "none");
+    }
+
+    #[test]
+    fn test_detect_subject_by_name() {
+        let mut p = make_project("pc", &[]);
+        p.name = Some("Plant Caravan".to_string());
+        let pf = ProjectFile { projects: vec![p] };
+        let result = detect_by_subject(&pf, "Plant Caravan sensor issue");
+        assert_eq!(result.slug, Some("pc".to_string()));
+        assert_eq!(result.confidence, "heuristic");
+    }
+
+    // ── build_repo_map ────────────────────────────────────────────
+
+    #[test]
+    fn test_build_repo_map() {
+        let pf = ProjectFile {
+            projects: vec![
+                make_project("keystone", &["ncrmro/keystone", "ncrmro/nixos-config"]),
+                make_project("caravan", &["ncrmro/plant-caravan"]),
+            ],
+        };
+        let map = build_repo_map(&pf);
+        assert_eq!(map.get("ncrmro/keystone"), Some(&"keystone".to_string()));
+        assert_eq!(map.get("ncrmro/plant-caravan"), Some(&"caravan".to_string()));
+        assert_eq!(map.len(), 3);
+    }
+}

--- a/packages/ks/src/cmd/tasks.rs
+++ b/packages/ks/src/cmd/tasks.rs
@@ -190,11 +190,10 @@ fn proposal_path() -> PathBuf {
     if let Ok(p) = std::env::var("KS_PROPOSAL_FILE") {
         return PathBuf::from(p);
     }
-    let state_dir = std::env::var("XDG_STATE_HOME")
-        .unwrap_or_else(|_| {
-            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-            format!("{home}/.local/state")
-        });
+    let state_dir = std::env::var("XDG_STATE_HOME").unwrap_or_else(|_| {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        format!("{home}/.local/state")
+    });
     PathBuf::from(state_dir).join("ks/tasks/proposal.json")
 }
 
@@ -217,15 +216,18 @@ pub fn save_tasks_to(task_file: &TaskFile, path: &PathBuf) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).ok();
     }
-    std::fs::write(path, output)
-        .with_context(|| format!("failed to write {}", path.display()))?;
+    std::fs::write(path, output).with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
 }
 
 /// Add a task, deduplicating by source_ref and name. Returns true if added.
 pub fn add_task(task_file: &mut TaskFile, task: Task) -> bool {
     if let Some(ref sref) = task.source_ref {
-        if task_file.tasks.iter().any(|t| t.source_ref.as_deref() == Some(sref)) {
+        if task_file
+            .tasks
+            .iter()
+            .any(|t| t.source_ref.as_deref() == Some(sref))
+        {
             return false;
         }
     }
@@ -313,7 +315,10 @@ pub fn apply_proposal(task_file: &mut TaskFile, proposal: &PrioritizationProposa
     reordered.append(&mut pending); // unmentioned pending tasks at the end
 
     // Reconstruct: in_progress, pending (reordered), blocked, completed
-    task_file.tasks = others.iter().filter(|t| t.status == "in_progress").cloned()
+    task_file.tasks = others
+        .iter()
+        .filter(|t| t.status == "in_progress")
+        .cloned()
         .chain(reordered)
         .chain(others.iter().filter(|t| t.status == "blocked").cloned())
         .chain(others.iter().filter(|t| t.status == "completed").cloned())
@@ -358,8 +363,18 @@ pub async fn execute(args: &TaskArgs) -> Result<()> {
     match &args.command {
         None => execute_list(args.json),
         Some(TaskCommand::Add {
-            description, name, source, source_ref, project,
-        }) => execute_add(description, name.as_deref(), source, source_ref.as_deref(), project.as_deref()),
+            description,
+            name,
+            source,
+            source_ref,
+            project,
+        }) => execute_add(
+            description,
+            name.as_deref(),
+            source,
+            source_ref.as_deref(),
+            project.as_deref(),
+        ),
         Some(TaskCommand::Start { name }) => execute_start(name),
         Some(TaskCommand::Done { name }) => execute_done(name),
         Some(TaskCommand::Block { name, reason }) => execute_block(name, reason.as_deref()),
@@ -386,20 +401,40 @@ fn execute_list(json: bool) -> Result<()> {
         return Ok(());
     }
 
-    let pending: Vec<_> = task_file.tasks.iter().filter(|t| t.status == "pending").collect();
-    let in_progress: Vec<_> = task_file.tasks.iter().filter(|t| t.status == "in_progress").collect();
-    let blocked: Vec<_> = task_file.tasks.iter().filter(|t| t.status == "blocked").collect();
-    let completed: Vec<_> = task_file.tasks.iter().filter(|t| t.status == "completed").collect();
+    let pending: Vec<_> = task_file
+        .tasks
+        .iter()
+        .filter(|t| t.status == "pending")
+        .collect();
+    let in_progress: Vec<_> = task_file
+        .tasks
+        .iter()
+        .filter(|t| t.status == "in_progress")
+        .collect();
+    let blocked: Vec<_> = task_file
+        .tasks
+        .iter()
+        .filter(|t| t.status == "blocked")
+        .collect();
+    let completed: Vec<_> = task_file
+        .tasks
+        .iter()
+        .filter(|t| t.status == "completed")
+        .collect();
 
     if !in_progress.is_empty() {
         println!("In Progress ({}):", in_progress.len());
-        for t in &in_progress { print_task(t); }
+        for t in &in_progress {
+            print_task(t);
+        }
         println!();
     }
 
     if !pending.is_empty() {
         println!("Pending ({}):", pending.len());
-        for t in &pending { print_task(t); }
+        for t in &pending {
+            print_task(t);
+        }
         println!();
     }
 
@@ -408,7 +443,9 @@ fn execute_list(json: bool) -> Result<()> {
         for t in &blocked {
             let reason = t.blocked_reason.as_deref().unwrap_or("");
             println!("  {} — {}", t.name, t.description);
-            if !reason.is_empty() { println!("    reason: {reason}"); }
+            if !reason.is_empty() {
+                println!("    reason: {reason}");
+            }
         }
         println!();
     }
@@ -433,13 +470,18 @@ fn print_task(task: &Task) {
 // ── Add ───────────────────────────────────────────────────────────────
 
 fn execute_add(
-    description: &str, name: Option<&str>, source: &str,
-    source_ref: Option<&str>, project: Option<&str>,
+    description: &str,
+    name: Option<&str>,
+    source: &str,
+    source_ref: Option<&str>,
+    project: Option<&str>,
 ) -> Result<()> {
     let path = tasks_file_path();
     let mut task_file = load_tasks_from(&path)?;
 
-    let task_name = name.map(String::from).unwrap_or_else(|| slugify(description));
+    let task_name = name
+        .map(String::from)
+        .unwrap_or_else(|| slugify(description));
     let task = Task {
         name: task_name.clone(),
         description: description.to_string(),
@@ -447,8 +489,13 @@ fn execute_add(
         project: project.map(String::from),
         source: Some(source.to_string()),
         source_ref: source_ref.map(String::from),
-        model: None, workflow: None, needs: None, blocked_reason: None,
-        created_at: Some(iso_now()), started_at: None, completed_at: None,
+        model: None,
+        workflow: None,
+        needs: None,
+        blocked_reason: None,
+        created_at: Some(iso_now()),
+        started_at: None,
+        completed_at: None,
     };
 
     if add_task(&mut task_file, task) {
@@ -514,8 +561,8 @@ async fn execute_ingest(file: Option<&PathBuf>, apply: bool) -> Result<()> {
         // Read IngestResult JSON from stdin
         let mut buf = String::new();
         std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
-        let ingest: IngestResult = serde_json::from_str(&buf)
-            .context("failed to parse ingest JSON from stdin")?;
+        let ingest: IngestResult =
+            serde_json::from_str(&buf).context("failed to parse ingest JSON from stdin")?;
 
         let mut task_file = load_tasks_from(&path)?;
         let (added, skipped) = apply_ingest(&mut task_file, &ingest);
@@ -532,8 +579,9 @@ async fn execute_ingest(file: Option<&PathBuf>, apply: bool) -> Result<()> {
 
     // Read notifications JSON
     let notifications_json = match file {
-        Some(f) => std::fs::read_to_string(f)
-            .with_context(|| format!("failed to read {}", f.display()))?,
+        Some(f) => {
+            std::fs::read_to_string(f).with_context(|| format!("failed to read {}", f.display()))?
+        }
         None => {
             let mut buf = String::new();
             std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
@@ -543,7 +591,9 @@ async fn execute_ingest(file: Option<&PathBuf>, apply: bool) -> Result<()> {
 
     // Load current tasks for context
     let task_file = load_tasks_from(&path)?;
-    let existing_refs: Vec<&str> = task_file.tasks.iter()
+    let existing_refs: Vec<&str> = task_file
+        .tasks
+        .iter()
         .filter_map(|t| t.source_ref.as_deref())
         .collect();
 
@@ -594,7 +644,9 @@ async fn execute_prioritize() -> Result<()> {
     let path = tasks_file_path();
     let task_file = load_tasks_from(&path)?;
 
-    let pending: Vec<&Task> = task_file.tasks.iter()
+    let pending: Vec<&Task> = task_file
+        .tasks
+        .iter()
         .filter(|t| t.status == "pending")
         .collect();
 
@@ -655,7 +707,10 @@ fn execute_proposal(accept: bool) -> Result<()> {
         save_tasks_to(&task_file, &tasks_path)?;
 
         std::fs::remove_file(&path).ok();
-        println!("Accepted prioritization. {} pending tasks reordered.", proposal.items.len());
+        println!(
+            "Accepted prioritization. {} pending tasks reordered.",
+            proposal.items.len()
+        );
         return Ok(());
     }
 
@@ -682,7 +737,10 @@ fn execute_prune(all: bool) -> Result<()> {
     let mut task_file = load_tasks_from(&path)?;
     let removed = prune_tasks(&mut task_file, all);
     save_tasks_to(&task_file, &path)?;
-    println!("Pruned {removed} completed tasks ({} remaining).", task_file.tasks.len());
+    println!(
+        "Pruned {removed} completed tasks ({} remaining).",
+        task_file.tasks.len()
+    );
     Ok(())
 }
 
@@ -753,9 +811,16 @@ mod tests {
             name: name.to_string(),
             description: format!("Test task: {name}"),
             status: status.to_string(),
-            project: None, source: None, source_ref: None, model: None,
-            workflow: None, needs: None, blocked_reason: None,
-            created_at: None, started_at: None, completed_at: None,
+            project: None,
+            source: None,
+            source_ref: None,
+            model: None,
+            workflow: None,
+            needs: None,
+            blocked_reason: None,
+            created_at: None,
+            started_at: None,
+            completed_at: None,
         }
     }
 
@@ -822,7 +887,9 @@ mod tests {
 
     #[test]
     fn test_add_task_dedup_by_name() {
-        let mut tf = TaskFile { tasks: vec![make_task("existing", "pending")] };
+        let mut tf = TaskFile {
+            tasks: vec![make_task("existing", "pending")],
+        };
         let dup = make_task("existing", "pending");
         assert!(!add_task(&mut tf, dup));
         assert_eq!(tf.tasks.len(), 1);
@@ -852,7 +919,9 @@ mod tests {
 
     #[test]
     fn test_start_task() {
-        let mut tf = TaskFile { tasks: vec![make_task("my-task", "pending")] };
+        let mut tf = TaskFile {
+            tasks: vec![make_task("my-task", "pending")],
+        };
         assert!(start_task(&mut tf, "my-task"));
         assert_eq!(tf.tasks[0].status, "in_progress");
         assert!(tf.tasks[0].started_at.is_some());
@@ -866,7 +935,9 @@ mod tests {
 
     #[test]
     fn test_complete_task() {
-        let mut tf = TaskFile { tasks: vec![make_task("fix-bug", "pending")] };
+        let mut tf = TaskFile {
+            tasks: vec![make_task("fix-bug", "pending")],
+        };
         assert!(complete_task(&mut tf, "fix-bug"));
         assert_eq!(tf.tasks[0].status, "completed");
         assert!(tf.tasks[0].completed_at.is_some());
@@ -880,10 +951,19 @@ mod tests {
 
     #[test]
     fn test_block_task() {
-        let mut tf = TaskFile { tasks: vec![make_task("blocked-task", "pending")] };
-        assert!(block_task(&mut tf, "blocked-task", Some("waiting for deploy")));
+        let mut tf = TaskFile {
+            tasks: vec![make_task("blocked-task", "pending")],
+        };
+        assert!(block_task(
+            &mut tf,
+            "blocked-task",
+            Some("waiting for deploy")
+        ));
         assert_eq!(tf.tasks[0].status, "blocked");
-        assert_eq!(tf.tasks[0].blocked_reason.as_deref(), Some("waiting for deploy"));
+        assert_eq!(
+            tf.tasks[0].blocked_reason.as_deref(),
+            Some("waiting for deploy")
+        );
     }
 
     // ── prune ─────────────────────────────────────────────────────
@@ -937,8 +1017,16 @@ mod tests {
         let proposal = PrioritizationProposal {
             proposed_at: "2026-04-13T00:00:00Z".to_string(),
             items: vec![
-                ProposalItem { rank: 1, name: "high-pri".to_string(), rationale: "Urgent".to_string() },
-                ProposalItem { rank: 2, name: "low-pri".to_string(), rationale: "Can wait".to_string() },
+                ProposalItem {
+                    rank: 1,
+                    name: "high-pri".to_string(),
+                    rationale: "Urgent".to_string(),
+                },
+                ProposalItem {
+                    rank: 2,
+                    name: "low-pri".to_string(),
+                    rationale: "Can wait".to_string(),
+                },
             ],
         };
 
@@ -962,8 +1050,16 @@ mod tests {
         let proposal = PrioritizationProposal {
             proposed_at: "2026-04-13T00:00:00Z".to_string(),
             items: vec![
-                ProposalItem { rank: 1, name: "pending-b".to_string(), rationale: "Higher priority".to_string() },
-                ProposalItem { rank: 2, name: "pending-a".to_string(), rationale: "Lower priority".to_string() },
+                ProposalItem {
+                    rank: 1,
+                    name: "pending-b".to_string(),
+                    rationale: "Higher priority".to_string(),
+                },
+                ProposalItem {
+                    rank: 2,
+                    name: "pending-a".to_string(),
+                    rationale: "Lower priority".to_string(),
+                },
             ],
         };
 
@@ -980,16 +1076,14 @@ mod tests {
     fn test_apply_ingest_adds_new() {
         let mut tf = TaskFile { tasks: vec![] };
         let ingest = IngestResult {
-            tasks: vec![
-                IngestTask {
-                    name: "reply-to-ping".to_string(),
-                    description: "Reply with pong".to_string(),
-                    source: Some("email".to_string()),
-                    source_ref: Some("email-99-user@host".to_string()),
-                    project: None,
-                    model: Some("haiku".to_string()),
-                },
-            ],
+            tasks: vec![IngestTask {
+                name: "reply-to-ping".to_string(),
+                description: "Reply with pong".to_string(),
+                source: Some("email".to_string()),
+                source_ref: Some("email-99-user@host".to_string()),
+                project: None,
+                model: Some("haiku".to_string()),
+            }],
         };
 
         let (added, skipped) = apply_ingest(&mut tf, &ingest);
@@ -1044,7 +1138,10 @@ mod tests {
 
         let result: IngestResult = serde_json::from_str(json).unwrap();
         assert_eq!(result.tasks.len(), 2);
-        assert_eq!(result.tasks[0].source_ref, Some("http://example.com/1".to_string()));
+        assert_eq!(
+            result.tasks[0].source_ref,
+            Some("http://example.com/1".to_string())
+        );
         assert_eq!(result.tasks[1].source, None);
     }
 

--- a/packages/ks/src/cmd/tasks.rs
+++ b/packages/ks/src/cmd/tasks.rs
@@ -1,10 +1,11 @@
-//! `ks tasks` — unified task management for humans and agents.
+//! `ks task` — unified task management for humans and agents.
 //!
 //! Manages TASKS.yaml: add, complete, list, prune, and AI-powered ingest
 //! and prioritization. Tasks are created from `ks notifications` sources
 //! or manually. Prioritization proposals include rationale and can be
 //! reviewed before acceptance.
 
+use std::io::Read;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
@@ -560,7 +561,7 @@ async fn execute_ingest(file: Option<&PathBuf>, apply: bool) -> Result<()> {
     if apply {
         // Read IngestResult JSON from stdin
         let mut buf = String::new();
-        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+        std::io::stdin().read_to_string(&mut buf)?;
         let ingest: IngestResult =
             serde_json::from_str(&buf).context("failed to parse ingest JSON from stdin")?;
 
@@ -584,7 +585,7 @@ async fn execute_ingest(file: Option<&PathBuf>, apply: bool) -> Result<()> {
         }
         None => {
             let mut buf = String::new();
-            std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+            std::io::stdin().read_to_string(&mut buf)?;
             buf
         }
     };

--- a/packages/ks/src/cmd/tasks.rs
+++ b/packages/ks/src/cmd/tasks.rs
@@ -63,29 +63,45 @@ pub enum TasksCommand {
         reason: Option<String>,
     },
 
+    /// Ingest notifications into tasks. Reads JSON from stdin or file.
+    /// Outputs tasks to add as JSON (for AI review) or applies directly.
+    Ingest {
+        /// Path to notifications JSON (from `ks notifications fetch`). Reads stdin if omitted.
+        #[arg(long)]
+        file: Option<PathBuf>,
+
+        /// Apply tasks directly without AI review (used by task-loop automation).
+        #[arg(long)]
+        apply: bool,
+    },
+
+    /// Generate a prioritization proposal for pending tasks.
+    /// Outputs JSON with rationale for each task ranking.
+    Prioritize,
+
+    /// Show or accept a prioritization proposal.
+    Proposal {
+        /// Accept the current proposal and apply the new ordering.
+        #[arg(long)]
+        accept: bool,
+    },
+
     /// Remove completed tasks older than a threshold.
     Prune {
         /// Remove all completed tasks (default: only those older than 30 days).
         #[arg(long)]
         all: bool,
     },
-
-    /// Show prioritization proposal from last `prioritize` run.
-    Proposal {
-        /// Accept the current proposal and apply the new ordering.
-        #[arg(long)]
-        accept: bool,
-    },
 }
 
 // ── Data model ────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskFile {
     pub tasks: Vec<Task>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Task {
     pub name: String,
     pub description: String,
@@ -113,38 +129,61 @@ pub struct Task {
 }
 
 /// A prioritization proposal from the AI, with rationale per task.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PrioritizationProposal {
     pub proposed_at: String,
     pub items: Vec<ProposalItem>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProposalItem {
     pub rank: u32,
     pub name: String,
     pub rationale: String,
 }
 
+/// Input format for `ks tasks ingest --apply`: tasks the AI decided to create.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IngestResult {
+    pub tasks: Vec<IngestTask>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IngestTask {
+    pub name: String,
+    pub description: String,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub source_ref: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
 // ── Paths ─────────────────────────────────────────────────────────────
 
 fn tasks_file_path() -> PathBuf {
-    // TASKS.yaml lives in $HOME for agents, or current dir for humans
+    if let Ok(p) = std::env::var("KS_TASKS_FILE") {
+        return PathBuf::from(p);
+    }
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
     let home_path = PathBuf::from(&home).join("TASKS.yaml");
     if home_path.exists() {
         return home_path;
     }
-    // Fall back to current directory
     let cwd_path = PathBuf::from("TASKS.yaml");
     if cwd_path.exists() {
         return cwd_path;
     }
-    // Default to home
     home_path
 }
 
 fn proposal_path() -> PathBuf {
+    if let Ok(p) = std::env::var("KS_PROPOSAL_FILE") {
+        return PathBuf::from(p);
+    }
     let state_dir = std::env::var("XDG_STATE_HOME")
         .unwrap_or_else(|_| {
             let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
@@ -153,28 +192,147 @@ fn proposal_path() -> PathBuf {
     PathBuf::from(state_dir).join("ks/tasks/proposal.json")
 }
 
-// ── File I/O ──────────────────────────────────────────────────────────
+// ── Core operations (testable, path-parameterized) ────────────────────
 
-fn load_tasks() -> Result<TaskFile> {
-    let path = tasks_file_path();
+pub fn load_tasks_from(path: &PathBuf) -> Result<TaskFile> {
     if !path.exists() {
         return Ok(TaskFile { tasks: vec![] });
     }
-    let content = std::fs::read_to_string(&path)
+    let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
     let tasks: TaskFile = serde_yaml::from_str(&content)
         .with_context(|| format!("failed to parse {}", path.display()))?;
     Ok(tasks)
 }
 
-fn save_tasks(task_file: &TaskFile) -> Result<()> {
-    let path = tasks_file_path();
+pub fn save_tasks_to(task_file: &TaskFile, path: &PathBuf) -> Result<()> {
     let content = serde_yaml::to_string(task_file)?;
-    // Write with --- header for clean YAML
     let output = format!("---\n{content}");
-    std::fs::write(&path, output)
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    std::fs::write(path, output)
         .with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
+}
+
+/// Add a task, deduplicating by source_ref and name. Returns true if added.
+pub fn add_task(task_file: &mut TaskFile, task: Task) -> bool {
+    if let Some(ref sref) = task.source_ref {
+        if task_file.tasks.iter().any(|t| t.source_ref.as_deref() == Some(sref)) {
+            return false;
+        }
+    }
+    if task_file.tasks.iter().any(|t| t.name == task.name) {
+        return false;
+    }
+    task_file.tasks.push(task);
+    true
+}
+
+/// Mark a task as completed. Returns true if found.
+pub fn complete_task(task_file: &mut TaskFile, name: &str) -> bool {
+    if let Some(t) = task_file.tasks.iter_mut().find(|t| t.name == name) {
+        t.status = "completed".to_string();
+        t.completed_at = Some(iso_now());
+        true
+    } else {
+        false
+    }
+}
+
+/// Mark a task as blocked. Returns true if found.
+pub fn block_task(task_file: &mut TaskFile, name: &str, reason: Option<&str>) -> bool {
+    if let Some(t) = task_file.tasks.iter_mut().find(|t| t.name == name) {
+        t.status = "blocked".to_string();
+        t.blocked_reason = reason.map(String::from);
+        true
+    } else {
+        false
+    }
+}
+
+/// Prune completed tasks. Returns count removed.
+pub fn prune_tasks(task_file: &mut TaskFile, all: bool) -> usize {
+    let before = task_file.tasks.len();
+    if all {
+        task_file.tasks.retain(|t| t.status != "completed");
+    } else {
+        let cutoff = chrono_days_ago(30);
+        task_file.tasks.retain(|t| {
+            if t.status != "completed" {
+                return true;
+            }
+            match &t.completed_at {
+                Some(ts) => ts.as_str() >= cutoff.as_str(),
+                None => true,
+            }
+        });
+    }
+    before - task_file.tasks.len()
+}
+
+/// Apply a prioritization proposal to reorder pending tasks.
+pub fn apply_proposal(task_file: &mut TaskFile, proposal: &PrioritizationProposal) {
+    let mut all_tasks: Vec<Task> = task_file.tasks.drain(..).collect();
+    let mut pending: Vec<Task> = Vec::new();
+    let mut others: Vec<Task> = Vec::new();
+
+    for task in all_tasks.drain(..) {
+        if task.status == "pending" {
+            pending.push(task);
+        } else {
+            others.push(task);
+        }
+    }
+
+    // Reorder pending by proposal rank
+    let mut reordered: Vec<Task> = Vec::new();
+    for item in &proposal.items {
+        if let Some(idx) = pending.iter().position(|t| t.name == item.name) {
+            reordered.push(pending.remove(idx));
+        }
+    }
+    reordered.append(&mut pending); // unmentioned pending tasks at the end
+
+    // Reconstruct: in_progress, pending (reordered), blocked, completed
+    task_file.tasks = others.iter().filter(|t| t.status == "in_progress").cloned()
+        .chain(reordered)
+        .chain(others.iter().filter(|t| t.status == "blocked").cloned())
+        .chain(others.iter().filter(|t| t.status == "completed").cloned())
+        .collect();
+}
+
+/// Apply ingest results: add tasks from AI output, deduplicating.
+/// Returns (added_count, skipped_count).
+pub fn apply_ingest(task_file: &mut TaskFile, ingest: &IngestResult) -> (usize, usize) {
+    let mut added = 0;
+    let mut skipped = 0;
+
+    for it in &ingest.tasks {
+        let task = Task {
+            name: it.name.clone(),
+            description: it.description.clone(),
+            status: "pending".to_string(),
+            project: it.project.clone(),
+            source: it.source.clone(),
+            source_ref: it.source_ref.clone(),
+            model: it.model.clone(),
+            workflow: None,
+            needs: None,
+            blocked_reason: None,
+            created_at: Some(iso_now()),
+            started_at: None,
+            completed_at: None,
+        };
+        if add_task(task_file, task) {
+            added += 1;
+        } else {
+            skipped += 1;
+        }
+    }
+
+    (added, skipped)
 }
 
 // ── Entry point ───────────────────────────────────────────────────────
@@ -183,23 +341,22 @@ pub async fn execute(args: &TasksArgs) -> Result<()> {
     match &args.command {
         None => execute_list(args.json),
         Some(TasksCommand::Add {
-            description,
-            name,
-            source,
-            source_ref,
-            project,
+            description, name, source, source_ref, project,
         }) => execute_add(description, name.as_deref(), source, source_ref.as_deref(), project.as_deref()),
         Some(TasksCommand::Done { name }) => execute_done(name),
         Some(TasksCommand::Block { name, reason }) => execute_block(name, reason.as_deref()),
-        Some(TasksCommand::Prune { all }) => execute_prune(*all),
+        Some(TasksCommand::Ingest { file, apply }) => execute_ingest(file.as_ref(), *apply).await,
+        Some(TasksCommand::Prioritize) => execute_prioritize().await,
         Some(TasksCommand::Proposal { accept }) => execute_proposal(*accept),
+        Some(TasksCommand::Prune { all }) => execute_prune(*all),
     }
 }
 
 // ── List ──────────────────────────────────────────────────────────────
 
 fn execute_list(json: bool) -> Result<()> {
-    let task_file = load_tasks()?;
+    let path = tasks_file_path();
+    let task_file = load_tasks_from(&path)?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&task_file.tasks)?);
@@ -218,17 +375,13 @@ fn execute_list(json: bool) -> Result<()> {
 
     if !in_progress.is_empty() {
         println!("In Progress ({}):", in_progress.len());
-        for t in &in_progress {
-            print_task(t);
-        }
+        for t in &in_progress { print_task(t); }
         println!();
     }
 
     if !pending.is_empty() {
         println!("Pending ({}):", pending.len());
-        for t in &pending {
-            print_task(t);
-        }
+        for t in &pending { print_task(t); }
         println!();
     }
 
@@ -237,15 +390,12 @@ fn execute_list(json: bool) -> Result<()> {
         for t in &blocked {
             let reason = t.blocked_reason.as_deref().unwrap_or("");
             println!("  {} — {}", t.name, t.description);
-            if !reason.is_empty() {
-                println!("    reason: {reason}");
-            }
+            if !reason.is_empty() { println!("    reason: {reason}"); }
         }
         println!();
     }
 
     println!("Completed: {}", completed.len());
-
     Ok(())
 }
 
@@ -265,121 +415,193 @@ fn print_task(task: &Task) {
 // ── Add ───────────────────────────────────────────────────────────────
 
 fn execute_add(
-    description: &str,
-    name: Option<&str>,
-    source: &str,
-    source_ref: Option<&str>,
-    project: Option<&str>,
+    description: &str, name: Option<&str>, source: &str,
+    source_ref: Option<&str>, project: Option<&str>,
 ) -> Result<()> {
-    let mut task_file = load_tasks()?;
+    let path = tasks_file_path();
+    let mut task_file = load_tasks_from(&path)?;
 
-    let task_name = match name {
-        Some(n) => n.to_string(),
-        None => slugify(description),
-    };
-
-    // Check for duplicate source_ref
-    if let Some(ref sref) = source_ref {
-        if task_file.tasks.iter().any(|t| t.source_ref.as_deref() == Some(sref)) {
-            eprintln!("Task with source_ref '{sref}' already exists, skipping.");
-            return Ok(());
-        }
-    }
-
-    // Check for duplicate name
-    if task_file.tasks.iter().any(|t| t.name == task_name) {
-        eprintln!("Task '{task_name}' already exists.");
-        return Ok(());
-    }
-
-    let now = iso_now();
-    task_file.tasks.push(Task {
+    let task_name = name.map(String::from).unwrap_or_else(|| slugify(description));
+    let task = Task {
         name: task_name.clone(),
         description: description.to_string(),
         status: "pending".to_string(),
         project: project.map(String::from),
         source: Some(source.to_string()),
         source_ref: source_ref.map(String::from),
-        model: None,
-        workflow: None,
-        needs: None,
-        blocked_reason: None,
-        created_at: Some(now),
-        started_at: None,
-        completed_at: None,
-    });
+        model: None, workflow: None, needs: None, blocked_reason: None,
+        created_at: Some(iso_now()), started_at: None, completed_at: None,
+    };
 
-    save_tasks(&task_file)?;
-    println!("Added: {task_name}");
+    if add_task(&mut task_file, task) {
+        save_tasks_to(&task_file, &path)?;
+        println!("Added: {task_name}");
+    } else {
+        eprintln!("Task '{task_name}' already exists, skipping.");
+    }
     Ok(())
 }
 
-// ── Done ──────────────────────────────────────────────────────────────
+// ── Done / Block ──────────────────────────────────────────────────────
 
 fn execute_done(name: &str) -> Result<()> {
-    let mut task_file = load_tasks()?;
-
-    let task = task_file.tasks.iter_mut().find(|t| t.name == name);
-    match task {
-        Some(t) => {
-            t.status = "completed".to_string();
-            t.completed_at = Some(iso_now());
-            save_tasks(&task_file)?;
-            println!("Completed: {name}");
-        }
-        None => {
-            eprintln!("Task '{name}' not found.");
-        }
+    let path = tasks_file_path();
+    let mut task_file = load_tasks_from(&path)?;
+    if complete_task(&mut task_file, name) {
+        save_tasks_to(&task_file, &path)?;
+        println!("Completed: {name}");
+    } else {
+        eprintln!("Task '{name}' not found.");
     }
     Ok(())
 }
-
-// ── Block ─────────────────────────────────────────────────────────────
 
 fn execute_block(name: &str, reason: Option<&str>) -> Result<()> {
-    let mut task_file = load_tasks()?;
-
-    let task = task_file.tasks.iter_mut().find(|t| t.name == name);
-    match task {
-        Some(t) => {
-            t.status = "blocked".to_string();
-            t.blocked_reason = reason.map(String::from);
-            save_tasks(&task_file)?;
-            println!("Blocked: {name}");
-        }
-        None => {
-            eprintln!("Task '{name}' not found.");
-        }
+    let path = tasks_file_path();
+    let mut task_file = load_tasks_from(&path)?;
+    if block_task(&mut task_file, name, reason) {
+        save_tasks_to(&task_file, &path)?;
+        println!("Blocked: {name}");
+    } else {
+        eprintln!("Task '{name}' not found.");
     }
     Ok(())
 }
 
-// ── Prune ─────────────────────────────────────────────────────────────
+// ── Ingest ────────────────────────────────────────────────────────────
 
-fn execute_prune(all: bool) -> Result<()> {
-    let mut task_file = load_tasks()?;
-    let before = task_file.tasks.len();
+/// Ingest notifications into tasks.
+///
+/// Without --apply: reads notifications JSON, outputs a prompt + context
+/// for an AI to decide which notifications become tasks. The AI should
+/// return an IngestResult JSON.
+///
+/// With --apply: reads IngestResult JSON from stdin and adds tasks.
+async fn execute_ingest(file: Option<&PathBuf>, apply: bool) -> Result<()> {
+    let path = tasks_file_path();
 
-    if all {
-        task_file.tasks.retain(|t| t.status != "completed");
-    } else {
-        // Keep completed tasks from the last 30 days
-        let cutoff = chrono_days_ago(30);
-        task_file.tasks.retain(|t| {
-            if t.status != "completed" {
-                return true;
-            }
-            // Keep if no completed_at or if within cutoff
-            match &t.completed_at {
-                Some(ts) => ts.as_str() >= cutoff.as_str(),
-                None => true,
-            }
+    if apply {
+        // Read IngestResult JSON from stdin
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+        let ingest: IngestResult = serde_json::from_str(&buf)
+            .context("failed to parse ingest JSON from stdin")?;
+
+        let mut task_file = load_tasks_from(&path)?;
+        let (added, skipped) = apply_ingest(&mut task_file, &ingest);
+        save_tasks_to(&task_file, &path)?;
+
+        let result = serde_json::json!({
+            "added": added,
+            "skipped": skipped,
+            "total": task_file.tasks.len(),
         });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
     }
 
-    let removed = before - task_file.tasks.len();
-    save_tasks(&task_file)?;
-    println!("Pruned {removed} completed tasks ({} remaining).", task_file.tasks.len());
+    // Read notifications JSON
+    let notifications_json = match file {
+        Some(f) => std::fs::read_to_string(f)
+            .with_context(|| format!("failed to read {}", f.display()))?,
+        None => {
+            let mut buf = String::new();
+            std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+            buf
+        }
+    };
+
+    // Load current tasks for context
+    let task_file = load_tasks_from(&path)?;
+    let existing_refs: Vec<&str> = task_file.tasks.iter()
+        .filter_map(|t| t.source_ref.as_deref())
+        .collect();
+
+    // Output structured context for AI consumption
+    let output = serde_json::json!({
+        "action": "ingest",
+        "instructions": "Review these notifications and decide which are actionable tasks. \
+            Return JSON matching the IngestResult schema: {\"tasks\": [{\"name\": \"kebab-case-name\", \
+            \"description\": \"what to do\", \"source\": \"email|github|forgejo\", \
+            \"source_ref\": \"unique-ref\", \"project\": \"optional-project\"}]}. \
+            Skip notifications that already have a matching source_ref in existing_refs. \
+            Skip automated notifications, newsletters, and CI status. \
+            Any message containing 'ping' MUST create a reply-with-pong task.",
+        "notifications": serde_json::from_str::<serde_json::Value>(&notifications_json)
+            .unwrap_or(serde_json::json!([])),
+        "existing_refs": existing_refs,
+        "response_schema": {
+            "type": "object",
+            "properties": {
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["name", "description"],
+                        "properties": {
+                            "name": {"type": "string"},
+                            "description": {"type": "string"},
+                            "source": {"type": "string"},
+                            "source_ref": {"type": "string"},
+                            "project": {"type": "string"},
+                            "model": {"type": "string"}
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+// ── Prioritize ────────────────────────────────────────────────────────
+
+/// Output pending tasks as a structured prompt for AI prioritization.
+/// The AI should return a PrioritizationProposal JSON.
+async fn execute_prioritize() -> Result<()> {
+    let path = tasks_file_path();
+    let task_file = load_tasks_from(&path)?;
+
+    let pending: Vec<&Task> = task_file.tasks.iter()
+        .filter(|t| t.status == "pending")
+        .collect();
+
+    if pending.is_empty() {
+        println!("No pending tasks to prioritize.");
+        return Ok(());
+    }
+
+    let output = serde_json::json!({
+        "action": "prioritize",
+        "instructions": "Rank these pending tasks by priority. Consider urgency, dependencies, \
+            project importance, and source type (PR reviews and email replies are typically \
+            time-sensitive). Return JSON matching the PrioritizationProposal schema. \
+            Include a short rationale (1-2 sentences) explaining why each task is ranked where it is.",
+        "pending_tasks": pending,
+        "response_schema": {
+            "type": "object",
+            "required": ["proposed_at", "items"],
+            "properties": {
+                "proposed_at": {"type": "string", "description": "ISO 8601 timestamp"},
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["rank", "name", "rationale"],
+                        "properties": {
+                            "rank": {"type": "integer"},
+                            "name": {"type": "string"},
+                            "rationale": {"type": "string"}
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())
 }
 
@@ -397,49 +619,16 @@ fn execute_proposal(accept: bool) -> Result<()> {
         let content = std::fs::read_to_string(&path)?;
         let proposal: PrioritizationProposal = serde_json::from_str(&content)?;
 
-        let mut task_file = load_tasks()?;
+        let tasks_path = tasks_file_path();
+        let mut task_file = load_tasks_from(&tasks_path)?;
+        apply_proposal(&mut task_file, &proposal);
+        save_tasks_to(&task_file, &tasks_path)?;
 
-        // Reorder pending tasks according to proposal
-        let mut pending: Vec<Task> = task_file.tasks.drain(..).collect();
-        let mut non_pending: Vec<Task> = Vec::new();
-        let mut reordered_pending: Vec<Task> = Vec::new();
-
-        // Separate pending from non-pending
-        let mut pending_tasks: Vec<Task> = Vec::new();
-        for task in pending.drain(..) {
-            if task.status == "pending" {
-                pending_tasks.push(task);
-            } else {
-                non_pending.push(task);
-            }
-        }
-
-        // Reorder pending by proposal rank
-        for item in &proposal.items {
-            if let Some(idx) = pending_tasks.iter().position(|t| t.name == item.name) {
-                reordered_pending.push(pending_tasks.remove(idx));
-            }
-        }
-        // Append any pending tasks not in the proposal
-        reordered_pending.append(&mut pending_tasks);
-
-        // Reconstruct: in_progress first, then reordered pending, then blocked, then completed
-        task_file.tasks = non_pending
-            .iter()
-            .filter(|t| t.status == "in_progress")
-            .cloned()
-            .chain(reordered_pending.into_iter())
-            .chain(non_pending.iter().filter(|t| t.status == "blocked").cloned())
-            .chain(non_pending.iter().filter(|t| t.status == "completed").cloned())
-            .collect();
-
-        save_tasks(&task_file)?;
         std::fs::remove_file(&path).ok();
         println!("Accepted prioritization. {} pending tasks reordered.", proposal.items.len());
         return Ok(());
     }
 
-    // Show current proposal
     if !path.exists() {
         println!("No pending proposal.");
         return Ok(());
@@ -453,13 +642,23 @@ fn execute_proposal(accept: bool) -> Result<()> {
         println!("  {}. {} — {}", item.rank, item.name, item.rationale);
     }
     println!("\nAccept with: ks tasks proposal --accept");
+    Ok(())
+}
 
+// ── Prune ─────────────────────────────────────────────────────────────
+
+fn execute_prune(all: bool) -> Result<()> {
+    let path = tasks_file_path();
+    let mut task_file = load_tasks_from(&path)?;
+    let removed = prune_tasks(&mut task_file, all);
+    save_tasks_to(&task_file, &path)?;
+    println!("Pruned {removed} completed tasks ({} remaining).", task_file.tasks.len());
     Ok(())
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
-fn slugify(text: &str) -> String {
+pub fn slugify(text: &str) -> String {
     text.to_lowercase()
         .chars()
         .map(|c| if c.is_alphanumeric() { c } else { '-' })
@@ -473,26 +672,22 @@ fn slugify(text: &str) -> String {
         .collect()
 }
 
-fn iso_now() -> String {
+pub fn iso_now() -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    // Format as ISO 8601 (approximate — no chrono dependency)
     let secs_per_day = 86400u64;
     let days = now / secs_per_day;
     let time_of_day = now % secs_per_day;
     let hours = time_of_day / 3600;
     let minutes = (time_of_day % 3600) / 60;
     let seconds = time_of_day % 60;
-
-    // Days since epoch to Y-M-D (simplified Gregorian)
     let (year, month, day) = epoch_days_to_ymd(days);
     format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
 }
 
 fn epoch_days_to_ymd(days: u64) -> (u64, u64, u64) {
-    // Algorithm from https://howardhinnant.github.io/date_algorithms.html
     let z = days + 719468;
     let era = z / 146097;
     let doe = z - era * 146097;
@@ -514,4 +709,334 @@ fn chrono_days_ago(days: u64) -> String {
     let past = now.saturating_sub(days * 86400);
     let (year, month, day) = epoch_days_to_ymd(past / 86400);
     format!("{year:04}-{month:02}-{day:02}")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    fn make_task(name: &str, status: &str) -> Task {
+        Task {
+            name: name.to_string(),
+            description: format!("Test task: {name}"),
+            status: status.to_string(),
+            project: None, source: None, source_ref: None, model: None,
+            workflow: None, needs: None, blocked_reason: None,
+            created_at: None, started_at: None, completed_at: None,
+        }
+    }
+
+    fn make_task_with_ref(name: &str, source_ref: &str) -> Task {
+        let mut t = make_task(name, "pending");
+        t.source_ref = Some(source_ref.to_string());
+        t
+    }
+
+    // ── slugify ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_slugify_basic() {
+        assert_eq!(slugify("Review PR #355"), "review-pr-355");
+    }
+
+    #[test]
+    fn test_slugify_special_chars() {
+        assert_eq!(slugify("Fix login (staging)!"), "fix-login-staging");
+    }
+
+    #[test]
+    fn test_slugify_truncation() {
+        let long = "a".repeat(100);
+        assert_eq!(slugify(&long).len(), 60);
+    }
+
+    // ── YAML round-trip ───────────────────────────────────────────
+
+    #[test]
+    fn test_yaml_round_trip() {
+        let task_file = TaskFile {
+            tasks: vec![
+                make_task("task-one", "pending"),
+                make_task("task-two", "completed"),
+            ],
+        };
+
+        let tmp = NamedTempFile::new().unwrap();
+        save_tasks_to(&task_file, &tmp.path().to_path_buf()).unwrap();
+
+        let loaded = load_tasks_from(&tmp.path().to_path_buf()).unwrap();
+        assert_eq!(loaded.tasks.len(), 2);
+        assert_eq!(loaded.tasks[0].name, "task-one");
+        assert_eq!(loaded.tasks[1].status, "completed");
+    }
+
+    #[test]
+    fn test_load_missing_file() {
+        let path = PathBuf::from("/tmp/nonexistent-ks-test-tasks.yaml");
+        let result = load_tasks_from(&path).unwrap();
+        assert!(result.tasks.is_empty());
+    }
+
+    // ── add_task deduplication ─────────────────────────────────────
+
+    #[test]
+    fn test_add_task_basic() {
+        let mut tf = TaskFile { tasks: vec![] };
+        let task = make_task("new-task", "pending");
+        assert!(add_task(&mut tf, task));
+        assert_eq!(tf.tasks.len(), 1);
+    }
+
+    #[test]
+    fn test_add_task_dedup_by_name() {
+        let mut tf = TaskFile { tasks: vec![make_task("existing", "pending")] };
+        let dup = make_task("existing", "pending");
+        assert!(!add_task(&mut tf, dup));
+        assert_eq!(tf.tasks.len(), 1);
+    }
+
+    #[test]
+    fn test_add_task_dedup_by_source_ref() {
+        let mut tf = TaskFile {
+            tasks: vec![make_task_with_ref("old-task", "email-42-user@host")],
+        };
+        let dup = make_task_with_ref("new-name", "email-42-user@host");
+        assert!(!add_task(&mut tf, dup));
+        assert_eq!(tf.tasks.len(), 1);
+    }
+
+    #[test]
+    fn test_add_task_different_ref_ok() {
+        let mut tf = TaskFile {
+            tasks: vec![make_task_with_ref("task-a", "ref-a")],
+        };
+        let new = make_task_with_ref("task-b", "ref-b");
+        assert!(add_task(&mut tf, new));
+        assert_eq!(tf.tasks.len(), 2);
+    }
+
+    // ── complete / block ──────────────────────────────────────────
+
+    #[test]
+    fn test_complete_task() {
+        let mut tf = TaskFile { tasks: vec![make_task("fix-bug", "pending")] };
+        assert!(complete_task(&mut tf, "fix-bug"));
+        assert_eq!(tf.tasks[0].status, "completed");
+        assert!(tf.tasks[0].completed_at.is_some());
+    }
+
+    #[test]
+    fn test_complete_task_not_found() {
+        let mut tf = TaskFile { tasks: vec![] };
+        assert!(!complete_task(&mut tf, "missing"));
+    }
+
+    #[test]
+    fn test_block_task() {
+        let mut tf = TaskFile { tasks: vec![make_task("blocked-task", "pending")] };
+        assert!(block_task(&mut tf, "blocked-task", Some("waiting for deploy")));
+        assert_eq!(tf.tasks[0].status, "blocked");
+        assert_eq!(tf.tasks[0].blocked_reason.as_deref(), Some("waiting for deploy"));
+    }
+
+    // ── prune ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_prune_all() {
+        let mut tf = TaskFile {
+            tasks: vec![
+                make_task("pending-task", "pending"),
+                make_task("done-task", "completed"),
+                make_task("done-old", "completed"),
+            ],
+        };
+        let removed = prune_tasks(&mut tf, true);
+        assert_eq!(removed, 2);
+        assert_eq!(tf.tasks.len(), 1);
+        assert_eq!(tf.tasks[0].name, "pending-task");
+    }
+
+    #[test]
+    fn test_prune_preserves_recent() {
+        let mut t = make_task("recent", "completed");
+        t.completed_at = Some(iso_now()); // just now
+        let mut tf = TaskFile { tasks: vec![t] };
+        let removed = prune_tasks(&mut tf, false);
+        assert_eq!(removed, 0);
+        assert_eq!(tf.tasks.len(), 1);
+    }
+
+    #[test]
+    fn test_prune_removes_old() {
+        let mut t = make_task("old", "completed");
+        t.completed_at = Some("2020-01-01T00:00:00Z".to_string());
+        let mut tf = TaskFile { tasks: vec![t] };
+        let removed = prune_tasks(&mut tf, false);
+        assert_eq!(removed, 1);
+    }
+
+    // ── apply_proposal ────────────────────────────────────────────
+
+    #[test]
+    fn test_apply_proposal_reorders() {
+        let mut tf = TaskFile {
+            tasks: vec![
+                make_task("low-pri", "pending"),
+                make_task("high-pri", "pending"),
+                make_task("done", "completed"),
+            ],
+        };
+
+        let proposal = PrioritizationProposal {
+            proposed_at: "2026-04-13T00:00:00Z".to_string(),
+            items: vec![
+                ProposalItem { rank: 1, name: "high-pri".to_string(), rationale: "Urgent".to_string() },
+                ProposalItem { rank: 2, name: "low-pri".to_string(), rationale: "Can wait".to_string() },
+            ],
+        };
+
+        apply_proposal(&mut tf, &proposal);
+
+        assert_eq!(tf.tasks[0].name, "high-pri"); // reordered first
+        assert_eq!(tf.tasks[1].name, "low-pri");
+        assert_eq!(tf.tasks[2].name, "done"); // completed at end
+    }
+
+    #[test]
+    fn test_apply_proposal_preserves_in_progress() {
+        let mut tf = TaskFile {
+            tasks: vec![
+                make_task("wip", "in_progress"),
+                make_task("pending-a", "pending"),
+                make_task("pending-b", "pending"),
+            ],
+        };
+
+        let proposal = PrioritizationProposal {
+            proposed_at: "2026-04-13T00:00:00Z".to_string(),
+            items: vec![
+                ProposalItem { rank: 1, name: "pending-b".to_string(), rationale: "Higher priority".to_string() },
+                ProposalItem { rank: 2, name: "pending-a".to_string(), rationale: "Lower priority".to_string() },
+            ],
+        };
+
+        apply_proposal(&mut tf, &proposal);
+
+        assert_eq!(tf.tasks[0].name, "wip"); // in_progress stays first
+        assert_eq!(tf.tasks[1].name, "pending-b");
+        assert_eq!(tf.tasks[2].name, "pending-a");
+    }
+
+    // ── apply_ingest ──────────────────────────────────────────────
+
+    #[test]
+    fn test_apply_ingest_adds_new() {
+        let mut tf = TaskFile { tasks: vec![] };
+        let ingest = IngestResult {
+            tasks: vec![
+                IngestTask {
+                    name: "reply-to-ping".to_string(),
+                    description: "Reply with pong".to_string(),
+                    source: Some("email".to_string()),
+                    source_ref: Some("email-99-user@host".to_string()),
+                    project: None,
+                    model: Some("haiku".to_string()),
+                },
+            ],
+        };
+
+        let (added, skipped) = apply_ingest(&mut tf, &ingest);
+        assert_eq!(added, 1);
+        assert_eq!(skipped, 0);
+        assert_eq!(tf.tasks[0].name, "reply-to-ping");
+        assert_eq!(tf.tasks[0].model, Some("haiku".to_string()));
+    }
+
+    #[test]
+    fn test_apply_ingest_dedup() {
+        let mut tf = TaskFile {
+            tasks: vec![make_task_with_ref("existing", "email-42-user@host")],
+        };
+        let ingest = IngestResult {
+            tasks: vec![
+                IngestTask {
+                    name: "new-task-same-ref".to_string(),
+                    description: "Duplicate ref".to_string(),
+                    source: Some("email".to_string()),
+                    source_ref: Some("email-42-user@host".to_string()),
+                    project: None,
+                    model: None,
+                },
+                IngestTask {
+                    name: "genuinely-new".to_string(),
+                    description: "New task".to_string(),
+                    source: Some("github".to_string()),
+                    source_ref: Some("https://github.com/o/r/issues/1".to_string()),
+                    project: None,
+                    model: None,
+                },
+            ],
+        };
+
+        let (added, skipped) = apply_ingest(&mut tf, &ingest);
+        assert_eq!(added, 1);
+        assert_eq!(skipped, 1);
+        assert_eq!(tf.tasks.len(), 2);
+    }
+
+    // ── IngestResult JSON parsing ─────────────────────────────────
+
+    #[test]
+    fn test_ingest_result_parse() {
+        let json = r#"{
+            "tasks": [
+                {"name": "fix-bug", "description": "Fix the bug", "source": "github", "source_ref": "http://example.com/1"},
+                {"name": "reply-email", "description": "Reply to email"}
+            ]
+        }"#;
+
+        let result: IngestResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.tasks.len(), 2);
+        assert_eq!(result.tasks[0].source_ref, Some("http://example.com/1".to_string()));
+        assert_eq!(result.tasks[1].source, None);
+    }
+
+    // ── PrioritizationProposal JSON parsing ───────────────────────
+
+    #[test]
+    fn test_proposal_parse() {
+        let json = r#"{
+            "proposed_at": "2026-04-13T12:00:00Z",
+            "items": [
+                {"rank": 1, "name": "urgent-task", "rationale": "Production is down"},
+                {"rank": 2, "name": "review-pr", "rationale": "Teammate waiting on review"}
+            ]
+        }"#;
+
+        let proposal: PrioritizationProposal = serde_json::from_str(json).unwrap();
+        assert_eq!(proposal.items.len(), 2);
+        assert_eq!(proposal.items[0].rationale, "Production is down");
+    }
+
+    // ── iso_now / epoch_days_to_ymd ───────────────────────────────
+
+    #[test]
+    fn test_iso_now_format() {
+        let now = iso_now();
+        // Should match YYYY-MM-DDTHH:MM:SSZ
+        assert!(now.len() == 20, "unexpected length: {now}");
+        assert!(now.ends_with('Z'));
+        assert_eq!(&now[4..5], "-");
+        assert_eq!(&now[10..11], "T");
+    }
+
+    #[test]
+    fn test_epoch_known_date() {
+        // 2026-01-01 = day 20454 from epoch
+        let (y, m, d) = epoch_days_to_ymd(20454);
+        assert_eq!((y, m, d), (2026, 1, 1));
+    }
 }

--- a/packages/ks/src/cmd/tasks.rs
+++ b/packages/ks/src/cmd/tasks.rs
@@ -14,9 +14,9 @@ use serde::{Deserialize, Serialize};
 // ── CLI definition ────────────────────────────────────────────────────
 
 #[derive(Args)]
-pub struct TasksArgs {
+pub struct TaskArgs {
     #[command(subcommand)]
-    pub command: Option<TasksCommand>,
+    pub command: Option<TaskCommand>,
 
     /// Output as JSON instead of human-readable table.
     #[arg(long)]
@@ -24,7 +24,7 @@ pub struct TasksArgs {
 }
 
 #[derive(Subcommand)]
-pub enum TasksCommand {
+pub enum TaskCommand {
     /// Add a new task.
     Add {
         /// Task description.
@@ -45,6 +45,12 @@ pub enum TasksCommand {
         /// Associated project.
         #[arg(long)]
         project: Option<String>,
+    },
+
+    /// Mark a task as in-progress.
+    Start {
+        /// Task name to start.
+        name: String,
     },
 
     /// Mark a task as completed.
@@ -230,6 +236,17 @@ pub fn add_task(task_file: &mut TaskFile, task: Task) -> bool {
     true
 }
 
+/// Mark a task as in-progress. Returns true if found.
+pub fn start_task(task_file: &mut TaskFile, name: &str) -> bool {
+    if let Some(t) = task_file.tasks.iter_mut().find(|t| t.name == name) {
+        t.status = "in_progress".to_string();
+        t.started_at = Some(iso_now());
+        true
+    } else {
+        false
+    }
+}
+
 /// Mark a task as completed. Returns true if found.
 pub fn complete_task(task_file: &mut TaskFile, name: &str) -> bool {
     if let Some(t) = task_file.tasks.iter_mut().find(|t| t.name == name) {
@@ -337,18 +354,19 @@ pub fn apply_ingest(task_file: &mut TaskFile, ingest: &IngestResult) -> (usize, 
 
 // ── Entry point ───────────────────────────────────────────────────────
 
-pub async fn execute(args: &TasksArgs) -> Result<()> {
+pub async fn execute(args: &TaskArgs) -> Result<()> {
     match &args.command {
         None => execute_list(args.json),
-        Some(TasksCommand::Add {
+        Some(TaskCommand::Add {
             description, name, source, source_ref, project,
         }) => execute_add(description, name.as_deref(), source, source_ref.as_deref(), project.as_deref()),
-        Some(TasksCommand::Done { name }) => execute_done(name),
-        Some(TasksCommand::Block { name, reason }) => execute_block(name, reason.as_deref()),
-        Some(TasksCommand::Ingest { file, apply }) => execute_ingest(file.as_ref(), *apply).await,
-        Some(TasksCommand::Prioritize) => execute_prioritize().await,
-        Some(TasksCommand::Proposal { accept }) => execute_proposal(*accept),
-        Some(TasksCommand::Prune { all }) => execute_prune(*all),
+        Some(TaskCommand::Start { name }) => execute_start(name),
+        Some(TaskCommand::Done { name }) => execute_done(name),
+        Some(TaskCommand::Block { name, reason }) => execute_block(name, reason.as_deref()),
+        Some(TaskCommand::Ingest { file, apply }) => execute_ingest(file.as_ref(), *apply).await,
+        Some(TaskCommand::Prioritize) => execute_prioritize().await,
+        Some(TaskCommand::Proposal { accept }) => execute_proposal(*accept),
+        Some(TaskCommand::Prune { all }) => execute_prune(*all),
     }
 }
 
@@ -442,7 +460,19 @@ fn execute_add(
     Ok(())
 }
 
-// ── Done / Block ──────────────────────────────────────────────────────
+// ── Start / Done / Block ──────────────────────────────────────────────
+
+fn execute_start(name: &str) -> Result<()> {
+    let path = tasks_file_path();
+    let mut task_file = load_tasks_from(&path)?;
+    if start_task(&mut task_file, name) {
+        save_tasks_to(&task_file, &path)?;
+        println!("Started: {name}");
+    } else {
+        eprintln!("Task '{name}' not found.");
+    }
+    Ok(())
+}
 
 fn execute_done(name: &str) -> Result<()> {
     let path = tasks_file_path();
@@ -819,6 +849,20 @@ mod tests {
     }
 
     // ── complete / block ──────────────────────────────────────────
+
+    #[test]
+    fn test_start_task() {
+        let mut tf = TaskFile { tasks: vec![make_task("my-task", "pending")] };
+        assert!(start_task(&mut tf, "my-task"));
+        assert_eq!(tf.tasks[0].status, "in_progress");
+        assert!(tf.tasks[0].started_at.is_some());
+    }
+
+    #[test]
+    fn test_start_task_not_found() {
+        let mut tf = TaskFile { tasks: vec![] };
+        assert!(!start_task(&mut tf, "missing"));
+    }
 
     #[test]
     fn test_complete_task() {

--- a/packages/ks/src/cmd/tasks.rs
+++ b/packages/ks/src/cmd/tasks.rs
@@ -1,0 +1,517 @@
+//! `ks tasks` — unified task management for humans and agents.
+//!
+//! Manages TASKS.yaml: add, complete, list, prune, and AI-powered ingest
+//! and prioritization. Tasks are created from `ks notifications` sources
+//! or manually. Prioritization proposals include rationale and can be
+//! reviewed before acceptance.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+
+// ── CLI definition ────────────────────────────────────────────────────
+
+#[derive(Args)]
+pub struct TasksArgs {
+    #[command(subcommand)]
+    pub command: Option<TasksCommand>,
+
+    /// Output as JSON instead of human-readable table.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Subcommand)]
+pub enum TasksCommand {
+    /// Add a new task.
+    Add {
+        /// Task description.
+        description: String,
+
+        /// Task name (kebab-case). Auto-generated from description if omitted.
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Source type (email, github-issue, github-pr, manual).
+        #[arg(long, default_value = "manual")]
+        source: String,
+
+        /// Source reference for deduplication.
+        #[arg(long)]
+        source_ref: Option<String>,
+
+        /// Associated project.
+        #[arg(long)]
+        project: Option<String>,
+    },
+
+    /// Mark a task as completed.
+    Done {
+        /// Task name to complete.
+        name: String,
+    },
+
+    /// Mark a task as blocked.
+    Block {
+        /// Task name to block.
+        name: String,
+
+        /// Reason for blocking.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+
+    /// Remove completed tasks older than a threshold.
+    Prune {
+        /// Remove all completed tasks (default: only those older than 30 days).
+        #[arg(long)]
+        all: bool,
+    },
+
+    /// Show prioritization proposal from last `prioritize` run.
+    Proposal {
+        /// Accept the current proposal and apply the new ordering.
+        #[arg(long)]
+        accept: bool,
+    },
+}
+
+// ── Data model ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskFile {
+    pub tasks: Vec<Task>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Task {
+    pub name: String,
+    pub description: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub needs: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<String>,
+}
+
+/// A prioritization proposal from the AI, with rationale per task.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrioritizationProposal {
+    pub proposed_at: String,
+    pub items: Vec<ProposalItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProposalItem {
+    pub rank: u32,
+    pub name: String,
+    pub rationale: String,
+}
+
+// ── Paths ─────────────────────────────────────────────────────────────
+
+fn tasks_file_path() -> PathBuf {
+    // TASKS.yaml lives in $HOME for agents, or current dir for humans
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    let home_path = PathBuf::from(&home).join("TASKS.yaml");
+    if home_path.exists() {
+        return home_path;
+    }
+    // Fall back to current directory
+    let cwd_path = PathBuf::from("TASKS.yaml");
+    if cwd_path.exists() {
+        return cwd_path;
+    }
+    // Default to home
+    home_path
+}
+
+fn proposal_path() -> PathBuf {
+    let state_dir = std::env::var("XDG_STATE_HOME")
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            format!("{home}/.local/state")
+        });
+    PathBuf::from(state_dir).join("ks/tasks/proposal.json")
+}
+
+// ── File I/O ──────────────────────────────────────────────────────────
+
+fn load_tasks() -> Result<TaskFile> {
+    let path = tasks_file_path();
+    if !path.exists() {
+        return Ok(TaskFile { tasks: vec![] });
+    }
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let tasks: TaskFile = serde_yaml::from_str(&content)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(tasks)
+}
+
+fn save_tasks(task_file: &TaskFile) -> Result<()> {
+    let path = tasks_file_path();
+    let content = serde_yaml::to_string(task_file)?;
+    // Write with --- header for clean YAML
+    let output = format!("---\n{content}");
+    std::fs::write(&path, output)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+// ── Entry point ───────────────────────────────────────────────────────
+
+pub async fn execute(args: &TasksArgs) -> Result<()> {
+    match &args.command {
+        None => execute_list(args.json),
+        Some(TasksCommand::Add {
+            description,
+            name,
+            source,
+            source_ref,
+            project,
+        }) => execute_add(description, name.as_deref(), source, source_ref.as_deref(), project.as_deref()),
+        Some(TasksCommand::Done { name }) => execute_done(name),
+        Some(TasksCommand::Block { name, reason }) => execute_block(name, reason.as_deref()),
+        Some(TasksCommand::Prune { all }) => execute_prune(*all),
+        Some(TasksCommand::Proposal { accept }) => execute_proposal(*accept),
+    }
+}
+
+// ── List ──────────────────────────────────────────────────────────────
+
+fn execute_list(json: bool) -> Result<()> {
+    let task_file = load_tasks()?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&task_file.tasks)?);
+        return Ok(());
+    }
+
+    if task_file.tasks.is_empty() {
+        println!("No tasks.");
+        return Ok(());
+    }
+
+    let pending: Vec<_> = task_file.tasks.iter().filter(|t| t.status == "pending").collect();
+    let in_progress: Vec<_> = task_file.tasks.iter().filter(|t| t.status == "in_progress").collect();
+    let blocked: Vec<_> = task_file.tasks.iter().filter(|t| t.status == "blocked").collect();
+    let completed: Vec<_> = task_file.tasks.iter().filter(|t| t.status == "completed").collect();
+
+    if !in_progress.is_empty() {
+        println!("In Progress ({}):", in_progress.len());
+        for t in &in_progress {
+            print_task(t);
+        }
+        println!();
+    }
+
+    if !pending.is_empty() {
+        println!("Pending ({}):", pending.len());
+        for t in &pending {
+            print_task(t);
+        }
+        println!();
+    }
+
+    if !blocked.is_empty() {
+        println!("Blocked ({}):", blocked.len());
+        for t in &blocked {
+            let reason = t.blocked_reason.as_deref().unwrap_or("");
+            println!("  {} — {}", t.name, t.description);
+            if !reason.is_empty() {
+                println!("    reason: {reason}");
+            }
+        }
+        println!();
+    }
+
+    println!("Completed: {}", completed.len());
+
+    Ok(())
+}
+
+fn print_task(task: &Task) {
+    let project = task.project.as_deref().unwrap_or("");
+    let source = task.source.as_deref().unwrap_or("");
+    let prefix = if !project.is_empty() {
+        format!("[{project}] ")
+    } else if !source.is_empty() {
+        format!("({source}) ")
+    } else {
+        String::new()
+    };
+    println!("  {} {}{}", task.name, prefix, task.description);
+}
+
+// ── Add ───────────────────────────────────────────────────────────────
+
+fn execute_add(
+    description: &str,
+    name: Option<&str>,
+    source: &str,
+    source_ref: Option<&str>,
+    project: Option<&str>,
+) -> Result<()> {
+    let mut task_file = load_tasks()?;
+
+    let task_name = match name {
+        Some(n) => n.to_string(),
+        None => slugify(description),
+    };
+
+    // Check for duplicate source_ref
+    if let Some(ref sref) = source_ref {
+        if task_file.tasks.iter().any(|t| t.source_ref.as_deref() == Some(sref)) {
+            eprintln!("Task with source_ref '{sref}' already exists, skipping.");
+            return Ok(());
+        }
+    }
+
+    // Check for duplicate name
+    if task_file.tasks.iter().any(|t| t.name == task_name) {
+        eprintln!("Task '{task_name}' already exists.");
+        return Ok(());
+    }
+
+    let now = iso_now();
+    task_file.tasks.push(Task {
+        name: task_name.clone(),
+        description: description.to_string(),
+        status: "pending".to_string(),
+        project: project.map(String::from),
+        source: Some(source.to_string()),
+        source_ref: source_ref.map(String::from),
+        model: None,
+        workflow: None,
+        needs: None,
+        blocked_reason: None,
+        created_at: Some(now),
+        started_at: None,
+        completed_at: None,
+    });
+
+    save_tasks(&task_file)?;
+    println!("Added: {task_name}");
+    Ok(())
+}
+
+// ── Done ──────────────────────────────────────────────────────────────
+
+fn execute_done(name: &str) -> Result<()> {
+    let mut task_file = load_tasks()?;
+
+    let task = task_file.tasks.iter_mut().find(|t| t.name == name);
+    match task {
+        Some(t) => {
+            t.status = "completed".to_string();
+            t.completed_at = Some(iso_now());
+            save_tasks(&task_file)?;
+            println!("Completed: {name}");
+        }
+        None => {
+            eprintln!("Task '{name}' not found.");
+        }
+    }
+    Ok(())
+}
+
+// ── Block ─────────────────────────────────────────────────────────────
+
+fn execute_block(name: &str, reason: Option<&str>) -> Result<()> {
+    let mut task_file = load_tasks()?;
+
+    let task = task_file.tasks.iter_mut().find(|t| t.name == name);
+    match task {
+        Some(t) => {
+            t.status = "blocked".to_string();
+            t.blocked_reason = reason.map(String::from);
+            save_tasks(&task_file)?;
+            println!("Blocked: {name}");
+        }
+        None => {
+            eprintln!("Task '{name}' not found.");
+        }
+    }
+    Ok(())
+}
+
+// ── Prune ─────────────────────────────────────────────────────────────
+
+fn execute_prune(all: bool) -> Result<()> {
+    let mut task_file = load_tasks()?;
+    let before = task_file.tasks.len();
+
+    if all {
+        task_file.tasks.retain(|t| t.status != "completed");
+    } else {
+        // Keep completed tasks from the last 30 days
+        let cutoff = chrono_days_ago(30);
+        task_file.tasks.retain(|t| {
+            if t.status != "completed" {
+                return true;
+            }
+            // Keep if no completed_at or if within cutoff
+            match &t.completed_at {
+                Some(ts) => ts.as_str() >= cutoff.as_str(),
+                None => true,
+            }
+        });
+    }
+
+    let removed = before - task_file.tasks.len();
+    save_tasks(&task_file)?;
+    println!("Pruned {removed} completed tasks ({} remaining).", task_file.tasks.len());
+    Ok(())
+}
+
+// ── Proposal ──────────────────────────────────────────────────────────
+
+fn execute_proposal(accept: bool) -> Result<()> {
+    let path = proposal_path();
+
+    if accept {
+        if !path.exists() {
+            eprintln!("No proposal to accept. Run prioritization first.");
+            return Ok(());
+        }
+
+        let content = std::fs::read_to_string(&path)?;
+        let proposal: PrioritizationProposal = serde_json::from_str(&content)?;
+
+        let mut task_file = load_tasks()?;
+
+        // Reorder pending tasks according to proposal
+        let mut pending: Vec<Task> = task_file.tasks.drain(..).collect();
+        let mut non_pending: Vec<Task> = Vec::new();
+        let mut reordered_pending: Vec<Task> = Vec::new();
+
+        // Separate pending from non-pending
+        let mut pending_tasks: Vec<Task> = Vec::new();
+        for task in pending.drain(..) {
+            if task.status == "pending" {
+                pending_tasks.push(task);
+            } else {
+                non_pending.push(task);
+            }
+        }
+
+        // Reorder pending by proposal rank
+        for item in &proposal.items {
+            if let Some(idx) = pending_tasks.iter().position(|t| t.name == item.name) {
+                reordered_pending.push(pending_tasks.remove(idx));
+            }
+        }
+        // Append any pending tasks not in the proposal
+        reordered_pending.append(&mut pending_tasks);
+
+        // Reconstruct: in_progress first, then reordered pending, then blocked, then completed
+        task_file.tasks = non_pending
+            .iter()
+            .filter(|t| t.status == "in_progress")
+            .cloned()
+            .chain(reordered_pending.into_iter())
+            .chain(non_pending.iter().filter(|t| t.status == "blocked").cloned())
+            .chain(non_pending.iter().filter(|t| t.status == "completed").cloned())
+            .collect();
+
+        save_tasks(&task_file)?;
+        std::fs::remove_file(&path).ok();
+        println!("Accepted prioritization. {} pending tasks reordered.", proposal.items.len());
+        return Ok(());
+    }
+
+    // Show current proposal
+    if !path.exists() {
+        println!("No pending proposal.");
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(&path)?;
+    let proposal: PrioritizationProposal = serde_json::from_str(&content)?;
+
+    println!("Prioritization proposal ({})\n", proposal.proposed_at);
+    for item in &proposal.items {
+        println!("  {}. {} — {}", item.rank, item.name, item.rationale);
+    }
+    println!("\nAccept with: ks tasks proposal --accept");
+
+    Ok(())
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+fn slugify(text: &str) -> String {
+    text.to_lowercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+        .chars()
+        .take(60)
+        .collect()
+}
+
+fn iso_now() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Format as ISO 8601 (approximate — no chrono dependency)
+    let secs_per_day = 86400u64;
+    let days = now / secs_per_day;
+    let time_of_day = now % secs_per_day;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    // Days since epoch to Y-M-D (simplified Gregorian)
+    let (year, month, day) = epoch_days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
+}
+
+fn epoch_days_to_ymd(days: u64) -> (u64, u64, u64) {
+    // Algorithm from https://howardhinnant.github.io/date_algorithms.html
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+fn chrono_days_ago(days: u64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let past = now.saturating_sub(days * 86400);
+    let (year, month, day) = epoch_days_to_ymd(past / 86400);
+    format!("{year:04}-{month:02}-{day:02}")
+}

--- a/packages/ks/src/main.rs
+++ b/packages/ks/src/main.rs
@@ -93,8 +93,9 @@ async fn main() -> Result<()> {
             Command::Agent(args) => run_agent_command(args).await,
             Command::Doctor(args) => run_doctor_command(args).await,
             Command::Install(args) => run_headless_install(&args.host, args.disk.as_deref()).await,
-            Command::Notifications(args) => run_notifications_command(args).await,
-            Command::Tasks(args) => cmd::tasks::execute(&args).await,
+            Command::Notification(args) => cmd::notifications::execute(&args).await,
+            Command::Task(args) => cmd::tasks::execute(&args).await,
+            Command::Project(args) => cmd::projects::execute(&args).await,
         };
     }
 
@@ -478,9 +479,6 @@ async fn run_doctor_command(args: cli::DoctorArgs) -> Result<()> {
     }
 }
 
-async fn run_notifications_command(args: cmd::notifications::NotificationsArgs) -> Result<()> {
-    cmd::notifications::execute(&args).await
-}
 
 /// Handle a global Action from a Component.
 ///

--- a/packages/ks/src/main.rs
+++ b/packages/ks/src/main.rs
@@ -94,6 +94,7 @@ async fn main() -> Result<()> {
             Command::Doctor(args) => run_doctor_command(args).await,
             Command::Install(args) => run_headless_install(&args.host, args.disk.as_deref()).await,
             Command::Notifications(args) => run_notifications_command(args).await,
+            Command::Tasks(args) => cmd::tasks::execute(&args).await,
         };
     }
 

--- a/packages/ks/src/main.rs
+++ b/packages/ks/src/main.rs
@@ -479,7 +479,6 @@ async fn run_doctor_command(args: cli::DoctorArgs) -> Result<()> {
     }
 }
 
-
 /// Handle a global Action from a Component.
 ///
 /// TODO: once all screens implement Component, this replaces handle_action entirely.

--- a/packages/ks/src/main.rs
+++ b/packages/ks/src/main.rs
@@ -93,6 +93,7 @@ async fn main() -> Result<()> {
             Command::Agent(args) => run_agent_command(args).await,
             Command::Doctor(args) => run_doctor_command(args).await,
             Command::Install(args) => run_headless_install(&args.host, args.disk.as_deref()).await,
+            Command::Notifications(args) => run_notifications_command(args).await,
         };
     }
 
@@ -474,6 +475,10 @@ async fn run_doctor_command(args: cli::DoctorArgs) -> Result<()> {
         Ok(report) => print_json_success(&report),
         Err(e) => print_json_error(&e),
     }
+}
+
+async fn run_notifications_command(args: cmd::notifications::NotificationsArgs) -> Result<()> {
+    cmd::notifications::execute(&args).await
 }
 
 /// Handle a global Action from a Component.


### PR DESCRIPTION
## Summary

- **`ks notification`** — unified fetch across email (himalaya), GitHub (gh), and Forgejo (curl) with source-level read tracking via manifest + ack. Replaces `fetch-email-source`, `fetch-github-sources`, `fetch-forgejo-sources` shell scripts. Only fetches unseen/unread items (1 API call per source for GitHub/Forgejo; email is 1 + N parallel body fetches). Makes `TASKS.yaml` safely prunable — the core problem from #355.
- **`ks task`** — CRUD on `TASKS.yaml` with AI-powered ingest and prioritization. Ingest outputs structured prompts for AI; prioritization proposals include per-task rationale as JSON with review-before-accept flow.
- **`ks project`** — project definitions with repo mapping, priority, and provider overrides. Deterministic repo→project detection (URL normalization + exact match) and heuristic subject-text matching. Projects feed into task ingest prompts so AI can auto-assign tasks to projects.

## Key design decisions

- **Metadata-only notifications**: GitHub/Forgejo return notification metadata (1 REST call each), no enrichment. Agent fetches full details JIT during task execution, not at ingest time.
- **AI boundary at shell level**: `ks` outputs structured JSON prompts; the caller pipes to the AI tool. `ks` never spawns AI directly — keeps it testable and provider-agnostic.
- **Singular noun CLI**: `ks task`, `ks project`, `ks notification` — matches existing `ks agent`, `ks doctor` pattern.
- **Proposal → review → accept**: AI prioritization proposals are saved as JSON with rationale; require explicit `--accept` before reordering tasks.
- **Thread ID alignment**: Only notification thread IDs for items actually emitted in fetch output are tracked in manifests, preventing silent ack of unseen items.

## Test plan

- [x] 43 unit tests passing (25 task + 18 project)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] CI: flake-check ✅, ks-cli ✅, iso-build ✅
- [x] All 16 copilot review comments addressed and replied to
- [ ] Manual: `ks notification fetch` returns email + GitHub data
- [ ] Manual: `ks task add/start/done/prune` lifecycle
- [ ] Manual: `ks project add/detect --repo` round-trip

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)