### PR TITLE
fix(storage): remove explicit systemd-initrd fallback flags

### DIFF
--- a/modules/os/storage.nix
+++ b/modules/os/storage.nix
@@ -157,7 +157,6 @@ in
         # LUKS credstore configuration
         luks.devices.credstore = {
           device = "/dev/zvol/rpool/credstore";
-          fallbackToPassword = true;
           crypttabExtraOpts = lib.optionals osCfg.tpm.enable [
             "tpm2-measure-pcr=yes"
             "tpm2-device=auto"
@@ -415,7 +414,6 @@ in
 
       boot.initrd.luks.devices.cryptroot = {
         device = "/dev/disk/by-partlabel/disk-root-root";
-        fallbackToPassword = true;
         crypttabExtraOpts = lib.optionals osCfg.tpm.enable [
           "tpm2-measure-pcr=yes"
           "tpm2-device=auto"
@@ -425,7 +423,6 @@ in
       # Hibernation support: persistent LUKS swap + resumeDevice
       boot.initrd.luks.devices.cryptswap = mkIf (enableSwap && cfg.hibernate.enable) {
         device = "/dev/disk/by-partlabel/disk-root-swap";
-        fallbackToPassword = true;
         crypttabExtraOpts = lib.optionals osCfg.tpm.enable [
           "tpm2-measure-pcr=yes"
           "tpm2-device=auto"


### PR DESCRIPTION
## Summary
- remove explicit `fallbackToPassword` from systemd-initrd LUKS device definitions
- keep TPM `crypttabExtraOpts` unchanged for the ZFS credstore, ext4 root, and hibernation swap paths
- unblock systemd-initrd evaluations that now assert password fallback is implicit

## Verification
- `nix build .#checks.x86_64-linux.os-evaluation`
- `nix build /home/ncrmro/.worktrees/<owner>/keystone-config/update/validation-laptop-iso-rc#nixosConfigurations.laptop.config.system.build.toplevel --override-input keystone /home/ncrmro/.worktrees/ncrmro/keystone/fix-systemd-initrd-luks-fallback --no-link`

Refs #383
