### PR TITLE
fix(desktop): gate Walker surfaces and repair setup, update, and wifi flows

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -449,6 +449,9 @@
           hyprlandBindingsAgentConflict = import ./tests/module/hyprland-bindings-agent-conflict.nix {
             inherit pkgs;
           };
+          desktopWalkerSurfaces = import ./tests/module/desktop-walker-surfaces.nix {
+            inherit pkgs;
+          };
           desktopAutostartAssertion = import ./tests/module/desktop-autostart-assertion.nix {
             pkgs = ksPkgs;
             lib = ksPkgs.lib;
@@ -505,6 +508,7 @@
           keystone-update-menu = keystoneUpdateMenu;
           keystone-fingerprint-menu = keystoneFingerprintMenu;
           hyprland-bindings-agent-conflict = hyprlandBindingsAgentConflict;
+          desktop-walker-surfaces = desktopWalkerSurfaces;
           desktop-autostart-assertion = desktopAutostartAssertion;
           hyprland-config-smoke = hyprlandConfigSmoke;
           ks-approve = ksApprove;
@@ -561,6 +565,7 @@
           check-desktop = pkgs.runCommand "check-desktop" { } ''
             mkdir -p "$out"
             ln -s ${hyprlandBindingsAgentConflict} "$out/hyprland-bindings-agent-conflict"
+            ln -s ${desktopWalkerSurfaces} "$out/desktop-walker-surfaces"
             ln -s ${desktopAutostartAssertion} "$out/desktop-autostart-assertion"
             ln -s ${hyprlandConfigSmoke} "$out/hyprland-config-smoke"
           '';

--- a/modules/desktop/home/components/keystone-wifi.lua
+++ b/modules/desktop/home/components/keystone-wifi.lua
@@ -1,0 +1,46 @@
+Name = "keystone-wifi"
+NamePretty = "Wi-Fi"
+Description = "Wi-Fi networks"
+Icon = "network-wireless"
+HideFromProviderlist = true
+History = false
+FixedOrder = true
+
+local function json_decode(value)
+    if jsonDecode ~= nil then
+        return jsonDecode(value)
+    end
+
+    if jsonDecodes ~= nil then
+        return jsonDecodes(value)
+    end
+
+    return nil
+end
+
+local function command_path(name)
+    return name
+end
+
+Action = command_path("keystone-wifi-menu") .. " dispatch '%VALUE%'"
+
+function GetEntries()
+    local handle = io.popen(command_path("keystone-wifi-menu") .. " list-json 2>/dev/null")
+    if not handle then
+        return {}
+    end
+
+    local payload = handle:read("*a") or ""
+    handle:close()
+
+    if payload == "" then
+        return {}
+    end
+
+    local ok, entries = pcall(json_decode, payload)
+    if not ok or type(entries) ~= "table" then
+        return {}
+    end
+
+    return entries
+end

--- a/modules/desktop/home/components/launcher.nix
+++ b/modules/desktop/home/components/launcher.nix
@@ -159,6 +159,11 @@ in
           sourcePath = ./keystone-printer.lua;
         }
         {
+          targetPath = ".config/elephant/menus/keystone-wifi.lua";
+          relativePath = "modules/desktop/home/components/keystone-wifi.lua";
+          sourcePath = ./keystone-wifi.lua;
+        }
+        {
           targetPath = ".config/elephant/menus/keystone-audio.lua";
           relativePath = "modules/desktop/home/components/keystone-audio.lua";
           sourcePath = ./keystone-audio.lua;
@@ -342,6 +347,10 @@ in
             "menus:keystone-printer" = {
               input = " Printers";
               list = "No printers found";
+            };
+            "menus:keystone-wifi" = {
+              input = " Wi-Fi";
+              list = "No Wi-Fi networks found";
             };
             "menus:keystone-audio" = {
               input = " Audio";

--- a/modules/desktop/home/components/waybar.nix
+++ b/modules/desktop/home/components/waybar.nix
@@ -100,7 +100,7 @@ in
             tooltip-format-disconnected = "Disconnected";
             interval = 3;
             spacing = 1;
-            on-click = "nm-connection-editor";
+            on-click = "keystone-wifi-menu open-menu";
           };
 
           battery = {

--- a/modules/desktop/home/default.nix
+++ b/modules/desktop/home/default.nix
@@ -10,6 +10,7 @@ let
 in
 {
   imports = [
+    ../../shared/experimental.nix
     ./components
     ./hyprland
     ./scripts
@@ -59,6 +60,30 @@ in
         default = null;
         description = "Default CUPS printer name to apply at desktop session start.";
       };
+    };
+
+    # Top-level Walker main-menu surfaces. Each gates one hard-coded entry in
+    # keystone-main-menu's main_json via KEYSTONE_MENU_SHOW_* env vars. Default
+    # to keystone.experimental so only stable surfaces appear by default.
+    photos.enable = mkOption {
+      type = types.bool;
+      default = config.keystone.experimental;
+      defaultText = literalExpression "config.keystone.experimental";
+      description = "Show the Photos entry in the Mod+Escape Walker main menu.";
+    };
+
+    agents.enable = mkOption {
+      type = types.bool;
+      default = config.keystone.experimental;
+      defaultText = literalExpression "config.keystone.experimental";
+      description = "Show the Agents entry in the Mod+Escape Walker main menu.";
+    };
+
+    contexts.enable = mkOption {
+      type = types.bool;
+      default = config.keystone.experimental;
+      defaultText = literalExpression "config.keystone.experimental";
+      description = "Show the Contexts entry in the Mod+Escape Walker main menu.";
     };
 
     startupLockCommand = mkOption {

--- a/modules/desktop/home/hyprland/bindings.nix
+++ b/modules/desktop/home/hyprland/bindings.nix
@@ -27,7 +27,7 @@ in
         "$mod, E, exec, $fileManager"
 
         # Menu system
-        "$mod, Escape, exec, keystone-menu"
+        "$mod, Escape, exec, keystone-menu system"
         "$mod, K, exec, keystone-menu-keybindings"
 
         # Context switcher

--- a/modules/desktop/home/scripts/default.nix
+++ b/modules/desktop/home/scripts/default.nix
@@ -400,6 +400,14 @@ let
         pkgs.walker
         pkgs.xdg-utils
       ];
+      # Capability gating for ISSUE-REQ-1 (issue #390): the script's main_json
+      # emits Photos/Agents/Contexts entries only when the corresponding env var
+      # is "true". Values are evaluated at build time from the desktop config.
+      extraEnvSetup = ''
+        export KEYSTONE_MENU_SHOW_PHOTOS="${if cfg.photos.enable then "true" else "false"}"
+        export KEYSTONE_MENU_SHOW_AGENTS="${if cfg.agents.enable then "true" else "false"}"
+        export KEYSTONE_MENU_SHOW_CONTEXTS="${if cfg.contexts.enable then "true" else "false"}"
+      '';
     })
     (mkHomeScriptCommand {
       inherit config pkgs;

--- a/modules/desktop/home/scripts/default.nix
+++ b/modules/desktop/home/scripts/default.nix
@@ -188,6 +188,13 @@ let
     builtins.readFile ./keystone-launch-walker.sh
   );
 
+  # Shared desktop-config helper, packaged as a subcommand CLI so other menu
+  # scripts (each in its own writeShellScriptBin $out/bin) can invoke helpers
+  # without relying on an unpackaged sibling path.
+  keystoneDesktopConfig = pkgs.writeShellScriptBin "keystone-desktop-config" (
+    builtins.readFile ./keystone-desktop-config.sh
+  );
+
   # Detached process launcher for menu-triggered long-lived commands.
   keystoneDetach = pkgs.writeShellScriptBin "keystone-detach" ''
     set -euo pipefail
@@ -348,6 +355,18 @@ let
     })
     (mkHomeScriptCommand {
       inherit config pkgs;
+      commandName = "keystone-desktop-config";
+      relativePath = "modules/desktop/home/scripts/keystone-desktop-config.sh";
+      package = keystoneDesktopConfig;
+      runtimeInputs = [
+        pkgs.coreutils
+        pkgs.findutils
+        pkgs.hostname
+        pkgs.python3
+      ];
+    })
+    (mkHomeScriptCommand {
+      inherit config pkgs;
       commandName = "keystone-menu";
       relativePath = "modules/desktop/home/scripts/keystone-menu.sh";
       package = keystoneMenu;
@@ -394,6 +413,7 @@ let
         pkgs.ghostty
         pkgs.jq
         pkgs.keystone.ks
+        keystoneDesktopConfig
         pkgs.libnotify
         pkgs.nix
         pkgs.python3
@@ -415,6 +435,7 @@ let
         pkgs.ghostty
         pkgs.jq
         pkgs.keystone.ks
+        keystoneDesktopConfig
         pkgs.libnotify
         pkgs.nix
         pkgs.systemd
@@ -438,6 +459,7 @@ let
       relativePath = "modules/desktop/home/scripts/keystone-audio-menu.sh";
       package = keystoneAudioMenu;
       runtimeInputs = [
+        keystoneDesktopConfig
         pkgs.jq
         pkgs.libnotify
         pkgs.pulseaudio
@@ -452,6 +474,7 @@ let
       package = keystonePrinterMenu;
       runtimeInputs = [
         pkgs.cups
+        keystoneDesktopConfig
         pkgs.jq
         pkgs.libnotify
         pkgs.python3
@@ -467,6 +490,7 @@ let
         pkgs.coreutils
         pkgs.gawk
         hyprlandPkg
+        keystoneDesktopConfig
         pkgs.jq
         pkgs.libnotify
         pkgs.python3

--- a/modules/desktop/home/scripts/default.nix
+++ b/modules/desktop/home/scripts/default.nix
@@ -497,6 +497,7 @@ let
       package = keystoneFingerprintMenu;
       runtimeInputs = [
         pkgs.coreutils
+        pkgs.fprintd
         pkgs.gnugrep
         pkgs.jq
         pkgs.libnotify

--- a/modules/desktop/home/scripts/default.nix
+++ b/modules/desktop/home/scripts/default.nix
@@ -279,6 +279,11 @@ let
     builtins.readFile ./keystone-secrets-menu.sh
   );
 
+  # Wi-Fi scan/join controller for Elephant/Walker
+  keystoneWifiMenu = pkgs.writeShellScriptBin "keystone-wifi-menu" (
+    builtins.readFile ./keystone-wifi-menu.sh
+  );
+
   # Keybindings viewer script
   keystoneMenuKeybindings = pkgs.writeShellScriptBin "keystone-menu-keybindings" (
     builtins.readFile ./keystone-menu-keybindings.sh
@@ -572,6 +577,22 @@ let
         pkgs.util-linux
         pkgs.walker
         pkgs.yubikey-manager
+      ];
+    })
+    (mkHomeScriptCommand {
+      inherit config pkgs;
+      commandName = "keystone-wifi-menu";
+      relativePath = "modules/desktop/home/scripts/keystone-wifi-menu.sh";
+      package = keystoneWifiMenu;
+      runtimeInputs = [
+        pkgs.coreutils
+        pkgs.gawk
+        pkgs.gnugrep
+        pkgs.gnused
+        pkgs.jq
+        pkgs.libnotify
+        pkgs.networkmanager
+        pkgs.walker
       ];
     })
     (mkHomeScriptCommand {

--- a/modules/desktop/home/scripts/default.nix
+++ b/modules/desktop/home/scripts/default.nix
@@ -426,7 +426,6 @@ let
         pkgs.ghostty
         pkgs.jq
         pkgs.keystone.ks
-        keystoneDesktopConfig
         pkgs.libnotify
         pkgs.nix
         pkgs.python3
@@ -448,7 +447,6 @@ let
         pkgs.ghostty
         pkgs.jq
         pkgs.keystone.ks
-        keystoneDesktopConfig
         pkgs.libnotify
         pkgs.nix
         pkgs.systemd
@@ -472,7 +470,6 @@ let
       relativePath = "modules/desktop/home/scripts/keystone-audio-menu.sh";
       package = keystoneAudioMenu;
       runtimeInputs = [
-        keystoneDesktopConfig
         pkgs.jq
         pkgs.libnotify
         pkgs.pulseaudio
@@ -487,7 +484,6 @@ let
       package = keystonePrinterMenu;
       runtimeInputs = [
         pkgs.cups
-        keystoneDesktopConfig
         pkgs.jq
         pkgs.libnotify
         pkgs.python3
@@ -503,7 +499,6 @@ let
         pkgs.coreutils
         pkgs.gawk
         hyprlandPkg
-        keystoneDesktopConfig
         pkgs.jq
         pkgs.libnotify
         pkgs.python3
@@ -592,6 +587,7 @@ let
         pkgs.jq
         pkgs.libnotify
         pkgs.networkmanager
+        pkgs.util-linux
         pkgs.walker
       ];
     })

--- a/modules/desktop/home/scripts/default.nix
+++ b/modules/desktop/home/scripts/default.nix
@@ -372,8 +372,10 @@ let
         pkgs.coreutils
         pkgs.findutils
         pkgs.gawk
+        pkgs.ghostty
         pkgs.gnugrep
         pkgs.jq
+        pkgs.keystone.ks
         pkgs.libnotify
         pkgs.systemd
         pkgs.walker

--- a/modules/desktop/home/scripts/keystone-audio-menu.sh
+++ b/modules/desktop/home/scripts/keystone-audio-menu.sh
@@ -3,10 +3,6 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
-# shellcheck source=./keystone-desktop-config.sh
-source "${SCRIPT_DIR}/keystone-desktop-config.sh"
-
 notify() {
   notify-send "$@"
 }
@@ -303,7 +299,7 @@ audio_defaults_snippet() {
 }
 
 save_audio_defaults() {
-  audio_defaults_snippet | keystone_write_desktop_state_section "audio defaults"
+  audio_defaults_snippet | keystone-desktop-config write-desktop-state-section "audio defaults"
 }
 
 open_menu() {

--- a/modules/desktop/home/scripts/keystone-desktop-config.sh
+++ b/modules/desktop/home/scripts/keystone-desktop-config.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Shared helpers for persisting desktop state into nixos-config.
+# keystone-desktop-config — Shared helpers for persisting desktop state into
+# nixos-config. Packaged as a CLI with subcommands so other Walker menu
+# scripts (each built via writeShellScriptBin into its own $out/bin) can
+# reach these helpers without a sibling-path source.
 
 set -euo pipefail
 
@@ -107,3 +110,45 @@ keystone_write_desktop_state_section() {
   target_file=$(keystone_home_manager_host_file)
   keystone_write_managed_section "$target_file" "desktop state" "$section_name"
 }
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: keystone-desktop-config <subcommand> [args...]
+
+Subcommands:
+  config-repo-root
+      Print the resolved nixos-config repo root.
+  home-manager-host-file
+      Print the path to the current host's home-manager .nix file.
+  write-managed-section <target-file> <top-label> <section-name>
+      Read section body from stdin; upsert it into <target-file>.
+  write-desktop-state-section <section-name>
+      Read section body from stdin; upsert into the current host's
+      home-manager file under the "desktop state" top-label.
+USAGE
+  exit 2
+}
+
+main() {
+  # CRITICAL: dispatch must fail loudly on unknown subcommands so upstream
+  # callers surface typos instead of silently no-op'ing.
+  local sub="${1:-}"
+  if [[ -z "$sub" ]]; then
+    usage
+  fi
+  shift
+
+  case "$sub" in
+    config-repo-root) keystone_config_repo_root "$@" ;;
+    home-manager-host-file) keystone_home_manager_host_file "$@" ;;
+    write-managed-section) keystone_write_managed_section "$@" ;;
+    write-desktop-state-section) keystone_write_desktop_state_section "$@" ;;
+    -h | --help | help) usage ;;
+    *)
+      printf "keystone-desktop-config: unknown subcommand: %s\n" "$sub" >&2
+      usage
+      ;;
+  esac
+}
+
+main "$@"

--- a/modules/desktop/home/scripts/keystone-main-menu.sh
+++ b/modules/desktop/home/scripts/keystone-main-menu.sh
@@ -63,7 +63,17 @@ blocked_entry_json() {
 }
 
 main_json() {
-  jq -n '
+  # ISSUE-REQ-1 (#390): Contexts/Photos/Agents are gated by capability env vars
+  # wired from the desktop home-manager module. Default to hidden when unset so
+  # the surface never leaks in stale builds or ad-hoc invocations.
+  local show_contexts="${KEYSTONE_MENU_SHOW_CONTEXTS:-false}"
+  local show_photos="${KEYSTONE_MENU_SHOW_PHOTOS:-false}"
+  local show_agents="${KEYSTONE_MENU_SHOW_AGENTS:-false}"
+
+  jq -n \
+    --arg show_contexts "$show_contexts" \
+    --arg show_photos "$show_photos" \
+    --arg show_agents "$show_agents" '
     [
       {
         Text: "Apps",
@@ -71,25 +81,25 @@ main_json() {
         Value: "open-apps",
         Icon: "view-app-grid-symbolic"
       },
-      {
+      (if $show_contexts == "true" then {
         Text: "Contexts",
         Subtext: "Project and session switcher",
         Value: "open-contexts",
         Icon: "folder-development-symbolic"
-      },
-      {
+      } else empty end),
+      (if $show_photos == "true" then {
         Text: "Photos",
         Subtext: "Search Keystone Photos and preview results",
         Value: "open-photos-search",
         Icon: "image-x-generic-symbolic"
-      },
-      {
+      } else empty end),
+      (if $show_agents == "true" then {
         Text: "Agents",
         Subtext: "Agent state, pause, and interactive defaults",
         Value: "agents",
         Icon: "computer-symbolic",
         SubMenu: "keystone-agents"
-      },
+      } else empty end),
       {
         Text: "Learn",
         Subtext: "Keybindings and desktop references",

--- a/modules/desktop/home/scripts/keystone-main-menu.sh
+++ b/modules/desktop/home/scripts/keystone-main-menu.sh
@@ -140,8 +140,8 @@ main_json() {
       },
       {
         Text: "Update",
-        Subtext: "Use nix flake update",
-        Value: "blocked\tUpdate\tUse nix flake update for system updates.",
+        Subtext: "Run ks update in a terminal",
+        Value: "run-update",
         Icon: "software-update-available-symbolic"
       },
       {
@@ -421,6 +421,9 @@ dispatch() {
       ;;
     screenrecord)
       detach "$(keystone_cmd keystone-screenrecord)"
+      ;;
+    run-update)
+      detach ghostty -e ks update
       ;;
     screenshot-smart)
       detach "$(keystone_cmd keystone-screenshot)" smart

--- a/modules/desktop/home/scripts/keystone-monitor-menu.sh
+++ b/modules/desktop/home/scripts/keystone-monitor-menu.sh
@@ -3,10 +3,6 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
-# shellcheck source=./keystone-desktop-config.sh
-source "${SCRIPT_DIR}/keystone-desktop-config.sh"
-
 STATE_DIR="${XDG_RUNTIME_DIR:-/run/user/$UID}/keystone-monitor-menu"
 mkdir -p "$STATE_DIR"
 
@@ -445,8 +441,8 @@ config_snippet() {
 
 save_monitor_defaults() {
   local target_file=""
-  target_file=$(keystone_home_manager_host_file)
-  config_snippet | keystone_write_desktop_state_section "monitors"
+  target_file=$(keystone-desktop-config home-manager-host-file)
+  config_snippet | keystone-desktop-config write-desktop-state-section "monitors"
   notify "Saved monitor defaults" "Updated ${target_file}"
 }
 
@@ -765,7 +761,7 @@ cmd_preview_action() {
       ;;
     save-layout)
       printf "Save the current monitor layout for this host.\n\nThis writes the current monitor state into the managed desktop block in:\n%s\n\nCurrent snippet:\n%s\n" \
-        "$(keystone_home_manager_host_file)" \
+        "$(keystone-desktop-config home-manager-host-file)" \
         "$(config_snippet)"
       ;;
     *)

--- a/modules/desktop/home/scripts/keystone-package-menu.sh
+++ b/modules/desktop/home/scripts/keystone-package-menu.sh
@@ -3,10 +3,6 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
-# shellcheck source=./keystone-desktop-config.sh
-source "${SCRIPT_DIR}/keystone-desktop-config.sh"
-
 notify() {
   notify-send "$@"
 }
@@ -195,7 +191,7 @@ current_host_key() {
   local repo_root=""
   local hostname=""
 
-  repo_root=$(keystone_config_repo_root)
+  repo_root=$(keystone-desktop-config config-repo-root)
   hostname=$(current_hostname)
 
   host_registry_json "$repo_root" | jq -r --arg hostname "$hostname" '
@@ -460,7 +456,7 @@ cmd_search_and_install() {
   local current_key=""
   local current_name=""
 
-  if ! repo_root=$(keystone_config_repo_root 2>/dev/null); then
+  if ! repo_root=$(keystone-desktop-config config-repo-root 2>/dev/null); then
     notify "Install unavailable" "Unable to locate the active system flake."
     return 0
   fi

--- a/modules/desktop/home/scripts/keystone-printer-menu.sh
+++ b/modules/desktop/home/scripts/keystone-printer-menu.sh
@@ -3,10 +3,6 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
-# shellcheck source=./keystone-desktop-config.sh
-source "${SCRIPT_DIR}/keystone-desktop-config.sh"
-
 notify() {
   notify-send "$@"
 }
@@ -279,7 +275,7 @@ printer_defaults_snippet() {
 }
 
 save_printer_defaults() {
-  printer_defaults_snippet | keystone_write_desktop_state_section "printer defaults"
+  printer_defaults_snippet | keystone-desktop-config write-desktop-state-section "printer defaults"
 }
 
 apply_config_defaults() {

--- a/modules/desktop/home/scripts/keystone-setup-menu.sh
+++ b/modules/desktop/home/scripts/keystone-setup-menu.sh
@@ -25,7 +25,7 @@ keystone_cmd() {
 }
 
 entries_json() {
-  local audio_menu monitor_menu hardware_menu fingerprint_menu accounts_menu printer_menu setup_menu secrets_menu
+  local audio_menu monitor_menu hardware_menu fingerprint_menu accounts_menu printer_menu setup_menu secrets_menu wifi_menu
   local current_flake="" show_secrets=false
   audio_menu=$(keystone_cmd keystone-audio-menu)
   monitor_menu=$(keystone_cmd keystone-monitor-menu)
@@ -35,6 +35,7 @@ entries_json() {
   printer_menu=$(keystone_cmd keystone-printer-menu)
   setup_menu=$(keystone_cmd keystone-setup-menu)
   secrets_menu=$(keystone_cmd keystone-secrets-menu)
+  wifi_menu=$(keystone_cmd keystone-wifi-menu)
 
   current_flake="$(keystone-current-system-flake 2>/dev/null || true)"
   if [[ -d "$HOME/.keystone/repos/ncrmro/agenix-secrets" ]]; then
@@ -105,9 +106,10 @@ entries_json() {
       else empty end),
       {
         Text: "Wifi",
-        Subtext: "Controller not implemented yet",
-        Value: "blocked\tWifi\tWifi setup is not implemented yet.",
-        Preview: ($setup_menu + " preview-blocked " + ("Wifi" | @sh) + " " + ("Wifi setup is not implemented yet." | @sh)),
+        Subtext: "Scan, join, and manage Wi-Fi networks",
+        Value: "wifi",
+        SubMenu: "keystone-wifi",
+        Preview: ($wifi_menu + " summary"),
         PreviewType: "command"
       },
       {
@@ -127,6 +129,7 @@ entries_json() {
     --arg printer_menu "$printer_menu" \
     --arg setup_menu "$setup_menu" \
     --arg secrets_menu "$secrets_menu" \
+    --arg wifi_menu "$wifi_menu" \
     --argjson show_secrets "$show_secrets"
 }
 
@@ -144,7 +147,7 @@ dispatch() {
   IFS=$'\t' read -r action title message <<<"$payload"
 
   case "$action" in
-    audio | monitors | printer | hardware | fingerprint | accounts | secrets)
+    audio | monitors | printer | hardware | fingerprint | accounts | secrets | wifi)
       ;;
     blocked)
       notify "$title" "$message"

--- a/modules/desktop/home/scripts/keystone-update-menu.sh
+++ b/modules/desktop/home/scripts/keystone-update-menu.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 SCRIPT_REPO_ROOT="$(readlink -f "${SCRIPT_DIR}/../../../..")"
-# shellcheck source=./keystone-desktop-config.sh
-source "${SCRIPT_DIR}/keystone-desktop-config.sh"
 
 KEYSTONE_RELEASE_OWNER="ncrmro"
 KEYSTONE_RELEASE_REPO="keystone"
@@ -236,7 +234,7 @@ load_state() {
   local update_reason=""
   local dirty="false"
 
-  if ! repo_root=$(keystone_config_repo_root 2>/dev/null); then
+  if ! repo_root=$(keystone-desktop-config config-repo-root 2>/dev/null); then
     jq -n --arg error "Unable to locate the active system flake." '{ ok: false, error: $error }'
     return 0
   fi

--- a/modules/desktop/home/scripts/keystone-wifi-menu.sh
+++ b/modules/desktop/home/scripts/keystone-wifi-menu.sh
@@ -220,7 +220,11 @@ join_network() {
     return 0
   fi
 
-  if nmcli device wifi connect "$ssid" password "$passphrase" >/dev/null 2>&1; then
+  # SECURITY: feed the passphrase on stdin via `nmcli --ask` rather than
+  # passing it as a `password <pw>` argv token, which would expose the
+  # secret in /proc/<pid>/cmdline for the duration of the connect call.
+  if printf '%s\n' "$passphrase" \
+       | nmcli --ask device wifi connect "$ssid" >/dev/null 2>&1; then
     notify "Wi-Fi connected" "$ssid"
   else
     notify "Wi-Fi failed" "Could not join $ssid — check the passphrase"

--- a/modules/desktop/home/scripts/keystone-wifi-menu.sh
+++ b/modules/desktop/home/scripts/keystone-wifi-menu.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# keystone-wifi-menu — Wi-Fi Walker/Elephant surface driven by nmcli.
+#
+# Verbs:
+#   open-menu        — launch Walker with menus:keystone-wifi
+#   list-json        — emit Elephant entries for visible SSIDs
+#   dispatch <val>   — handle a selected entry payload
+#   summary          — short status blurb for the Setup menu preview
+#   preview-blocked  — parity with other menus for blocked entries
+
+set -euo pipefail
+
+notify() {
+  notify-send "$@"
+}
+
+keystone_cmd() {
+  local command_name="$1"
+
+  if command -v "$command_name" >/dev/null 2>&1; then
+    command -v "$command_name"
+    return 0
+  fi
+
+  if [[ -x "$HOME/.local/bin/$command_name" ]]; then
+    printf "%s\n" "$HOME/.local/bin/$command_name"
+    return 0
+  fi
+
+  printf "Unable to locate %s\n" "$command_name" >&2
+  exit 1
+}
+
+nmcli_available() {
+  command -v nmcli >/dev/null 2>&1
+}
+
+# Decode nmcli's ':'-escaped terse output field. nmcli escapes ':' and '\'
+# in terse (-t) output with a leading backslash.
+nmcli_unescape() {
+  local s="$1"
+  # Replace escaped colons and backslashes.
+  printf '%s' "${s//\\:/:}" | sed 's/\\\\/\\/g'
+}
+
+# Map a signal strength (0-100) to a Freedesktop network-wireless icon name.
+signal_icon() {
+  local signal="${1:-0}"
+  if ! [[ "$signal" =~ ^[0-9]+$ ]]; then
+    signal=0
+  fi
+  if (( signal >= 80 )); then
+    printf "network-wireless-signal-excellent\n"
+  elif (( signal >= 55 )); then
+    printf "network-wireless-signal-good\n"
+  elif (( signal >= 30 )); then
+    printf "network-wireless-signal-ok\n"
+  elif (( signal > 0 )); then
+    printf "network-wireless-signal-weak\n"
+  else
+    printf "network-wireless-signal-none\n"
+  fi
+}
+
+current_ssid() {
+  nmcli -t -f ACTIVE,SSID dev wifi 2>/dev/null \
+    | awk -F: '$1=="yes" {$1=""; sub(/^:/, ""); print; exit}'
+}
+
+# Return 0 if the SSID has a saved NetworkManager connection profile.
+has_saved_connection() {
+  local ssid="$1"
+  nmcli -t -f NAME connection show 2>/dev/null | grep -Fxq "$ssid"
+}
+
+blocked_entry_json() {
+  local title="$1"
+  local reason="$2"
+
+  jq -n --arg title "$title" --arg reason "$reason" '
+    [
+      {
+        Text: $title,
+        Subtext: $reason,
+        Value: "blocked",
+        Icon: "network-wireless-offline",
+        Preview: ("printf " + (($title + "\n\n" + $reason + "\n") | @sh)),
+        PreviewType: "command"
+      }
+    ]
+  '
+}
+
+list_json() {
+  if ! nmcli_available; then
+    blocked_entry_json "Wi-Fi unavailable" "nmcli is not available in PATH."
+    return 0
+  fi
+
+  # IN-USE:SSID:SIGNAL:SECURITY — terse output, rescan to refresh.
+  local raw
+  if ! raw=$(nmcli -t -f IN-USE,SSID,SIGNAL,SECURITY dev wifi list --rescan yes 2>/dev/null); then
+    blocked_entry_json "Wi-Fi scan failed" "nmcli dev wifi list returned a non-zero status."
+    return 0
+  fi
+
+  if [[ -z "$raw" ]]; then
+    blocked_entry_json "No networks found" "nmcli did not return any visible Wi-Fi networks."
+    return 0
+  fi
+
+  local entries_json="[]"
+  local seen_ssids=""
+  local line in_use ssid signal security icon subtext text entry
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    # nmcli -t uses ':' as a field separator and escapes literal ':' as '\:'.
+    # Split on unescaped ':' by substituting placeholders.
+    local placeheld="${line//\\:/$'\x01'}"
+    IFS=':' read -r in_use ssid signal security <<<"$placeheld"
+    in_use="${in_use//$'\x01'/:}"
+    ssid="${ssid//$'\x01'/:}"
+    signal="${signal//$'\x01'/:}"
+    security="${security//$'\x01'/:}"
+    ssid=$(nmcli_unescape "$ssid")
+    security=$(nmcli_unescape "$security")
+
+    # Skip hidden networks and duplicates (keep strongest, which appears first).
+    [[ -z "$ssid" ]] && continue
+    if printf '%s\n' "$seen_ssids" | grep -Fxq "$ssid"; then
+      continue
+    fi
+    seen_ssids+="${ssid}"$'\n'
+
+    icon=$(signal_icon "$signal")
+
+    local marker=""
+    [[ "$in_use" == "*" ]] && marker="✓ "
+
+    local sec_label="$security"
+    [[ -z "$sec_label" ]] && sec_label="open"
+
+    text="${marker}${ssid}"
+    subtext="${signal}%  ·  ${sec_label}"
+
+    entry=$(jq -n \
+      --arg text "$text" \
+      --arg subtext "$subtext" \
+      --arg ssid "$ssid" \
+      --arg security "$security" \
+      --arg icon "$icon" \
+      '{
+        Text: $text,
+        Subtext: $subtext,
+        Value: ("join\t" + $ssid + "\t" + $security),
+        Icon: $icon
+      }')
+    entries_json=$(jq -n --argjson arr "$entries_json" --argjson entry "$entry" '$arr + [$entry]')
+  done <<<"$raw"
+
+  # If loop filtered everything out, fall back to a blocked entry.
+  if [[ "$entries_json" == "[]" ]]; then
+    blocked_entry_json "No networks found" "No visible Wi-Fi SSIDs after filtering."
+    return 0
+  fi
+
+  printf "%s\n" "$entries_json"
+}
+
+# Prompt for a passphrase via walker --dmenu --inputonly --password.
+prompt_passphrase() {
+  local ssid="$1"
+  local walker
+  walker=$(keystone_cmd keystone-launch-walker)
+
+  # --password masks input if supported; --inputonly suppresses list items.
+  printf '\n' \
+    | "$walker" --dmenu --inputonly --password \
+        --placeholder "Password for ${ssid}" 2>/dev/null \
+    | tr -d '\r\n'
+}
+
+join_network() {
+  local ssid="$1"
+  local security="$2"
+
+  if ! nmcli_available; then
+    notify "Wi-Fi unavailable" "nmcli is not available."
+    exit 1
+  fi
+
+  if has_saved_connection "$ssid"; then
+    if nmcli connection up "$ssid" >/dev/null 2>&1; then
+      notify "Wi-Fi connected" "$ssid"
+      return 0
+    else
+      notify "Wi-Fi failed" "Could not activate saved connection: $ssid"
+      exit 1
+    fi
+  fi
+
+  # Open network → no passphrase needed.
+  if [[ -z "$security" || "$security" == "--" ]]; then
+    if nmcli device wifi connect "$ssid" >/dev/null 2>&1; then
+      notify "Wi-Fi connected" "$ssid"
+      return 0
+    else
+      notify "Wi-Fi failed" "Could not join open network: $ssid"
+      exit 1
+    fi
+  fi
+
+  # Secured network without a saved profile — prompt for passphrase.
+  local passphrase
+  passphrase=$(prompt_passphrase "$ssid" || true)
+  if [[ -z "$passphrase" ]]; then
+    notify "Wi-Fi cancelled" "No passphrase entered for $ssid"
+    return 0
+  fi
+
+  if nmcli device wifi connect "$ssid" password "$passphrase" >/dev/null 2>&1; then
+    notify "Wi-Fi connected" "$ssid"
+  else
+    notify "Wi-Fi failed" "Could not join $ssid — check the passphrase"
+    exit 1
+  fi
+}
+
+dispatch() {
+  local payload="${1:-}"
+  local action="" ssid="" security=""
+
+  IFS=$'\t' read -r action ssid security <<<"$payload"
+
+  case "$action" in
+    join)
+      join_network "$ssid" "$security"
+      ;;
+    blocked)
+      notify "Wi-Fi unavailable" "nmcli is not available on this host."
+      ;;
+    *)
+      printf "Unknown dispatch action: %s\n" "$action" >&2
+      exit 1
+      ;;
+  esac
+}
+
+summary() {
+  if ! nmcli_available; then
+    printf "Wi-Fi unavailable\nnmcli is not available in PATH.\n"
+    return 0
+  fi
+
+  local ssid
+  ssid=$(current_ssid)
+
+  if [[ -z "$ssid" ]]; then
+    printf "Wi-Fi: disconnected\n"
+    return 0
+  fi
+
+  local signal
+  signal=$(nmcli -t -f ACTIVE,SIGNAL dev wifi 2>/dev/null \
+    | awk -F: '$1=="yes" {print $2; exit}')
+  signal="${signal:-?}"
+
+  printf "Wi-Fi: %s\nSignal: %s%%\n" "$ssid" "$signal"
+}
+
+preview_blocked() {
+  local title="$1"
+  local message="$2"
+
+  printf "%s\n\n%s\n" "$title" "$message"
+}
+
+open_menu() {
+  walker -q >/dev/null 2>&1 || true
+  setsid "$(keystone_cmd keystone-launch-walker)" -m menus:keystone-wifi -p "Wi-Fi" >/dev/null 2>&1 &
+}
+
+case "${1:-}" in
+  open-menu)
+    shift
+    open_menu "$@"
+    ;;
+  list-json)
+    shift
+    list_json "$@"
+    ;;
+  dispatch)
+    shift
+    dispatch "$@"
+    ;;
+  summary)
+    shift
+    summary "$@"
+    ;;
+  preview-blocked)
+    shift
+    preview_blocked "$@"
+    ;;
+  *)
+    echo "Usage: keystone-wifi-menu {open-menu|list-json|dispatch|summary|preview-blocked} ..." >&2
+    exit 1
+    ;;
+esac

--- a/tests/module/desktop-walker-surfaces.nix
+++ b/tests/module/desktop-walker-surfaces.nix
@@ -1,0 +1,80 @@
+# Red/green gate for GitHub issue #390 — gate Walker surfaces and repair
+# setup, update, and wifi flows. Each assertion below encodes a requirement
+# from engineering issue #391 (ISSUE-REQ-1..8). These tests MUST fail on main
+# and pass once all fixes land.
+{ pkgs }:
+pkgs.runCommand "test-desktop-walker-surfaces"
+  {
+    nativeBuildInputs = with pkgs; [ gnugrep ];
+  }
+  ''
+    set -euo pipefail
+
+    repo="${../..}"
+    scripts="$repo/modules/desktop/home/scripts"
+    bindings="$repo/modules/desktop/home/hyprland/bindings.nix"
+    waybar="$repo/modules/desktop/home/components/waybar.nix"
+    default_nix="$scripts/default.nix"
+    main_menu="$scripts/keystone-main-menu.sh"
+    setup_menu="$scripts/keystone-setup-menu.sh"
+
+    fail() {
+      echo "FAIL: $1" >&2
+      exit 1
+    }
+
+    # ISSUE-REQ-2: $mod+Escape must default to the System menu.
+    if ! grep -F '"$mod, Escape, exec, keystone-menu system"' "$bindings" >/dev/null; then
+      fail "ISSUE-REQ-2: \$mod+Escape bind must be 'keystone-menu system' (was 'keystone-menu')"
+    fi
+
+    # ISSUE-REQ-8: Waybar network click must open the Keystone Wi-Fi flow, not nm-connection-editor.
+    if grep -F 'on-click = "nm-connection-editor"' "$waybar" >/dev/null; then
+      fail "ISSUE-REQ-8: waybar network on-click must not be 'nm-connection-editor'"
+    fi
+    if ! grep -E 'on-click = "keystone-wifi-menu' "$waybar" >/dev/null; then
+      fail "ISSUE-REQ-8: waybar network on-click must invoke 'keystone-wifi-menu'"
+    fi
+
+    # ISSUE-REQ-6: Update entry must not be the blocked 'Use nix flake update' placeholder.
+    if grep -F 'Use nix flake update for system updates.' "$main_menu" >/dev/null; then
+      fail "ISSUE-REQ-6: Update entry must not remain a blocked 'Use nix flake update' placeholder"
+    fi
+
+    # ISSUE-REQ-7: Wifi entry must not be the blocked 'not implemented yet' placeholder.
+    if grep -F 'Wifi setup is not implemented yet.' "$setup_menu" >/dev/null; then
+      fail "ISSUE-REQ-7: Wifi entry must not remain a blocked 'not implemented yet' placeholder"
+    fi
+
+    # ISSUE-REQ-7: A keystone-wifi-menu script must exist.
+    if [[ ! -f "$scripts/keystone-wifi-menu.sh" ]]; then
+      fail "ISSUE-REQ-7: modules/desktop/home/scripts/keystone-wifi-menu.sh must exist"
+    fi
+
+    # ISSUE-REQ-3/4: Setup controllers MUST NOT source a sibling helper that is
+    # not packaged. writeShellScriptBin places each script in its own $out/bin,
+    # so a sibling keystone-desktop-config.sh path never resolves at runtime.
+    for s in \
+      "$scripts/keystone-audio-menu.sh" \
+      "$scripts/keystone-monitor-menu.sh" \
+      "$scripts/keystone-printer-menu.sh" \
+      "$scripts/keystone-update-menu.sh" \
+      "$scripts/keystone-package-menu.sh"; do
+      if grep -F 'source "''${SCRIPT_DIR}/keystone-desktop-config.sh"' "$s" >/dev/null; then
+        fail "ISSUE-REQ-3/4: $(basename "$s") must not source a sibling keystone-desktop-config.sh — helper must be packaged"
+      fi
+    done
+
+    # ISSUE-REQ-5: Fingerprint menu runtime inputs must include fprintd.
+    if ! grep -E 'pkgs\.fprintd' "$default_nix" >/dev/null; then
+      fail "ISSUE-REQ-5: default.nix must include pkgs.fprintd in keystoneFingerprintMenu runtimeInputs"
+    fi
+
+    # ISSUE-REQ-1: Top-level menu entries must be gated by capability env vars
+    # wired from the Nix module.
+    if ! grep -E 'KEYSTONE_MENU_SHOW_(PHOTOS|AGENTS|CONTEXTS)' "$main_menu" >/dev/null; then
+      fail "ISSUE-REQ-1: keystone-main-menu.sh must gate Photos/Agents/Contexts entries via KEYSTONE_MENU_SHOW_* env vars"
+    fi
+
+    touch "$out"
+  ''

--- a/tests/module/keystone-secrets-menu.nix
+++ b/tests/module/keystone-secrets-menu.nix
@@ -71,7 +71,7 @@ pkgs.runCommand "test-keystone-secrets-menu"
     EOF
     chmod +x "$PWD/bin/ghostty"
 
-    for command_name in keystone-audio-menu keystone-monitor-menu keystone-hardware-menu keystone-fingerprint-menu keystone-accounts-menu keystone-printer-menu; do
+    for command_name in keystone-audio-menu keystone-monitor-menu keystone-hardware-menu keystone-fingerprint-menu keystone-accounts-menu keystone-printer-menu keystone-wifi-menu; do
       cat > "$PWD/bin/$command_name" <<EOF
     #!${pkgs.bash}/bin/bash
     exit 0

--- a/tests/module/keystone-update-menu.nix
+++ b/tests/module/keystone-update-menu.nix
@@ -52,6 +52,26 @@ pkgs.runCommand "test-keystone-update-menu"
     EOF
     chmod +x "$PWD/bin/keystone-detach"
 
+    cat > "$PWD/bin/keystone-desktop-config" <<'EOF'
+    #!${pkgs.bash}/bin/bash
+    set -euo pipefail
+    case "''${1:-}" in
+      config-repo-root)
+        if [[ -n "''${KEYSTONE_SYSTEM_FLAKE:-}" ]]; then
+          printf '%s\n' "$KEYSTONE_SYSTEM_FLAKE"
+        else
+          echo "KEYSTONE_SYSTEM_FLAKE unset in test harness" >&2
+          exit 1
+        fi
+        ;;
+      *)
+        echo "Unexpected keystone-desktop-config subcommand: $*" >&2
+        exit 1
+        ;;
+    esac
+    EOF
+    chmod +x "$PWD/bin/keystone-desktop-config"
+
     cat > "$PWD/bin/ghostty" <<'EOF'
     #!${pkgs.bash}/bin/bash
     exit 0


### PR DESCRIPTION
## Summary
Gate Walker top-level entries, rebind `$mod+Escape` to System, package the shared desktop-config helper so setup controllers run, add fingerprint runtime, wire up a real Update entry, and replace the blocked Wifi placeholder with a Walker Wi-Fi flow (also used by Waybar's network click).

Parent product issue: #390
Engineering issue: #391

## Task Checklist
- [x] Failing tests committed (`test(desktop): add failing tests for #390`)
- [x] Task 1: Package shared `keystone-desktop-config.sh` so installed scripts can source it (ISSUE-REQ-3, 4)
- [x] Task 2: Gate top-level Walker entries (Contexts, Photos, Agents) by capability (ISSUE-REQ-1)
- [x] Task 3: Rebind `\$mod+Escape` to System submenu (ISSUE-REQ-2)
- [x] Task 4: Ship fingerprint runtime (fprintd) or hide the menu entry (ISSUE-REQ-5)
- [x] Task 5: Replace blocked Update entry with a real flow (ISSUE-REQ-6)
- [x] Task 6: Implement Keystone Wi-Fi Walker flow (ISSUE-REQ-7)
- [x] Task 7: Point Waybar network click at the new Wi-Fi flow (ISSUE-REQ-8)

## Test plan
- [x] \`nix build .#checks.x86_64-linux.desktop-walker-surfaces\` passes (all 9 assertions green)
- [ ] \`nix flake check --no-build\`
- [ ] \`nix flake check\`
- [ ] \`ks build\` (home-manager profile for current host)
- [ ] Manual probes per engineering_issue.md test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)