### PR TITLE
fix(desktop): stabilize hyprlock startup and add fast desktop checks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -63,6 +63,7 @@ jobs:
       check_eval: ${{ steps.pr-policy.outputs.check_eval || steps.call-policy.outputs.check_eval || 'true' }}
       check_ks: ${{ steps.pr-policy.outputs.check_ks || steps.call-policy.outputs.check_ks || 'true' }}
       check_scripts: ${{ steps.pr-policy.outputs.check_scripts || steps.call-policy.outputs.check_scripts || 'true' }}
+      check_desktop: ${{ steps.pr-policy.outputs.check_desktop || steps.call-policy.outputs.check_desktop || 'true' }}
       check_agents: ${{ steps.pr-policy.outputs.check_agents || steps.call-policy.outputs.check_agents || 'true' }}
       iso_build: ${{ steps.pr-policy.outputs.iso_build || steps.call-policy.outputs.iso_build || 'false' }}
       nixfmt: ${{ steps.pr-policy.outputs.nixfmt || steps.call-policy.outputs.nixfmt || 'false' }}
@@ -101,8 +102,14 @@ jobs:
               - 'tests/module/pz-*.nix'
               - 'tests/module/keystone-*-menu.nix'
               - 'tests/module/agentctl-*.nix'
-              - 'tests/module/hyprland-*.nix'
               - 'tests/module/projects-schema.nix'
+            check_desktop:
+              - '.github/workflows/validate.yml'
+              - 'flake.nix'
+              - 'flake.lock'
+              - 'modules/desktop/**'
+              - 'tests/module/desktop-*.nix'
+              - 'tests/module/hyprland-*.nix'
             check_agents:
               - '.github/workflows/validate.yml'
               - 'flake.nix'
@@ -143,6 +150,7 @@ jobs:
             echo "check_eval=${{ steps.filter.outputs.check_eval }}"
             echo "check_ks=${{ steps.filter.outputs.check_ks }}"
             echo "check_scripts=${{ steps.filter.outputs.check_scripts }}"
+            echo "check_desktop=${{ steps.filter.outputs.check_desktop }}"
             echo "check_agents=${{ steps.filter.outputs.check_agents }}"
             echo "iso_build=${{ steps.filter.outputs.iso_build }}"
             echo "nixfmt=${{ steps.filter.outputs.nixfmt }}"
@@ -157,6 +165,7 @@ jobs:
             echo "check_eval=true"
             echo "check_ks=true"
             echo "check_scripts=true"
+            echo "check_desktop=true"
             echo "check_agents=true"
             echo "iso_build=${{ inputs.force_iso_build }}"
             echo "nixfmt=true"
@@ -200,6 +209,19 @@ jobs:
         with:
           check: checks.x86_64-linux.check-scripts
           cache-name: scripts
+          cache-branch-name: ${{ github.event_name == 'workflow_call' && inputs.cache_branch_name || '' }}
+          cachix-ci-auth-token: ${{ secrets.CACHIX_CI_AUTH_TOKEN }}
+
+  desktop:
+    needs: changes
+    if: needs.changes.outputs.check_desktop == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/nix-check
+        with:
+          check: checks.x86_64-linux.check-desktop
+          cache-name: desktop
           cache-branch-name: ${{ github.event_name == 'workflow_call' && inputs.cache_branch_name || '' }}
           cachix-ci-auth-token: ${{ secrets.CACHIX_CI_AUTH_TOKEN }}
 

--- a/flake.nix
+++ b/flake.nix
@@ -449,6 +449,14 @@
           hyprlandBindingsAgentConflict = import ./tests/module/hyprland-bindings-agent-conflict.nix {
             inherit pkgs;
           };
+          desktopAutostartAssertion = import ./tests/module/desktop-autostart-assertion.nix {
+            inherit pkgs lib home-manager;
+            self = self;
+          };
+          hyprlandConfigSmoke = import ./tests/module/hyprland-config-smoke.nix {
+            inherit pkgs lib home-manager;
+            self = self;
+          };
           agentctlRegression = import ./tests/module/agentctl-regression.nix {
             inherit pkgs;
           };
@@ -493,6 +501,8 @@
           keystone-update-menu = keystoneUpdateMenu;
           keystone-fingerprint-menu = keystoneFingerprintMenu;
           hyprland-bindings-agent-conflict = hyprlandBindingsAgentConflict;
+          desktop-autostart-assertion = desktopAutostartAssertion;
+          hyprland-config-smoke = hyprlandConfigSmoke;
           ks-approve = ksApprove;
           ks-doctor-report = ksDoctorReport;
           ks-rust-tests = ksRustTests;
@@ -541,7 +551,14 @@
             ln -s ${keystoneUpdateMenu} "$out/keystone-update-menu"
             ln -s ${keystoneFingerprintMenu} "$out/keystone-fingerprint-menu"
             ln -s ${projectsSchema} "$out/projects-schema"
+          '';
+
+          # Desktop config serialization and startup regressions
+          check-desktop = pkgs.runCommand "check-desktop" { } ''
+            mkdir -p "$out"
             ln -s ${hyprlandBindingsAgentConflict} "$out/hyprland-bindings-agent-conflict"
+            ln -s ${desktopAutostartAssertion} "$out/desktop-autostart-assertion"
+            ln -s ${hyprlandConfigSmoke} "$out/hyprland-config-smoke"
           '';
 
           # Agent runtime and miscellaneous module tests

--- a/flake.nix
+++ b/flake.nix
@@ -450,11 +450,15 @@
             inherit pkgs;
           };
           desktopAutostartAssertion = import ./tests/module/desktop-autostart-assertion.nix {
-            inherit pkgs lib home-manager;
+            pkgs = ksPkgs;
+            lib = ksPkgs.lib;
+            inherit home-manager;
             self = self;
           };
           hyprlandConfigSmoke = import ./tests/module/hyprland-config-smoke.nix {
-            inherit pkgs lib home-manager;
+            pkgs = ksPkgs;
+            lib = ksPkgs.lib;
+            inherit home-manager;
             self = self;
           };
           agentctlRegression = import ./tests/module/agentctl-regression.nix {

--- a/modules/desktop/AGENTS.md
+++ b/modules/desktop/AGENTS.md
@@ -26,6 +26,27 @@ MUST NOT expose an unlocked desktop.
 
 OS-level changes require a full `nixos-rebuild switch` — not just `ks build`.
 
+## Validation safety
+
+Desktop validation MUST NOT probe real Wayland binaries against the developer's
+active session. Tools such as `hyprlock`, `hyprpaper`, `hypridle`, and
+`hyprctl` will attach to the current compositor when environment variables such
+as `WAYLAND_DISPLAY`, `HYPRLAND_INSTANCE_SIGNATURE`, and `XDG_RUNTIME_DIR` are
+in scope.
+
+When validating generated desktop config:
+
+1. Prefer rendered-config assertions first.
+2. Run real-binary smoke tests only in an isolated environment that does not
+   inherit the live session variables above.
+3. Prefer Nix check derivations or other non-interactive test wrappers over
+   ad hoc terminal probes on the developer machine.
+4. If a real session is required, use a dedicated test compositor or test host
+   — never the operator's current unlocked desktop session.
+
+CRITICAL: live-session validation can lock the operator screen, kill the active
+wallpaper process, or otherwise mutate the running desktop while debugging.
+
 ## Home-Manager Level (`home/`)
 
 Enabled via `keystone.desktop.enable = true` in home-manager config. Components:

--- a/modules/desktop/home/hyprland/bindings.nix
+++ b/modules/desktop/home/hyprland/bindings.nix
@@ -174,7 +174,7 @@ in
         ", XF86AudioPrev, exec, playerctl previous"
         ", XF86PowerOff, exec, keystone-menu system"
         # Lid switch bindings - lock AND suspend on close
-        ", switch:on:Lid Switch, exec, pidof hyprlock || hyprlock; systemctl suspend"
+        ", switch:on:Lid Switch, exec, pidof hyprlock || hyprlock --immediate-render; systemctl suspend"
         ", switch:off:Lid Switch, exec, hyprctl dispatch dpms on"
       ];
     };

--- a/modules/desktop/home/hyprland/hypridle.nix
+++ b/modules/desktop/home/hyprland/hypridle.nix
@@ -7,6 +7,7 @@
 with lib;
 let
   desktopCfg = config.keystone.desktop;
+  lockCommand = "pidof hyprlock || hyprlock --immediate-render";
 in
 {
   config = mkIf desktopCfg.enable {
@@ -25,8 +26,8 @@ in
       enable = mkDefault true;
       settings = {
         general = {
-          lock_cmd = "pidof hyprlock || hyprlock";
-          before_sleep_cmd = "pidof hyprlock || hyprlock";
+          lock_cmd = lockCommand;
+          before_sleep_cmd = lockCommand;
           after_sleep_cmd = "hyprctl dispatch dpms on";
           ignore_dbus_inhibit = true;
           inhibit_sleep = 3;
@@ -36,7 +37,7 @@ in
           # Lock screen at 5 minutes
           {
             timeout = 300;
-            on-timeout = "pidof hyprlock || hyprlock";
+            on-timeout = lockCommand;
           }
           # DPMS off at 5.5 minutes
           {

--- a/modules/desktop/home/hyprland/hyprlock.nix
+++ b/modules/desktop/home/hyprland/hyprlock.nix
@@ -13,11 +13,6 @@ in
     programs.hyprlock = {
       enable = mkDefault true;
       settings = {
-        general = {
-          disable_loading_bar = true;
-          no_fade_in = false;
-        };
-
         auth = {
           fingerprint.enabled = true;
         };
@@ -45,10 +40,8 @@ in
           outline_thickness = 4;
 
           font_family = "JetBrainsMono Nerd Font";
-          font_size = 32;
           font_color = "rgb(cdd6f4)";
 
-          placeholder_color = "rgb(9399b2)";
           placeholder_text = "  Enter Password";
           check_color = "rgb(a6e3a1)";
           fail_text = "Wrong ($ATTEMPTS)";

--- a/modules/desktop/home/hyprland/hyprpaper.nix
+++ b/modules/desktop/home/hyprland/hyprpaper.nix
@@ -19,6 +19,9 @@ in
       ];
       settings = {
         splash = false;
+        preload = [
+          "${config.xdg.configHome}/keystone/current/background"
+        ];
         wallpaper = [
           ",${config.xdg.configHome}/keystone/current/background"
         ];

--- a/modules/desktop/home/scripts/keystone-startup-lock.sh
+++ b/modules/desktop/home/scripts/keystone-startup-lock.sh
@@ -20,6 +20,7 @@ timeout_steps="${KEYSTONE_STARTUP_LOCK_TIMEOUT_STEPS:-50}"
 # NOT extend the per-attempt timeout.
 max_lock_attempts="${KEYSTONE_STARTUP_LOCK_MAX_ATTEMPTS:-3}"
 retry_delay_seconds="${KEYSTONE_STARTUP_LOCK_RETRY_DELAY:-1}"
+hyprlock_cmd=(hyprlock --immediate-render)
 
 log() {
   local priority="$1"
@@ -67,7 +68,7 @@ fail_closed() {
 }
 
 try_lock() {
-  hyprlock >/dev/null 2>&1 &
+  "${hyprlock_cmd[@]}" >/dev/null 2>&1 &
   lock_pid=$!
 
   for _ in $(seq 1 "$timeout_steps"); do

--- a/tests/module/desktop-autostart-assertion.nix
+++ b/tests/module/desktop-autostart-assertion.nix
@@ -25,6 +25,8 @@ let
           home.homeDirectory = "/home/testuser";
           home.stateVersion = "25.05";
 
+          programs.ssh.enableDefaultConfig = false;
+
           keystone.terminal = {
             enable = true;
             git = {
@@ -41,6 +43,7 @@ let
       ]
       ++ extraModules;
     }).config;
+  boolString = value: if value then "true" else "false";
 
   # Test 1: Default config should have startup lock in exec-once
   defaultConfig = evalDesktop [ ];
@@ -71,22 +74,14 @@ let
   mkAfterHasCustom = builtins.any (cmd: cmd == "my-custom-app") mkAfterExecOnce;
 
   # Test 4: Verify assertion fires when lock is replaced via mkForce
-  badConfig = evalDesktop [
+  badConfigResult = builtins.tryEval (evalDesktop [
     {
       wayland.windowManager.hyprland.settings.exec-once = lib.mkForce [
         "some-other-app"
       ];
     }
-  ];
-  badAssertionResult = builtins.tryEval (
-    let
-      failingAssertions = builtins.filter (a: !a.assertion) badConfig.assertions;
-    in
-    builtins.length failingAssertions == 0
-  );
-  # tryEval succeeds (no Nix error), but the value should be false
-  # because the assertion condition fails
-  assertionTripped = badAssertionResult.success && !badAssertionResult.value;
+  ]);
+  assertionTripped = !badConfigResult.success;
 
   # Test 5: Custom startupLockCommand is used in exec-once
   customLockConfig = evalDesktop [
@@ -108,22 +103,22 @@ pkgs.runCommand "test-desktop-autostart-assertion" { } ''
     fi
   }
 
-  check "${builtins.toString hasStartupLock}" \
+  check "${boolString hasStartupLock}" \
     "default exec-once contains keystone-startup-lock"
 
-  check "${builtins.toString lockIsFirst}" \
+  check "${boolString lockIsFirst}" \
     "startup lock is the first user-visible exec-once entry"
 
-  check "${builtins.toString mkAfterHasLock}" \
+  check "${boolString mkAfterHasLock}" \
     "mkAfter preserves startup lock in exec-once"
 
-  check "${builtins.toString mkAfterHasCustom}" \
+  check "${boolString mkAfterHasCustom}" \
     "mkAfter appends custom entry to exec-once"
 
-  check "${builtins.toString assertionTripped}" \
+  check "${boolString assertionTripped}" \
     "assertion fires when exec-once is replaced without lock"
 
-  check "${builtins.toString hasCustomLock}" \
+  check "${boolString hasCustomLock}" \
     "custom startupLockCommand appears in exec-once"
 
   if [ "$errors" -gt 0 ]; then

--- a/tests/module/hyprland-config-smoke.nix
+++ b/tests/module/hyprland-config-smoke.nix
@@ -1,0 +1,127 @@
+{
+  pkgs,
+  lib,
+  self,
+  home-manager,
+}:
+let
+  evalDesktop =
+    extraModules:
+    (home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      modules = [
+        self.homeModules.terminal
+        self.homeModules.desktop
+        {
+          home.username = "testuser";
+          home.homeDirectory = "/home/testuser";
+          home.stateVersion = "25.05";
+
+          programs.ssh.enableDefaultConfig = false;
+
+          keystone.terminal = {
+            enable = true;
+            git = {
+              userName = "Test User";
+              userEmail = "test@test";
+            };
+          };
+
+          keystone.desktop.enable = true;
+          wayland.windowManager.hyprland.enable = true;
+        }
+      ]
+      ++ extraModules;
+    }).config;
+
+  desktopConfig = evalDesktop [ ];
+  hyprlandConf = desktopConfig.xdg.configFile."hypr/hyprland.conf".source;
+  hypridleConf = desktopConfig.xdg.configFile."hypr/hypridle.conf".source;
+  hyprlockConf = desktopConfig.xdg.configFile."hypr/hyprlock.conf".source;
+  hyprpaperConf = desktopConfig.xdg.configFile."hypr/hyprpaper.conf".source;
+  hyprlandPkg = desktopConfig.wayland.windowManager.hyprland.package;
+  startupLockScript = ../../modules/desktop/home/scripts/keystone-startup-lock.sh;
+in
+pkgs.runCommand "hyprland-config-smoke"
+  {
+    nativeBuildInputs = with pkgs; [
+      coreutils
+      gnugrep
+      gnused
+    ];
+  }
+  ''
+    set -euo pipefail
+
+    input_field_block="$(sed -n '/^input-field {/,/^}/p' "${hyprlockConf}")"
+
+    assert_contains() {
+      local file="$1"
+      local needle="$2"
+      local description="$3"
+
+      if grep -F "$needle" "$file" >/dev/null; then
+        echo "PASS: $description"
+      else
+        echo "FAIL: $description" >&2
+        echo "missing: $needle" >&2
+        exit 1
+      fi
+    }
+
+    assert_not_contains() {
+      local file="$1"
+      local needle="$2"
+      local description="$3"
+
+      if grep -F "$needle" "$file" >/dev/null; then
+        echo "FAIL: $description" >&2
+        echo "unexpected: $needle" >&2
+        exit 1
+      else
+        echo "PASS: $description"
+      fi
+    }
+
+    assert_contains "${hyprpaperConf}" "preload=/home/testuser/.config/keystone/current/background" \
+      "hyprpaper preloads the theme background before assigning wallpaper"
+    assert_contains "${hyprpaperConf}" "wallpaper=,/home/testuser/.config/keystone/current/background" \
+      "hyprpaper assigns the theme background to all monitors"
+
+    assert_contains "${hypridleConf}" "lock_cmd=pidof hyprlock || hyprlock --immediate-render" \
+      "hypridle uses immediate-render for the lock command"
+    assert_contains "${hypridleConf}" "before_sleep_cmd=pidof hyprlock || hyprlock --immediate-render" \
+      "hypridle uses immediate-render before suspend"
+    assert_contains "${hypridleConf}" "on-timeout=pidof hyprlock || hyprlock --immediate-render" \
+      "hypridle timeout locking uses immediate-render"
+
+    assert_contains "${hyprlandConf}" "switch:on:Lid Switch, exec, pidof hyprlock || hyprlock --immediate-render; systemctl suspend" \
+      "lid-close binding uses immediate-render before suspend"
+    assert_contains "${startupLockScript}" "hyprlock_cmd=(hyprlock --immediate-render)" \
+      "startup lock wrapper launches hyprlock with immediate-render"
+
+    assert_not_contains "${hyprlockConf}" "disable_loading_bar" \
+      "hyprlock config omits removed general.disable_loading_bar"
+    assert_not_contains "${hyprlockConf}" "no_fade_in" \
+      "hyprlock config omits removed general.no_fade_in"
+    assert_not_contains "${hyprlockConf}" "placeholder_color" \
+      "hyprlock config omits removed input-field.placeholder_color"
+    if printf '%s\n' "$input_field_block" | grep -F "font_size" >/dev/null; then
+      echo "FAIL: hyprlock input-field omits removed font_size" >&2
+      exit 1
+    else
+      echo "PASS: hyprlock input-field omits removed font_size"
+    fi
+
+    export HOME="$PWD/home"
+    export XDG_CONFIG_HOME="$HOME/.config"
+    export XDG_RUNTIME_DIR="$PWD/runtime"
+    mkdir -p "$XDG_CONFIG_HOME/keystone/current/theme" "$XDG_RUNTIME_DIR"
+    : > "$XDG_CONFIG_HOME/keystone/current/theme/hyprland.conf"
+
+    "${hyprlandPkg}/bin/Hyprland" --verify-config -c "${hyprlandConf}" >"$PWD/hyprland-verify.log" 2>&1
+    assert_contains "$PWD/hyprland-verify.log" "config ok" \
+      "Hyprland verifies the rendered desktop config successfully"
+
+    touch "$out"
+  ''


### PR DESCRIPTION
Refs #359

## Summary
- fix the shipped Hyprland desktop config so `hyprlock` and `hyprpaper` match the current runtime expectations
- switch desktop lock entrypoints to `hyprlock --immediate-render`
- add a fast `check-desktop` CI group with a rendered-config smoke test for Hyprland
- document that real Wayland binary probes must not run against a live developer session

## Validation
- `nix build -L .#checks.x86_64-linux.check-desktop --no-link`
- `nix build -L /home/ncrmro/.worktrees/<owner>/keystone-config/update/validation-laptop-iso-rc#nixosConfigurations.laptop.config.system.build.toplevel --override-input keystone /home/ncrmro/.worktrees/ncrmro/keystone/fix-hyprlock-startup --no-link`

## Follow-up
- after merge, bump the validation laptop `keystone` input and run `sudo nixos-rebuild switch` on the validation laptop over SSH to verify the live desktop session
