### PR TITLE
fix(installer): simplify headless confirmation token

### DIFF
--- a/docs/testing/iso-os-virtual-machine.md
+++ b/docs/testing/iso-os-virtual-machine.md
@@ -180,7 +180,7 @@ This loop takes 2-3 minutes instead of 15+ minutes for a full reinstall.
 
 # SSH in and drive manually:
 ssh -i .test-iso-dev-key -p 12260 keystone@localhost
-ks install --host laptop   # previews disks and asks you to type the target path
+ks install --host laptop   # previews disks and asks you to type `destroy`
 ```
 
 Then use snapshot commands directly to save and restore checkpoints.
@@ -222,10 +222,9 @@ ks install --host laptop --disk /dev/disk/by-id/virtio-keystone-test-disk
 ```
 
 The command prints discovered disks, highlights the selected target, and then
-requires you to type the exact `/dev/disk/by-id/...` path before it will erase
-the disk. If `--disk` is omitted, it shows a best guess first. Exit code 0
-means success. The `--e2e` flag in `test-iso` pipes the confirmation string
-into this prompt.
+requires you to type `destroy` before it will erase the disk. If `--disk` is
+omitted, it shows a best guess first. Exit code 0 means success. The `--e2e`
+flag in `test-iso` pipes the confirmation token into this prompt.
 
 ## Screenshot-based reboot validation
 
@@ -434,8 +433,8 @@ TERM=xterm-256color ks
 For scripted testing, `ks install --host laptop` is preferred over driving the
 TUI with `expect` or FIFO-based key injection. The headless install reuses the
 same code paths (host selection, disk discovery, disko, nixos-install,
-handoff) without needing a PTY; automation can pipe the selected disk path into
-stdin to satisfy the confirmation prompt.
+handoff) without needing a PTY; automation can pipe `destroy` into stdin to
+satisfy the confirmation prompt.
 
 If TUI-level regression testing is needed (verifying screen rendering,
 navigation, key bindings), use `ks --screenshot <screen>` which renders a

--- a/docs/testing/iso-os-virtual-machine.md
+++ b/docs/testing/iso-os-virtual-machine.md
@@ -180,7 +180,7 @@ This loop takes 2-3 minutes instead of 15+ minutes for a full reinstall.
 
 # SSH in and drive manually:
 ssh -i .test-iso-dev-key -p 12260 keystone@localhost
-ks install --host laptop   # previews disks and asks you to type `destroy`
+ks install --host laptop   # excludes installer media, may prompt for a disk number, then asks for `destroy`
 ```
 
 Then use snapshot commands directly to save and restore checkpoints.
@@ -223,8 +223,10 @@ ks install --host laptop --disk /dev/disk/by-id/virtio-keystone-test-disk
 
 The command prints discovered disks, highlights the selected target, and then
 requires you to type `destroy` before it will erase the disk. If `--disk` is
-omitted, it shows a best guess first. Exit code 0 means success. The `--e2e`
-flag in `test-iso` pipes the confirmation token into this prompt.
+omitted, it excludes installer media first, auto-selects the only remaining
+disk, or prompts for a numbered disk choice when multiple candidates remain.
+Exit code 0 means success. The `--e2e` flag in `test-iso` passes `--disk` and
+pipes the confirmation token into this prompt.
 
 ## Screenshot-based reboot validation
 
@@ -433,8 +435,9 @@ TERM=xterm-256color ks
 For scripted testing, `ks install --host laptop` is preferred over driving the
 TUI with `expect` or FIFO-based key injection. The headless install reuses the
 same code paths (host selection, disk discovery, disko, nixos-install,
-handoff) without needing a PTY; automation can pipe `destroy` into stdin to
-satisfy the confirmation prompt.
+handoff) without needing a PTY. For automation, pass `--disk` so only the
+destructive confirmation prompt remains, then pipe `destroy` into stdin to
+satisfy it.
 
 If TUI-level regression testing is needed (verifying screen rendering,
 navigation, key bindings), use `ks --screenshot <screen>` which renders a

--- a/packages/ks/src/cli.rs
+++ b/packages/ks/src/cli.rs
@@ -149,6 +149,8 @@ pub struct InstallArgs {
     pub host: String,
 
     /// Target disk to install to (must match a discovered /dev/disk/by-id path).
+    /// When omitted, headless install excludes installer media and may prompt
+    /// for a numbered disk choice.
     #[arg(long)]
     pub disk: Option<String>,
 }

--- a/packages/ks/src/components/install.rs
+++ b/packages/ks/src/components/install.rs
@@ -1001,22 +1001,108 @@ fn format_available_disks(disks: &[DiskEntry], selected_disk: Option<&str>) -> S
 
 const HEADLESS_CONFIRMATION_TOKEN: &str = "destroy";
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum HeadlessSelectionSource {
+    Requested,
+    AutoSelected,
+    Prompted,
+}
+
+fn format_numbered_available_disks(disks: &[DiskEntry], preferred_index: usize) -> String {
+    if disks.is_empty() {
+        return "Discovered disks: none".to_string();
+    }
+
+    let mut lines = vec!["Discovered disks:".to_string()];
+    for (index, disk) in disks.iter().enumerate() {
+        let mut line = format!("  {}. {}", index + 1, format_disk_summary(disk));
+        if index == preferred_index {
+            line.push_str("  [best guess]");
+        }
+        lines.push(line);
+    }
+
+    lines.join("\n")
+}
+
+fn parse_headless_disk_selection(
+    input: &str,
+    disk_count: usize,
+    preferred_index: usize,
+) -> Result<usize, String> {
+    if disk_count == 0 {
+        return Err("Install cancelled. No disks were available for selection.".to_string());
+    }
+
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Ok(preferred_index);
+    }
+
+    let selected = trimmed.parse::<usize>().map_err(|_| {
+        format!(
+            "Install cancelled. Expected a disk number between 1 and {}.",
+            disk_count
+        )
+    })?;
+    if !(1..=disk_count).contains(&selected) {
+        return Err(format!(
+            "Install cancelled. Expected a disk number between 1 and {}.",
+            disk_count
+        ));
+    }
+
+    Ok(selected - 1)
+}
+
+fn prompt_for_headless_disk_selection(
+    host: &str,
+    disks: &[DiskEntry],
+    preferred_index: usize,
+) -> Result<usize, String> {
+    eprintln!("No --disk was provided for host '{}'.", host);
+    eprintln!("Installer media is excluded from this list.");
+    eprintln!(
+        "{}",
+        format_numbered_available_disks(disks, preferred_index)
+    );
+    eprintln!(
+        "Press Enter to use {} or type a disk number between 1 and {}.",
+        preferred_index + 1,
+        disks.len()
+    );
+    eprint!("Disk> ");
+    std::io::stderr()
+        .flush()
+        .map_err(|error| format!("Failed to flush disk selection prompt: {}", error))?;
+
+    let mut selection = String::new();
+    std::io::stdin()
+        .read_line(&mut selection)
+        .map_err(|error| format!("Failed to read disk selection: {}", error))?;
+
+    parse_headless_disk_selection(&selection, disks.len(), preferred_index)
+}
+
 fn build_headless_confirmation_message(
     host: &str,
     selected_disk: &str,
-    disk_was_autoselected: bool,
+    selection_source: HeadlessSelectionSource,
     disks: &[DiskEntry],
 ) -> String {
     let mut lines = Vec::new();
 
-    if disk_was_autoselected {
-        lines.push(format!("No --disk was provided for host '{}'.", host));
-        lines.push(format!("Best guess: {}", selected_disk));
-    } else {
-        lines.push(format!(
-            "Headless install is ready for host '{}' on '{}'.",
-            host, selected_disk
-        ));
+    match selection_source {
+        HeadlessSelectionSource::Requested | HeadlessSelectionSource::Prompted => {
+            lines.push(format!(
+                "Headless install is ready for host '{}' on '{}'.",
+                host, selected_disk
+            ));
+        }
+        HeadlessSelectionSource::AutoSelected => {
+            lines.push(format!("No --disk was provided for host '{}'.", host));
+            lines.push(format!("Only available install disk: {}", selected_disk));
+        }
     }
 
     lines.push(format!("This will erase all data on '{}'.", selected_disk));
@@ -1034,12 +1120,12 @@ fn build_headless_confirmation_message(
 fn confirm_headless_install(
     host: &str,
     selected_disk: &str,
-    disk_was_autoselected: bool,
+    selection_source: HeadlessSelectionSource,
     disks: &[DiskEntry],
 ) -> Result<(), String> {
     eprintln!(
         "{}",
-        build_headless_confirmation_message(host, selected_disk, disk_was_autoselected, disks)
+        build_headless_confirmation_message(host, selected_disk, selection_source, disks)
     );
     eprint!("Confirmation> ");
     std::io::stderr()
@@ -1186,7 +1272,8 @@ impl InstallScreen {
     }
 
     /// Run the install headlessly — no TUI. Resolves disk selection using the
-    /// same best-guess policy as the TUI, then requires an explicit
+    /// same disk discovery as the TUI, prompting for a numbered choice when
+    /// multiple installable disks remain, then requires an explicit
     /// confirmation prompt before destructive actions proceed.
     pub async fn run_headless(&mut self, disk_path: Option<&str>) -> Result<(), String> {
         // Phase 1: select host (copies repo, vendors keystone input)
@@ -1201,35 +1288,49 @@ impl InstallScreen {
             .await
             .map_err(|e| format!("Disk discovery failed: {}", e))?;
         if disks.is_empty() {
-            return Err("No disks found".to_string());
+            return Err("No installable disks found after excluding installer media.".to_string());
         }
         self.available_disks = disks;
-        let disk_was_autoselected = if let Some(disk_path) = disk_path {
+        let selection_source = if let Some(disk_path) = disk_path {
             self.set_disk_by_path(disk_path)?;
-            false
+            HeadlessSelectionSource::Requested
+        } else if self.available_disks.len() == 1 {
+            self.selected_disk_index = 0;
+            HeadlessSelectionSource::AutoSelected
         } else {
-            self.selected_disk_index =
+            let preferred_index =
                 preferred_disk_index(&self.available_disks, self.config.disk_device.as_deref());
-            true
+            self.selected_disk_index = prompt_for_headless_disk_selection(
+                &self.config.flake_host,
+                &self.available_disks,
+                preferred_index,
+            )?;
+            HeadlessSelectionSource::Prompted
         };
         let selected_disk = self.available_disks[self.selected_disk_index]
             .by_id_path
             .clone();
-        eprintln!("Found {} disk(s).", self.available_disks.len(),);
-        if disk_was_autoselected {
-            eprintln!(
-                "{}",
-                format_available_disks(&self.available_disks, Some(&selected_disk))
-            );
-            eprintln!("Best guess: {}", selected_disk);
-        } else {
-            eprintln!("Using requested disk: {}", selected_disk);
+        eprintln!("Found {} installable disk(s).", self.available_disks.len());
+        match selection_source {
+            HeadlessSelectionSource::Requested => {
+                eprintln!("Using requested disk: {}", selected_disk);
+            }
+            HeadlessSelectionSource::AutoSelected => {
+                eprintln!(
+                    "{}",
+                    format_available_disks(&self.available_disks, Some(&selected_disk))
+                );
+                eprintln!("Auto-selected only available disk: {}", selected_disk);
+            }
+            HeadlessSelectionSource::Prompted => {
+                eprintln!("Selected disk: {}", selected_disk);
+            }
         }
 
         confirm_headless_install(
             &self.config.flake_host,
             &selected_disk,
-            disk_was_autoselected,
+            selection_source,
             &self.available_disks,
         )?;
 
@@ -3339,13 +3440,51 @@ mod tests {
         let message = build_headless_confirmation_message(
             "laptop",
             "/dev/disk/by-id/nvme-best",
-            true,
+            HeadlessSelectionSource::AutoSelected,
             &disks,
         );
 
         assert!(message.contains("No --disk was provided for host 'laptop'."));
         assert!(message.contains("This will erase all data on '/dev/disk/by-id/nvme-best'."));
         assert!(message.contains("Type 'destroy' to confirm installation"));
+    }
+
+    #[test]
+    fn test_build_headless_confirmation_message_for_prompted_disk() {
+        let disks = vec![DiskEntry {
+            by_id_path: "/dev/disk/by-id/nvme-best".to_string(),
+            model: "Best Disk".to_string(),
+            size: "2T".to_string(),
+            transport: "nvme".to_string(),
+        }];
+
+        let message = build_headless_confirmation_message(
+            "laptop",
+            "/dev/disk/by-id/nvme-best",
+            HeadlessSelectionSource::Prompted,
+            &disks,
+        );
+
+        assert!(message.contains("Headless install is ready for host 'laptop'"));
+        assert!(!message.contains("Only available install disk"));
+    }
+
+    #[test]
+    fn test_parse_headless_disk_selection_accepts_enter_for_default() {
+        assert_eq!(parse_headless_disk_selection("", 3, 1).unwrap(), 1);
+        assert_eq!(parse_headless_disk_selection(" \n", 3, 2).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_parse_headless_disk_selection_accepts_one_based_choice() {
+        assert_eq!(parse_headless_disk_selection("2", 3, 0).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_parse_headless_disk_selection_rejects_invalid_choice() {
+        let error = parse_headless_disk_selection("9", 3, 0).unwrap_err();
+
+        assert!(error.contains("Expected a disk number between 1 and 3"));
     }
 
     #[test]

--- a/packages/ks/src/components/install.rs
+++ b/packages/ks/src/components/install.rs
@@ -999,6 +999,8 @@ fn format_available_disks(disks: &[DiskEntry], selected_disk: Option<&str>) -> S
     lines.join("\n")
 }
 
+const HEADLESS_CONFIRMATION_TOKEN: &str = "destroy";
+
 fn build_headless_confirmation_message(
     host: &str,
     selected_disk: &str,
@@ -1023,7 +1025,7 @@ fn build_headless_confirmation_message(
     lines.push(String::new());
     lines.push(format!(
         "Type '{}' to confirm installation, or anything else to cancel.",
-        selected_disk
+        HEADLESS_CONFIRMATION_TOKEN
     ));
 
     lines.join("\n")
@@ -1049,10 +1051,10 @@ fn confirm_headless_install(
         .read_line(&mut confirmation)
         .map_err(|error| format!("Failed to read confirmation: {}", error))?;
 
-    if confirmation.trim() != selected_disk {
+    if confirmation.trim() != HEADLESS_CONFIRMATION_TOKEN {
         return Err(format!(
             "Install cancelled. Expected '{}' at the confirmation prompt.",
-            selected_disk
+            HEADLESS_CONFIRMATION_TOKEN
         ));
     }
 
@@ -3343,7 +3345,7 @@ mod tests {
 
         assert!(message.contains("No --disk was provided for host 'laptop'."));
         assert!(message.contains("This will erase all data on '/dev/disk/by-id/nvme-best'."));
-        assert!(message.contains("Type '/dev/disk/by-id/nvme-best' to confirm installation"));
+        assert!(message.contains("Type 'destroy' to confirm installation"));
     }
 
     #[test]

--- a/packages/ks/src/disk.rs
+++ b/packages/ks/src/disk.rs
@@ -5,7 +5,13 @@
 
 use std::path::Path;
 
-const INSTALLER_VOLUME_LABEL: &str = "KEYSTONE";
+// Must stay in sync with the installer ISO volume label defined by the build.
+// Prefer setting INSTALLER_VOLUME_LABEL at compile time (for example from Nix)
+// so installer-media exclusion cannot silently drift from the ISO label.
+const INSTALLER_VOLUME_LABEL: &str = match option_env!("INSTALLER_VOLUME_LABEL") {
+    Some(label) => label,
+    None => "KEYSTONE",
+};
 
 /// A discovered disk device suitable for installation.
 #[derive(Debug, Clone)]

--- a/packages/ks/src/disk.rs
+++ b/packages/ks/src/disk.rs
@@ -5,6 +5,8 @@
 
 use std::path::Path;
 
+const INSTALLER_VOLUME_LABEL: &str = "KEYSTONE";
+
 /// A discovered disk device suitable for installation.
 #[derive(Debug, Clone)]
 pub struct DiskEntry {
@@ -37,6 +39,21 @@ fn parse_blockdevices(lsblk_output: &[u8]) -> Vec<serde_json::Value> {
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default()
+}
+
+fn installer_device_name(blockdevices: &[serde_json::Value]) -> Option<String> {
+    let device = blockdevices.first()?;
+    match device.get("type").and_then(|v| v.as_str()) {
+        Some("disk") => device
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|name| name.to_string()),
+        Some("part") => device
+            .get("pkname")
+            .and_then(|v| v.as_str())
+            .map(|name| name.to_string()),
+        _ => None,
+    }
 }
 
 fn should_skip_by_id_name(name: &str) -> bool {
@@ -97,6 +114,27 @@ fn build_device_map(raw_links: &[(String, String)]) -> std::collections::HashMap
     }
 
     device_map
+}
+
+async fn discover_installer_device_name() -> anyhow::Result<Option<String>> {
+    let installer_label_path = Path::new("/dev/disk/by-label").join(INSTALLER_VOLUME_LABEL);
+    if !installer_label_path.exists() {
+        return Ok(None);
+    }
+
+    let lsblk_output = tokio::process::Command::new("lsblk")
+        .args(["--json", "-o", "NAME,PKNAME,TYPE"])
+        .arg(installer_label_path)
+        .output()
+        .await?;
+
+    if !lsblk_output.status.success() {
+        return Ok(None);
+    }
+
+    Ok(installer_device_name(&parse_blockdevices(
+        &lsblk_output.stdout,
+    )))
 }
 
 fn find_lsblk_info<'a>(
@@ -171,10 +209,17 @@ pub async fn discover_disks() -> anyhow::Result<Vec<DiskEntry>> {
     let blockdevices = parse_blockdevices(&lsblk_output.stdout);
     let raw_links = collect_raw_links(by_id_dir).await?;
     let device_map = build_device_map(&raw_links);
+    let installer_device_name = discover_installer_device_name().await?;
 
     // Build DiskEntry list by correlating with lsblk
     let mut disks: Vec<DiskEntry> = Vec::new();
     for (dev_name, by_id_name) in &device_map {
+        if installer_device_name
+            .as_deref()
+            .is_some_and(|installer_device| installer_device == dev_name)
+        {
+            continue;
+        }
         if let Some(entry) = build_disk_entry(dev_name, by_id_name, &blockdevices) {
             disks.push(entry);
         }
@@ -211,5 +256,44 @@ mod tests {
 
         assert!(nvme.sort_key() < sata.sort_key());
         assert!(sata.sort_key() < usb.sort_key());
+    }
+
+    #[test]
+    fn test_installer_device_name_prefers_parent_disk_for_partition() {
+        let blockdevices = parse_blockdevices(
+            br#"{
+              "blockdevices": [
+                {
+                  "name": "sda1",
+                  "pkname": "sda",
+                  "type": "part"
+                }
+              ]
+            }"#,
+        );
+
+        assert_eq!(
+            installer_device_name(&blockdevices),
+            Some("sda".to_string())
+        );
+    }
+
+    #[test]
+    fn test_installer_device_name_uses_disk_name_directly() {
+        let blockdevices = parse_blockdevices(
+            br#"{
+              "blockdevices": [
+                {
+                  "name": "sda",
+                  "type": "disk"
+                }
+              ]
+            }"#,
+        );
+
+        assert_eq!(
+            installer_device_name(&blockdevices),
+            Some("sda".to_string())
+        );
     }
 }

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -255,11 +255,11 @@ ssh_cmd() {
 }
 
 # Run the headless installer via `ks install --host --disk` and feed the
-# required destructive confirmation over stdin.
+# required destructive confirmation token over stdin.
 run_e2e_installer() {
     local host="${E2E_HOST:-laptop}"
     log_info "E2E: running headless install for host '$host' on '$E2E_DISK_DEVICE'"
-    if ! ssh_cmd "printf '%s\n' '$E2E_DISK_DEVICE' | ks install --host $host --disk $E2E_DISK_DEVICE" 2>&1; then
+    if ! ssh_cmd "printf 'destroy\n' | ks install --host $host --disk $E2E_DISK_DEVICE" 2>&1; then
         log_error "E2E: ks install --host $host --disk $E2E_DISK_DEVICE failed"
         return 1
     fi


### PR DESCRIPTION
## Summary
- replace the headless install disk-path confirmation with a short `destroy` token
- keep `test-iso --e2e` aligned by piping the same destructive token into stdin
- update ISO VM docs to describe the simpler confirmation flow

## Testing
- bash -n templates/default/bin/test-iso
- nix develop -c cargo fmt --check --manifest-path packages/ks/Cargo.toml
- nix develop -c cargo test --manifest-path packages/ks/Cargo.toml

Refs #344