### PR TITLE
docs(ks): require rnix AST handling for Nix source

### DIFF
--- a/packages/ks/.deepreview
+++ b/packages/ks/.deepreview
@@ -1,10 +1,10 @@
 # =====================================================================
-# Rust TUI: Format, Lint, and Test
+# ks validation
 # Runs cargo fmt --check, clippy, and tests when Rust source changes.
-# Mirrors the CI pipeline in .github/workflows/validate.tui.yml.
+# Mirrors the ks CLI validation expectations in packages/ks/AGENTS.md.
 # =====================================================================
-tui_validate:
-  description: "Run cargo fmt check, clippy, and tests on TUI Rust source changes."
+ks_validate:
+  description: "Run cargo fmt check, clippy, and tests for ks Rust source changes."
   match:
     include:
       - "**/*.rs"
@@ -15,8 +15,8 @@ tui_validate:
   review:
     strategy: matches_together
     instructions: |
-      Rust source files changed in the ks package. Run these checks
-      from the packages/ks directory and report any failures:
+      Rust source files changed in the ks package. Run these checks from the
+      packages/ks directory and report any failures:
 
       1. **Formatting** — Run `cargo fmt --all -- --check` and report any
          unformatted files. Do NOT auto-fix; just list which files need formatting.
@@ -28,4 +28,114 @@ tui_validate:
          with the failing test name and error output.
 
       If all three pass, report "All checks passed." with a brief summary of
-      what was validated (file count, test count).
+      what was validated.
+
+# =====================================================================
+# ks Rust code review
+# Reviews ks Rust source against idiomatic Rust practices and package
+# conventions in packages/ks/AGENTS.md.
+# =====================================================================
+ks_rust_code_review:
+  description: "Review ks Rust source against idiomatic Rust practices and package conventions."
+  match:
+    include:
+      - "src/**/*.rs"
+      - "tests/**/*.rs"
+    exclude:
+      - "target/**"
+  review:
+    strategy: individual
+    instructions: |
+      Review this Rust source file against idiomatic Rust practices and the
+      package conventions documented in AGENTS.md.
+
+      Check for:
+      - Proper error handling (Result/Option usage, no unwrap in production code)
+      - Idiomatic Rust patterns (iterators over manual loops, pattern matching)
+      - Consistent naming (snake_case functions/variables, CamelCase types)
+      - Appropriate visibility modifiers (prefer private by default)
+      - Module organization consistent with the documented ks structure
+      - Correct use of lifetimes and ownership (no unnecessary clones)
+      - Test coverage for new public functions or user-visible behavior
+
+      Additionally, always check:
+      - **DRY violations**: duplicated logic that should move into a shared helper,
+        trait, or module
+      - **Comment accuracy**: comments, doc comments, and inline documentation
+        still match the code after the change
+
+# =====================================================================
+# ks Nix AST review
+# Enforces the ks rule that Rust code reading or writing .nix source must
+# use rnix AST parsing/rewriting rather than string-based manipulation.
+# =====================================================================
+ks_nix_ast_review:
+  description: "Review ks Rust files that handle Nix source and enforce rnix AST usage."
+  match:
+    include:
+      - "src/nix.rs"
+      - "src/template.rs"
+      - "src/repo.rs"
+      - "src/components/install.rs"
+      - "src/components/template/**/*.rs"
+  review:
+    strategy: matches_together
+    instructions: |
+      Review these ks Rust files for compliance with the Nix source handling
+      rules in AGENTS.md.
+
+      The required rule is:
+      - when Rust code reads or writes `.nix` source, it should use `rnix`
+        and operate on the AST
+
+      Check for:
+      - string matching, regex parsing, line filtering, or ad hoc extraction
+        used to read `.nix` source
+      - string replacement, line-based filtering, or template reconstruction
+        used to rewrite `.nix` source
+      - new Nix source handling that does not use `rnix`
+      - migration debt that should be called out explicitly when touched
+
+      Current known debt to flag if it persists or spreads:
+      - `strip_generated_storage_assignments()`
+      - `parse_nix_string_assignment()`
+      - `parse_nix_string_list_assignment()`
+      - `build_reconciled_hardware_wrapper()`
+
+# =====================================================================
+# ks component architecture review
+# Enforces the ratatui Component Architecture and the documented split
+# between components, widgets, and shared CLI/JSON/TUI execution logic.
+# =====================================================================
+ks_component_architecture_review:
+  description: "Review ks UI architecture against the documented component model."
+  match:
+    include:
+      - "src/main.rs"
+      - "src/app.rs"
+      - "src/action.rs"
+      - "src/component.rs"
+      - "src/cli.rs"
+      - "src/tui.rs"
+      - "src/components/**/*.rs"
+      - "src/widgets/**/*.rs"
+  review:
+    strategy: matches_together
+    instructions: |
+      Review these ks files against the architecture documented in AGENTS.md.
+
+      Check for:
+      - components implementing the documented Component model cleanly
+      - internal component actions staying local rather than leaking into the
+        global `Action` enum
+      - navigation and cross-component effects going through `Action`
+      - complex components using the documented `types.rs` / `run.rs` split
+        when CLI/JSON/TUI logic is shared
+      - widgets remaining stateless rendering primitives
+      - new file placement matching the documented package layout
+
+      Additionally, always check:
+      - **DRY violations**: repeated component or command wiring that should be
+        extracted into shared helpers
+      - **Comment accuracy**: comments and architecture notes still match the
+        actual component boundaries

--- a/packages/ks/AGENTS.md
+++ b/packages/ks/AGENTS.md
@@ -133,6 +133,27 @@ Detection resolves notifications to projects deterministically or heuristically.
 
 Detection output: `{"slug": "keystone", "confidence": "exact|heuristic|none", "method": "..."}`
 
+## Nix source handling
+
+When Rust code reads or writes `.nix` source, it should use the installed
+`rnix` parser (`rnix = "0.11"` in `Cargo.toml`) and operate on the AST.
+
+**Rules:**
+- Rust code must not parse Nix source with string matching, regexes, line
+  filtering, or ad hoc text extraction.
+- Rust code must not rewrite Nix source with string replacement, line-based
+  filtering, or template reconstruction.
+- New Nix source handling in `ks` should use `rnix` for both read paths and
+  write paths.
+- Existing non-AST Nix source handling is migration debt and must not be copied
+  into new code paths.
+
+Current documented debt in `src/components/install.rs`:
+- `strip_generated_storage_assignments()`
+- `parse_nix_string_assignment()`
+- `parse_nix_string_list_assignment()`
+- `build_reconciled_hardware_wrapper()`
+
 ## Clippy Configuration
 
 The crate enables strict clippy lint groups:


### PR DESCRIPTION
## Summary

This PR documents and enforces the `packages/ks` policy that Rust code reading or writing `.nix` source should use `rnix` AST parsing/rewriting.

It does two focused things:

- updates `packages/ks/AGENTS.md` to make `rnix` the explicit rule for Rust Nix source handling
- consolidates `ks`-specific Rust review rules into `packages/ks/.deepreview`

## Context

`packages/ks` already depends on `rnix = "0.11"`, but `packages/ks/src/components/install.rs` still contains text-based Nix parsing and rewriting in the installer hardware reconciliation path.

The remaining implementation debt is tracked in #375.

Today that debt includes:

- `strip_generated_storage_assignments()`
- `parse_nix_string_assignment()`
- `parse_nix_string_list_assignment()`
- `build_reconciled_hardware_wrapper()`

Those helpers currently do line filtering, string extraction, and template reconstruction for generated hardware reconciliation.

## What this PR changes

### `packages/ks/AGENTS.md`

Adds a dedicated `Nix source handling` section that states:

- when Rust code reads or writes `.nix` source, it should use `rnix`
- string matching, regex parsing, line filtering, and ad hoc text reconstruction are not acceptable new patterns
- existing non-AST Nix source handling is migration debt

### `packages/ks/.deepreview`

Consolidates `ks`-specific Rust reviews locally:

- renames `tui_validate` to `ks_validate`
- adds `ks_rust_code_review`
- adds `ks_nix_ast_review`
- adds `ks_component_architecture_review`

This makes the package-local review surface match the actual `ks` crate instead of relying on stale `tui` naming or unrelated repo-root Rust rules.

## Remaining tasks

This PR does **not** migrate the Rust implementation yet. The remaining code work is tracked in #375:

- replace generated-hardware sanitization with `rnix` AST removal of
  - `fileSystems.*`
  - `swapDevices`
  - `boot.initrd.luks.devices.*`
- replace text-based extraction of Keystone-owned fields from `hardware.nix` with AST queries
- replace text reconstruction of the reconciled `hardware.nix` wrapper with AST-backed rewriting
- add tests that validate the AST path preserves hardware facts while removing Keystone-owned storage definitions

## Verification

- `yq keys packages/ks/.deepreview`

Refs #375
