### PR TITLE
fix(desktop): make startup lock succeed on stable hyprlock state

### DIFF
--- a/modules/desktop/home/scripts/keystone-startup-lock.sh
+++ b/modules/desktop/home/scripts/keystone-startup-lock.sh
@@ -2,22 +2,24 @@
 set -u -o pipefail
 
 # SECURITY: This script is the fail-closed gate for the desktop session.
-# If hyprlock does not present a lock surface within the timeout, the
-# entire session is terminated rather than exposing an unlocked desktop.
+# If the session never reaches a real startup lock state, the entire
+# session is terminated rather than exposing an unlocked desktop.
 #
-# Do NOT increase the timeout to work around rendering issues — fix the
-# rendering instead. A longer timeout means a longer window where the
-# desktop could be exposed without a lock screen.
+# Do NOT treat an early non-zero hyprlock exit as the source of truth.
+# During greetd -> uwsm -> Hyprland startup, the compositor may briefly
+# reject the lock while outputs are still coming online. The correct
+# truth source is a visible lock signal or a stable-running hyprlock
+# process after session-lock readiness is established.
 poll_interval_seconds="${KEYSTONE_STARTUP_LOCK_POLL_INTERVAL_SECONDS:-0.1}"
 timeout_steps="${KEYSTONE_STARTUP_LOCK_TIMEOUT_STEPS:-50}"
+readiness_timeout_steps="${KEYSTONE_STARTUP_LOCK_READINESS_TIMEOUT_STEPS:-100}"
+stable_lock_steps="${KEYSTONE_STARTUP_LOCK_STABLE_LOCK_STEPS:-20}"
 
-# SECURITY: During session startup (greetd → uwsm → Hyprland), the
+# SECURITY: During session startup (greetd -> uwsm -> Hyprland), the
 # compositor may deny the session lock while outputs are being
-# reconfigured. hyprlock reports this as "yeeten" and exits non-zero.
-# We retry a limited number of times to handle this transient denial,
-# but still fail closed if all attempts are exhausted. Each retry is
-# a full hyprlock launch + surface poll cycle — the retry count does
-# NOT extend the per-attempt timeout.
+# reconfigured. We relaunch a limited number of times inside the
+# overall startup deadline, but still fail closed unless a lock signal
+# appears or hyprlock stays stable after readiness.
 max_lock_attempts="${KEYSTONE_STARTUP_LOCK_MAX_ATTEMPTS:-3}"
 retry_delay_seconds="${KEYSTONE_STARTUP_LOCK_RETRY_DELAY:-1}"
 hyprlock_cmd=(hyprlock --immediate-render)
@@ -34,14 +36,52 @@ log() {
   fi
 }
 
+hyprctl_json() {
+  local subcommand="$1"
+  local output
+
+  output="$(hyprctl -j "$subcommand" 2>/dev/null)" || return 1
+  printf '%s\n' "$output" | jq -e . >/dev/null 2>&1 || return 1
+  printf '%s\n' "$output"
+}
+
 lock_surface_present() {
-  hyprctl layers -j 2>/dev/null | jq -e '
+  hyprctl_json layers | jq -e '
     .. | objects | select(
       (.namespace? // "") == "hyprlock"
       or (.class? // "") == "hyprlock"
       or (.name? // "") == "hyprlock"
     )
   ' >/dev/null
+}
+
+session_lock_ready() {
+  hyprctl_json monitors | jq -e 'type == "array" and length > 0' >/dev/null
+}
+
+session_locked() {
+  if [[ -z "${XDG_SESSION_ID:-}" ]] || ! command -v loginctl >/dev/null 2>&1; then
+    return 1
+  fi
+
+  [[ "$(loginctl show-session "$XDG_SESSION_ID" -p LockedHint --value 2>/dev/null)" == "yes" ]]
+}
+
+lock_ready() {
+  session_locked || lock_surface_present
+}
+
+lock_process_alive() {
+  local pid="$1"
+  local state_file="/proc/$pid/stat"
+  local state
+
+  [[ -n "$pid" ]] || return 1
+  kill -0 "$pid" >/dev/null 2>&1 || return 1
+  [[ -r "$state_file" ]] || return 1
+
+  state="$(awk '{ print $3 }' "$state_file" 2>/dev/null)" || return 1
+  [[ "$state" != "Z" ]]
 }
 
 fail_closed() {
@@ -67,52 +107,90 @@ fail_closed() {
   exit 1
 }
 
-try_lock() {
-  "${hyprlock_cmd[@]}" >/dev/null 2>&1 &
-  lock_pid=$!
-
-  for _ in $(seq 1 "$timeout_steps"); do
-    if lock_surface_present; then
-      log info "startup lock is ready"
+wait_for_session_lock_ready() {
+  for _ in $(seq 1 "$readiness_timeout_steps"); do
+    if session_lock_ready; then
       return 0
-    fi
-
-    if ! kill -0 "$lock_pid" >/dev/null 2>&1; then
-      wait "$lock_pid"
-      lock_status=$?
-      # hyprlock exit 0 means successful authentication — the user
-      # unlocked before we polled. This is not a failure.
-      if [[ "$lock_status" -eq 0 ]]; then
-        log info "hyprlock exited cleanly (user authenticated)"
-        return 0
-      fi
-      # Non-zero exit: hyprlock was denied the session lock ("yeeten")
-      # or crashed. Return the status for the retry logic.
-      return "$lock_status"
     fi
 
     sleep "$poll_interval_seconds"
   done
 
-  # Timeout — hyprlock is running but never presented a surface.
-  pkill -TERM -x hyprlock >/dev/null 2>&1 || true
   return 1
 }
+
+launch_lock() {
+  "${hyprlock_cmd[@]}" >/dev/null 2>&1 &
+  current_lock_pid=$!
+  launch_count=$((launch_count + 1))
+  log info "launched hyprlock attempt ${launch_count}/${max_lock_attempts}"
+}
+
+current_lock_pid=""
+launch_count=0
+stable_lock_count=0
+
+if lock_ready; then
+  log info "session already reports locked"
+  exit 0
+fi
 
 if pgrep -x hyprlock >/dev/null 2>&1; then
   log info "hyprlock is already running"
   exit 0
 fi
 
-for attempt in $(seq 1 "$max_lock_attempts"); do
-  if try_lock; then
+if ! wait_for_session_lock_ready; then
+  fail_closed "Hyprland did not become ready for session locking before the startup lock deadline."
+fi
+
+log info "session lock prerequisites are ready"
+
+launch_lock
+
+for _ in $(seq 1 "$timeout_steps"); do
+  if lock_ready; then
+    log info "startup lock is ready"
     exit 0
   fi
 
-  if [[ "$attempt" -lt "$max_lock_attempts" ]]; then
-    log warning "hyprlock denied on attempt $attempt/$max_lock_attempts (session lock not ready), retrying in ${retry_delay_seconds}s"
-    sleep "$retry_delay_seconds"
+  if [[ -n "$current_lock_pid" ]] && lock_process_alive "$current_lock_pid"; then
+    stable_lock_count=$((stable_lock_count + 1))
+
+    if [[ "$stable_lock_count" -ge "$stable_lock_steps" ]]; then
+      log info "hyprlock remained alive for the startup grace window"
+      exit 0
+    fi
+  else
+    stable_lock_count=0
   fi
+
+  if [[ -n "$current_lock_pid" ]] && ! lock_process_alive "$current_lock_pid"; then
+    wait "$current_lock_pid"
+    lock_status=$?
+    current_lock_pid=""
+
+    if [[ "$lock_status" -eq 0 ]]; then
+      log info "hyprlock exited cleanly (user authenticated)"
+      exit 0
+    fi
+
+    if lock_ready; then
+      log info "session locked after hyprlock exit"
+      exit 0
+    fi
+
+    if [[ "$launch_count" -lt "$max_lock_attempts" ]]; then
+      log warning "hyprlock exited before lock state was visible, relaunching in ${retry_delay_seconds}s"
+      sleep "$retry_delay_seconds"
+      wait_for_session_lock_ready || true
+      launch_lock
+      stable_lock_count=0
+      continue
+    fi
+  fi
+
+  sleep "$poll_interval_seconds"
 done
 
-fail_closed "hyprlock failed to present a startup lock after $max_lock_attempts attempts."
+fail_closed "hyprlock failed to make the session report locked after ${launch_count} launch attempts."


### PR DESCRIPTION
Refs #359

## Summary
- make `keystone-startup-lock` wait for Hyprland session-lock readiness before the first `hyprlock` launch
- treat startup-lock success as real lock state or a stable-running `hyprlock` process, not just the first exit code
- keep fail-closed behavior and limited relaunches when the compositor transiently rejects the lock during startup

## Validation
- `bash -n modules/desktop/home/scripts/keystone-startup-lock.sh`
- `nix develop -c shellcheck modules/desktop/home/scripts/keystone-startup-lock.sh`
- `nix build -L .#checks.x86_64-linux.check-desktop --no-link`
- `nix build -L /home/ncrmro/.worktrees/noah-horton/keystone-config/update/noah-iso-rc#nixosConfigurations.laptop.config.system.build.toplevel --override-input keystone /home/ncrmro/.worktrees/ncrmro/keystone/fix-startup-lock-state-detection --no-link`

## Proven behavior
- the latest validation-laptop boot no longer fail-closes the session at startup
- `hyprpaper` and `hypridle` remain healthy on that host
- the host-only debug wrapper succeeds via `hyprlock remained alive for the startup grace window`

## Follow-up
- after merge, bump `keystone` in the validation-laptop config and re-test with the normal upstream startup-lock path
- then remove the host-only startup-lock override from the validation-laptop config repo