### PR TITLE
fix(desktop): hyprland autostart fail-safe convention and assertion

### DIFF
--- a/conventions/os.hyprland-autostart.md
+++ b/conventions/os.hyprland-autostart.md
@@ -1,10 +1,11 @@
 # Convention: Hyprland autostart (os.hyprland-autostart)
 
 The Hyprland `exec-once` list is a security-critical boot chain. Its first
-user-visible command MUST be `keystone-startup-lock`, which launches hyprlock
-and kills the session if the lock surface fails to appear. Dropping or
-reordering this entry exposes an unlocked desktop after reboot — a fail-open
-security defect.
+user-visible command MUST be the configured startup lock command
+(`keystone.desktop.startupLockCommand`, default `keystone-startup-lock`),
+which launches the lock screen and kills the session if the lock surface
+fails to appear. Dropping or reordering this entry exposes an unlocked
+desktop after reboot — a fail-open security defect.
 
 This convention exists because a priority collision between `mkDefault`
 (priority 1000) and `mkAfter` (priority 100) silently replaced the entire

--- a/conventions/os.hyprland-autostart.md
+++ b/conventions/os.hyprland-autostart.md
@@ -57,6 +57,14 @@ exposing an unlocked desktop. This is a fail-closed design. See
 11. `extraConfig` is string-based and appended after all settings — it cannot
     displace the base exec-once list.
 
+## Customizing the lock command
+
+12. Consumer flakes MAY override `keystone.desktop.startupLockCommand` to use
+    a different lock binary. The assertion checks for whatever command is
+    configured — not a hardcoded string.
+13. Any replacement command MUST implement fail-closed semantics: present a
+    lock surface or terminate the session.
+
 ## Golden example
 
 Module adding audio defaults at session start (correct):

--- a/conventions/os.hyprland-autostart.md
+++ b/conventions/os.hyprland-autostart.md
@@ -1,0 +1,90 @@
+# Convention: Hyprland autostart (os.hyprland-autostart)
+
+The Hyprland `exec-once` list is a security-critical boot chain. Its first
+user-visible command MUST be `keystone-startup-lock`, which launches hyprlock
+and kills the session if the lock surface fails to appear. Dropping or
+reordering this entry exposes an unlocked desktop after reboot — a fail-open
+security defect.
+
+This convention exists because a priority collision between `mkDefault`
+(priority 1000) and `mkAfter` (priority 100) silently replaced the entire
+base exec-once list, dropping the lock screen, D-Bus setup, polkit agent,
+and clipboard manager.
+
+## Boot chain context
+
+```
+greetd (auto-login) → UWSM → Hyprland → exec-once → keystone-startup-lock → hyprlock
+```
+
+If `keystone-startup-lock` is missing from `exec-once`, or if hyprlock fails
+to present a lock surface, the script terminates the session rather than
+exposing an unlocked desktop. This is a fail-closed design. See
+`modules/desktop/home/scripts/keystone-startup-lock.sh`.
+
+## Base list ownership
+
+1. The base `exec-once` list MUST be defined exclusively in
+   `modules/desktop/home/hyprland/autostart.nix`.
+2. The base list MUST use bare assignment (normal priority 100) — MUST NOT
+   use `mkDefault`. `mkDefault` (priority 1000) is weaker than `mkAfter`
+   (priority 100), causing `mkAfter` entries to replace rather than append.
+3. The base list MUST contain `keystone-startup-lock`, appearing after D-Bus
+   environment setup and before all other user-visible entries.
+4. A build-time assertion MUST verify `keystone-startup-lock` appears in the
+   final resolved `exec-once` list.
+
+## Adding commands from other modules
+
+5. Modules that add entries to `exec-once` MUST use `mkAfter [ ... ]` so
+   their commands append after the base list.
+6. Modules MUST NOT use bare assignment (`exec-once = [ ... ]`) — bare
+   assignment at normal priority collides with the base list and produces
+   undefined merge order.
+7. Modules MUST NOT use `mkDefault` on `exec-once` — it is silently ignored
+   at best, or replaces the base list if the base is accidentally weakened.
+8. Modules MUST NOT use `mkOverride`, `mkForce`, or any priority stronger
+   than 100 on `exec-once` — these override the base list and drop the
+   startup lock.
+9. Each module's `mkAfter` addition SHOULD be guarded by `mkIf` on the
+   relevant feature flag so disabled features do not leave dead entries.
+
+## Consumer flake additions
+
+10. Consumer flakes (e.g., `nixos-config`) that need additional autostart
+    commands MUST use `wayland.windowManager.hyprland.extraConfig`, not
+    `settings.exec-once`.
+11. `extraConfig` is string-based and appended after all settings — it cannot
+    displace the base exec-once list.
+
+## Golden example
+
+Module adding audio defaults at session start (correct):
+
+```nix
+# modules/desktop/home/scripts/default.nix
+wayland.windowManager.hyprland.settings.exec-once =
+  mkIf (cfg.audio.defaults.sink != null)
+    (mkAfter [
+      "env KEYSTONE_AUDIO_DEFAULT_SINK='...' keystone-audio-menu apply-config-defaults"
+    ]);
+```
+
+Consumer flake adding a workspace dispatch (correct):
+
+```nix
+# nixos-config — uses extraConfig, not settings
+wayland.windowManager.hyprland.extraConfig = ''
+  exec-once = hyprctl dispatch workspace 2
+'';
+```
+
+Anti-pattern that caused the incident:
+
+```nix
+# WRONG — mkDefault on the base list allows mkAfter to replace it
+exec-once = mkDefault [
+  "keystone-startup-lock"
+  # ...
+];
+```

--- a/modules/desktop/home/default.nix
+++ b/modules/desktop/home/default.nix
@@ -60,6 +60,16 @@ in
         description = "Default CUPS printer name to apply at desktop session start.";
       };
     };
+
+    startupLockCommand = mkOption {
+      type = types.str;
+      default = "keystone-startup-lock";
+      description = ''
+        Command to run as the first user-visible exec-once entry in Hyprland.
+        Must present a lock surface or terminate the session (fail-closed).
+        See convention os.hyprland-autostart.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {

--- a/modules/desktop/home/hyprland/autostart.nix
+++ b/modules/desktop/home/hyprland/autostart.nix
@@ -11,21 +11,30 @@ let
 in
 {
   config = mkIf desktopCfg.enable {
-    # SECURITY: Build-time guard — if a module accidentally replaces the
-    # exec-once list (e.g., bare assignment instead of mkAfter), this
-    # assertion stops the build before an unlocked desktop can be deployed.
-    # See convention os.hyprland-autostart.
+    # SECURITY: Build-time guard — if a module accidentally replaces or
+    # reorders the exec-once list (e.g., bare assignment, mkDefault, or
+    # mkBefore), this assertion stops the build before an unlocked desktop
+    # can be deployed. See convention os.hyprland-autostart.
     assertions = [
       {
-        assertion = builtins.any (
-          cmd: lib.hasPrefix desktopCfg.startupLockCommand cmd
-        ) hyprSettings.exec-once;
+        assertion =
+          let
+            userVisible = builtins.filter (
+              cmd:
+              !(
+                lib.hasPrefix "systemctl --user import-environment" cmd
+                || lib.hasPrefix "dbus-update-activation-environment" cmd
+              )
+            ) hyprSettings.exec-once;
+          in
+          userVisible != [ ] && lib.hasPrefix desktopCfg.startupLockCommand (builtins.head userVisible);
         message = ''
-          SECURITY: ${desktopCfg.startupLockCommand} is missing from Hyprland exec-once.
+          SECURITY: ${desktopCfg.startupLockCommand} must be the first non-D-Bus
+          Hyprland exec-once entry.
           The desktop session MUST start locked to prevent exposing an unlocked
-          desktop after reboot. A module likely set exec-once with bare assignment
-          or mkDefault instead of mkAfter, replacing the base list from
-          autostart.nix. See convention os.hyprland-autostart.
+          desktop after reboot. A module likely reordered exec-once with mkBefore
+          or replaced the base list from autostart.nix with bare assignment or
+          mkDefault. See convention os.hyprland-autostart.
         '';
       }
     ];
@@ -36,7 +45,7 @@ in
         "systemctl --user import-environment"
         "dbus-update-activation-environment --systemd --all"
         # Session startup. The first graphical interaction MUST be the startup
-        # lock. If it does not come up, the lock script exits the session
+        # lock. If it does not come up, the lock command exits the session
         # rather than exposing an unlocked desktop.
         desktopCfg.startupLockCommand
         # Only start hyprsunset if the GPU supports CTM (color transform).

--- a/modules/desktop/home/hyprland/autostart.nix
+++ b/modules/desktop/home/hyprland/autostart.nix
@@ -7,11 +7,29 @@
 with lib;
 let
   desktopCfg = config.keystone.desktop;
+  hyprSettings = config.wayland.windowManager.hyprland.settings;
 in
 {
   config = mkIf desktopCfg.enable {
+    # SECURITY: Build-time guard — if a module accidentally replaces the
+    # exec-once list (e.g., bare assignment instead of mkAfter), this
+    # assertion stops the build before an unlocked desktop can be deployed.
+    # See convention os.hyprland-autostart.
+    assertions = [
+      {
+        assertion = builtins.any (cmd: lib.hasPrefix "keystone-startup-lock" cmd) hyprSettings.exec-once;
+        message = ''
+          SECURITY: keystone-startup-lock is missing from Hyprland exec-once.
+          The desktop session MUST start locked to prevent exposing an unlocked
+          desktop after reboot. A module likely set exec-once with bare assignment
+          or mkDefault instead of mkAfter, replacing the base list from
+          autostart.nix. See convention os.hyprland-autostart.
+        '';
+      }
+    ];
+
     wayland.windowManager.hyprland.settings = {
-      exec-once = mkDefault [
+      exec-once = [
         # D-Bus activation environment - required for app notifications (Chrome, etc) to use mako
         "systemctl --user import-environment"
         "dbus-update-activation-environment --systemd --all"
@@ -27,7 +45,7 @@ in
         "wl-clip-persist --clipboard regular & uwsm app -- clipse -listen"
       ];
 
-      exec = mkDefault [
+      exec = [
         "pkill -SIGUSR2 waybar || uwsm app -- waybar"
       ];
     };

--- a/modules/desktop/home/hyprland/autostart.nix
+++ b/modules/desktop/home/hyprland/autostart.nix
@@ -17,9 +17,11 @@ in
     # See convention os.hyprland-autostart.
     assertions = [
       {
-        assertion = builtins.any (cmd: lib.hasPrefix "keystone-startup-lock" cmd) hyprSettings.exec-once;
+        assertion = builtins.any (
+          cmd: lib.hasPrefix desktopCfg.startupLockCommand cmd
+        ) hyprSettings.exec-once;
         message = ''
-          SECURITY: keystone-startup-lock is missing from Hyprland exec-once.
+          SECURITY: ${desktopCfg.startupLockCommand} is missing from Hyprland exec-once.
           The desktop session MUST start locked to prevent exposing an unlocked
           desktop after reboot. A module likely set exec-once with bare assignment
           or mkDefault instead of mkAfter, replacing the base list from
@@ -34,9 +36,9 @@ in
         "systemctl --user import-environment"
         "dbus-update-activation-environment --systemd --all"
         # Session startup. The first graphical interaction MUST be the startup
-        # lock. If it does not come up, keystone-startup-lock exits the session
+        # lock. If it does not come up, the lock script exits the session
         # rather than exposing an unlocked desktop.
-        "keystone-startup-lock"
+        desktopCfg.startupLockCommand
         # Only start hyprsunset if the GPU supports CTM (color transform).
         # virtio-gpu in VMs lacks CTM, and hyprsunset's CTM commits block
         # all page-flips, freezing the display.

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -212,6 +212,11 @@
         test-iso-evaluation = import ./module/iso-evaluation.nix {
           inherit pkgs lib;
         };
+
+        test-desktop-autostart-assertion = import ./module/desktop-autostart-assertion.nix {
+          inherit pkgs lib home-manager;
+          self = keystone;
+        };
       };
 
       # Also expose tests as packages for convenience

--- a/tests/module/desktop-autostart-assertion.nix
+++ b/tests/module/desktop-autostart-assertion.nix
@@ -1,0 +1,114 @@
+# Desktop autostart assertion test
+#
+# Verifies the build-time assertion in autostart.nix catches a missing
+# startup lock command. This is a pure evaluation test — no VM needed.
+#
+# The test evaluates the desktop home-manager module twice:
+#   1. Default config → assertion passes (startup lock present)
+#   2. Overridden exec-once without lock → assertion fails
+#
+# Build: nix build .#test-desktop-autostart-assertion
+#
+{
+  pkgs,
+  lib,
+  self,
+  home-manager,
+}:
+let
+  # Evaluate a home-manager configuration with the desktop module
+  evalDesktop =
+    extraModules:
+    (home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      modules = [
+        self.homeModules.terminal
+        self.homeModules.desktop
+        {
+          home.username = "testuser";
+          home.homeDirectory = "/home/testuser";
+          home.stateVersion = "25.05";
+
+          keystone.terminal = {
+            enable = true;
+            git = {
+              userName = "Test User";
+              userEmail = "test@test";
+            };
+          };
+
+          keystone.desktop.enable = true;
+
+          # Hyprland requires a compositor to be enabled for settings to take effect
+          wayland.windowManager.hyprland.enable = true;
+        }
+      ]
+      ++ extraModules;
+    }).config;
+
+  # Test 1: Default config should have startup lock in exec-once
+  defaultConfig = evalDesktop [ ];
+  defaultExecOnce = defaultConfig.wayland.windowManager.hyprland.settings.exec-once;
+  hasStartupLock = builtins.any (cmd: lib.hasPrefix "keystone-startup-lock" cmd) defaultExecOnce;
+
+  # Test 2: Verify that mkAfter properly appends (doesn't replace)
+  withMkAfterConfig = evalDesktop [
+    {
+      wayland.windowManager.hyprland.settings.exec-once = lib.mkAfter [
+        "my-custom-app"
+      ];
+    }
+  ];
+  mkAfterExecOnce = withMkAfterConfig.wayland.windowManager.hyprland.settings.exec-once;
+  mkAfterHasLock = builtins.any (cmd: lib.hasPrefix "keystone-startup-lock" cmd) mkAfterExecOnce;
+  mkAfterHasCustom = builtins.any (cmd: cmd == "my-custom-app") mkAfterExecOnce;
+
+  # Test 3: Verify assertion fires when lock is missing
+  # We can't evaluate a failing assertion directly, but we can check that
+  # the assertion definition exists and references the right command.
+  defaultAssertions = defaultConfig.assertions;
+  hasLockAssertion = builtins.any (a: lib.hasInfix "startup-lock" a.message) defaultAssertions;
+
+  # Test 4: Custom startupLockCommand is used in exec-once
+  customLockConfig = evalDesktop [
+    { keystone.desktop.startupLockCommand = "my-custom-lock"; }
+  ];
+  customExecOnce = customLockConfig.wayland.windowManager.hyprland.settings.exec-once;
+  hasCustomLock = builtins.any (cmd: lib.hasPrefix "my-custom-lock" cmd) customExecOnce;
+in
+pkgs.runCommand "test-desktop-autostart-assertion" { } ''
+  set -euo pipefail
+  errors=0
+
+  check() {
+    if [ "$1" = "true" ]; then
+      echo "PASS: $2"
+    else
+      echo "FAIL: $2" >&2
+      errors=$((errors + 1))
+    fi
+  }
+
+  check "${builtins.toString hasStartupLock}" \
+    "default exec-once contains keystone-startup-lock"
+
+  check "${builtins.toString mkAfterHasLock}" \
+    "mkAfter preserves startup lock in exec-once"
+
+  check "${builtins.toString mkAfterHasCustom}" \
+    "mkAfter appends custom entry to exec-once"
+
+  check "${builtins.toString hasLockAssertion}" \
+    "assertion referencing startup-lock exists"
+
+  check "${builtins.toString hasCustomLock}" \
+    "custom startupLockCommand appears in exec-once"
+
+  if [ "$errors" -gt 0 ]; then
+    echo "$errors test(s) failed" >&2
+    exit 1
+  fi
+
+  echo "All desktop autostart assertion tests passed"
+  touch "$out"
+''

--- a/tests/module/desktop-autostart-assertion.nix
+++ b/tests/module/desktop-autostart-assertion.nix
@@ -1,11 +1,7 @@
 # Desktop autostart assertion test
 #
 # Verifies the build-time assertion in autostart.nix catches a missing
-# startup lock command. This is a pure evaluation test — no VM needed.
-#
-# The test evaluates the desktop home-manager module twice:
-#   1. Default config → assertion passes (startup lock present)
-#   2. Overridden exec-once without lock → assertion fails
+# or misordered startup lock command. Pure evaluation test — no VM needed.
 #
 # Build: nix build .#test-desktop-autostart-assertion
 #
@@ -51,7 +47,18 @@ let
   defaultExecOnce = defaultConfig.wayland.windowManager.hyprland.settings.exec-once;
   hasStartupLock = builtins.any (cmd: lib.hasPrefix "keystone-startup-lock" cmd) defaultExecOnce;
 
-  # Test 2: Verify that mkAfter properly appends (doesn't replace)
+  # Test 2: Verify startup lock is the first user-visible entry (not just present)
+  userVisible = builtins.filter (
+    cmd:
+    !(
+      lib.hasPrefix "systemctl --user import-environment" cmd
+      || lib.hasPrefix "dbus-update-activation-environment" cmd
+    )
+  ) defaultExecOnce;
+  lockIsFirst =
+    userVisible != [ ] && lib.hasPrefix "keystone-startup-lock" (builtins.head userVisible);
+
+  # Test 3: Verify that mkAfter properly appends (doesn't replace)
   withMkAfterConfig = evalDesktop [
     {
       wayland.windowManager.hyprland.settings.exec-once = lib.mkAfter [
@@ -63,13 +70,25 @@ let
   mkAfterHasLock = builtins.any (cmd: lib.hasPrefix "keystone-startup-lock" cmd) mkAfterExecOnce;
   mkAfterHasCustom = builtins.any (cmd: cmd == "my-custom-app") mkAfterExecOnce;
 
-  # Test 3: Verify assertion fires when lock is missing
-  # We can't evaluate a failing assertion directly, but we can check that
-  # the assertion definition exists and references the right command.
-  defaultAssertions = defaultConfig.assertions;
-  hasLockAssertion = builtins.any (a: lib.hasInfix "startup-lock" a.message) defaultAssertions;
+  # Test 4: Verify assertion fires when lock is replaced via mkForce
+  badConfig = evalDesktop [
+    {
+      wayland.windowManager.hyprland.settings.exec-once = lib.mkForce [
+        "some-other-app"
+      ];
+    }
+  ];
+  badAssertionResult = builtins.tryEval (
+    let
+      failingAssertions = builtins.filter (a: !a.assertion) badConfig.assertions;
+    in
+    builtins.length failingAssertions == 0
+  );
+  # tryEval succeeds (no Nix error), but the value should be false
+  # because the assertion condition fails
+  assertionTripped = badAssertionResult.success && !badAssertionResult.value;
 
-  # Test 4: Custom startupLockCommand is used in exec-once
+  # Test 5: Custom startupLockCommand is used in exec-once
   customLockConfig = evalDesktop [
     { keystone.desktop.startupLockCommand = "my-custom-lock"; }
   ];
@@ -92,14 +111,17 @@ pkgs.runCommand "test-desktop-autostart-assertion" { } ''
   check "${builtins.toString hasStartupLock}" \
     "default exec-once contains keystone-startup-lock"
 
+  check "${builtins.toString lockIsFirst}" \
+    "startup lock is the first user-visible exec-once entry"
+
   check "${builtins.toString mkAfterHasLock}" \
     "mkAfter preserves startup lock in exec-once"
 
   check "${builtins.toString mkAfterHasCustom}" \
     "mkAfter appends custom entry to exec-once"
 
-  check "${builtins.toString hasLockAssertion}" \
-    "assertion referencing startup-lock exists"
+  check "${builtins.toString assertionTripped}" \
+    "assertion fires when exec-once is replaced without lock"
 
   check "${builtins.toString hasCustomLock}" \
     "custom startupLockCommand appears in exec-once"


### PR DESCRIPTION
## Summary

- Remove `mkDefault` from exec-once base list in `autostart.nix` — `mkDefault` (priority 1000) was silently replaced by `mkAfter` (priority 100) entries from other modules, dropping the startup lock, D-Bus env, polkit, and clipboard manager. After an OOM reboot the desktop came up unlocked.
- Add build-time assertion that fails `ks build` if `keystone-startup-lock` is missing from the final resolved exec-once list.
- Add configurable `keystone.desktop.startupLockCommand` option so consumers can customize the lock binary while keeping the assertion functional.
- Add `os.hyprland-autostart` convention documenting the fail-safe rules for the exec-once boot chain.
- Add evaluation test verifying the assertion catches missing lock entries and mkAfter properly appends.

## Test plan

- [ ] `ks build` succeeds with assertion present
- [ ] Temporarily remove startup lock from base list → `ks build` fails with security message
- [ ] Inspect generated `~/.config/hypr/hyprland.conf` — all base exec-once entries present alongside audio/printer mkAfter entries
- [ ] `nix build ./tests#test-desktop-autostart-assertion` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)