### PR TITLE
fix(desktop): restore hyprlock theming and fix blank lock screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ installer-iso
 # ISO files (they are large)
 *.iso
 
-# E2E test working screenshots (ephemeral)
+# E2E test artifacts
 .test-e2e-screenshots/
 
 # Editor / AI tool files

--- a/CONTRIBUTOR.md
+++ b/CONTRIBUTOR.md
@@ -97,6 +97,23 @@ ks switch                   # Fast deploy current local state
 ks doctor                   # Diagnose system health
 ```
 
+### E2E testing
+
+`bin/test-e2e` runs the full installer pipeline from the keystone repo:
+ISO build → VM boot → install → reboot → desktop validation.
+
+```bash
+bin/test-e2e                  # Full e2e (build + boot + install + validate)
+bin/test-e2e --build-only     # ISO build only (CI parity)
+bin/test-e2e --clean          # Regenerate fixture before running
+bin/test-e2e --no-build       # Reuse existing ISO
+```
+
+The script generates a consumer-flake fixture from the default template,
+locks it to the current keystone checkout, and delegates to the fixture's
+`test-iso`. The fixture is cached at `/tmp/keystone-e2e-fixture/` and refreshed
+automatically on each run.
+
 ## AI instruction regeneration
 
 AI instruction files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) are automatically

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 .PHONY: test-tui-eval test-tui-build
 .PHONY: vm-create vm-start vm-stop vm-destroy vm-reset vm-ssh vm-console vm-display vm-status vm-post-install vm-reset-secureboot
 .PHONY: build-vm-terminal build-vm-desktop build-iso build-iso-ssh
+.PHONY: test-e2e test-e2e-build
 .PHONY: test-deploy test-desktop test-hm
 
 # Default VM name for libvirt targets
@@ -150,6 +151,14 @@ vm-post-install: ## Post-install: remove ISO, snapshot, reboot
 
 vm-reset-secureboot: ## Reset to Secure Boot setup mode
 	./bin/virtual-machine --reset-setup-mode $(VM_NAME)
+
+## E2E Testing (ISO build + VM boot + install + validate)
+
+test-e2e: ## Run full e2e test from keystone repo
+	./bin/test-e2e
+
+test-e2e-build: ## Build e2e ISO only (no VM boot)
+	./bin/test-e2e --build-only
 
 ## Deployment Testing
 

--- a/bin/test-e2e
+++ b/bin/test-e2e
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Run the full e2e test pipeline from the keystone repo.
+#
+# Generates a consumer-flake fixture from the default template, locks it
+# to the current keystone checkout, then delegates to the fixture's
+# test-iso script. All flags are passed through.
+#
+# Usage:
+#   bin/test-e2e                          # full e2e (build + boot + install + validate)
+#   bin/test-e2e --build-only             # ISO build only
+#   bin/test-e2e --clean                  # regenerate fixture before running
+#   bin/test-e2e --no-build --port 12260  # reuse existing ISO, custom port
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+FIXTURE_DIR="/tmp/keystone-e2e-fixture"
+CLEAN=false
+PASSTHROUGH_ARGS=()
+
+log_info() { printf '\033[0;34m%s\033[0m\n' "$*"; }
+log_error() { printf '\033[0;31m%s\033[0m\n' "$*" >&2; }
+
+# Separate --clean from passthrough args
+for arg in "$@"; do
+    if [[ "$arg" == "--clean" ]]; then
+        CLEAN=true
+    else
+        PASSTHROUGH_ARGS+=("$arg")
+    fi
+done
+
+# Default to --dev --headless --e2e when no mode flags are given
+has_mode_flag=false
+for arg in "${PASSTHROUGH_ARGS[@]+"${PASSTHROUGH_ARGS[@]}"}"; do
+    case "$arg" in
+        --e2e|--build-only|--no-build) has_mode_flag=true ;;
+    esac
+done
+if [[ "$has_mode_flag" == false ]]; then
+    PASSTHROUGH_ARGS=(--dev --headless --e2e "${PASSTHROUGH_ARGS[@]+"${PASSTHROUGH_ARGS[@]}"}")
+fi
+
+# Ensure --dev is present (required for keystone-repo builds)
+has_dev=false
+for arg in "${PASSTHROUGH_ARGS[@]}"; do
+    [[ "$arg" == "--dev" ]] && has_dev=true
+done
+if [[ "$has_dev" == false ]]; then
+    PASSTHROUGH_ARGS=(--dev "${PASSTHROUGH_ARGS[@]}")
+fi
+
+if [[ "$CLEAN" == true ]] && [[ -d "$FIXTURE_DIR" ]]; then
+    log_info "Cleaning existing fixture..."
+    rm -rf "$FIXTURE_DIR"
+fi
+
+if [[ ! -d "$FIXTURE_DIR" ]]; then
+    log_info "Generating consumer-flake fixture from template..."
+    "$REPO_ROOT/bin/generate-template-fixture" \
+        --output "$FIXTURE_DIR" \
+        --keystone-source "path:${REPO_ROOT}"
+else
+    log_info "Refreshing fixture keystone lock..."
+    (cd "$FIXTURE_DIR" && nix flake lock --override-input keystone "path:${REPO_ROOT}")
+    # Commit the lock update so test-iso sees a clean tree
+    if ! git -C "$FIXTURE_DIR" diff --quiet flake.lock 2>/dev/null; then
+        git -C "$FIXTURE_DIR" add flake.lock
+        git -C "$FIXTURE_DIR" commit -m "chore: refresh keystone lock" --no-gpg-sign >/dev/null
+    fi
+fi
+
+if [[ ! -x "$FIXTURE_DIR/bin/test-iso" ]]; then
+    log_error "Fixture missing bin/test-iso — try bin/test-e2e --clean"
+    exit 1
+fi
+
+log_info "Running: bin/test-iso ${PASSTHROUGH_ARGS[*]}"
+exec "$FIXTURE_DIR/bin/test-iso" "${PASSTHROUGH_ARGS[@]}"

--- a/modules/desktop/home/hyprland/bindings.nix
+++ b/modules/desktop/home/hyprland/bindings.nix
@@ -174,7 +174,7 @@ in
         ", XF86AudioPrev, exec, playerctl previous"
         ", XF86PowerOff, exec, keystone-menu system"
         # Lid switch bindings - lock AND suspend on close
-        ", switch:on:Lid Switch, exec, pidof hyprlock || hyprlock --immediate-render; systemctl suspend"
+        ", switch:on:Lid Switch, exec, pidof hyprlock || hyprlock; systemctl suspend"
         ", switch:off:Lid Switch, exec, hyprctl dispatch dpms on"
       ];
     };

--- a/modules/desktop/home/hyprland/hypridle.nix
+++ b/modules/desktop/home/hyprland/hypridle.nix
@@ -7,7 +7,7 @@
 with lib;
 let
   desktopCfg = config.keystone.desktop;
-  lockCommand = "pidof hyprlock || hyprlock --immediate-render";
+  lockCommand = "pidof hyprlock || hyprlock";
 in
 {
   config = mkIf desktopCfg.enable {

--- a/modules/desktop/home/hyprland/hyprlock.nix
+++ b/modules/desktop/home/hyprland/hyprlock.nix
@@ -13,6 +13,13 @@ in
     programs.hyprlock = {
       enable = mkDefault true;
       settings = {
+        source = mkDefault "${config.xdg.configHome}/keystone/current/theme/hyprlock.conf";
+
+        general = {
+          disable_loading_bar = true;
+          no_fade_in = false;
+        };
+
         auth = {
           fingerprint.enabled = true;
         };
@@ -35,15 +42,17 @@ in
           halign = "center";
           valign = "center";
 
-          inner_color = "rgb(1e1e2e)";
-          outer_color = "rgb(89b4fa)";
+          inner_color = "$inner_color";
+          outer_color = "$outer_color";
           outline_thickness = 4;
 
           font_family = "JetBrainsMono Nerd Font";
-          font_color = "rgb(cdd6f4)";
+          font_size = 32;
+          font_color = "$font_color";
 
+          placeholder_color = "$placeholder_color";
           placeholder_text = "  Enter Password";
-          check_color = "rgb(a6e3a1)";
+          check_color = "$check_color";
           fail_text = "Wrong ($ATTEMPTS)";
 
           rounding = 0;
@@ -55,7 +64,7 @@ in
           monitor = "";
           text = "$FPRINTPROMPT";
           text_align = "center";
-          color = "rgb(f9e2af)";
+          color = "$font_color";
           font_size = 24;
           font_family = "JetBrainsMono Nerd Font";
           position = "0, -100";

--- a/modules/desktop/home/scripts/keystone-startup-lock.sh
+++ b/modules/desktop/home/scripts/keystone-startup-lock.sh
@@ -22,7 +22,7 @@ stable_lock_steps="${KEYSTONE_STARTUP_LOCK_STABLE_LOCK_STEPS:-20}"
 # appears or hyprlock stays stable after readiness.
 max_lock_attempts="${KEYSTONE_STARTUP_LOCK_MAX_ATTEMPTS:-3}"
 retry_delay_seconds="${KEYSTONE_STARTUP_LOCK_RETRY_DELAY:-1}"
-hyprlock_cmd=(hyprlock --immediate-render)
+hyprlock_cmd=(hyprlock)
 
 log() {
   local priority="$1"

--- a/tests/module/hyprland-config-smoke.nix
+++ b/tests/module/hyprland-config-smoke.nix
@@ -88,29 +88,35 @@ pkgs.runCommand "hyprland-config-smoke"
     assert_contains "${hyprpaperConf}" "wallpaper=,/home/testuser/.config/keystone/current/background" \
       "hyprpaper assigns the theme background to all monitors"
 
-    assert_contains "${hypridleConf}" "lock_cmd=pidof hyprlock || hyprlock --immediate-render" \
-      "hypridle uses immediate-render for the lock command"
-    assert_contains "${hypridleConf}" "before_sleep_cmd=pidof hyprlock || hyprlock --immediate-render" \
-      "hypridle uses immediate-render before suspend"
-    assert_contains "${hypridleConf}" "on-timeout=pidof hyprlock || hyprlock --immediate-render" \
-      "hypridle timeout locking uses immediate-render"
+    assert_contains "${hypridleConf}" "lock_cmd=pidof hyprlock || hyprlock" \
+      "hypridle lock command invokes hyprlock"
+    assert_contains "${hypridleConf}" "before_sleep_cmd=pidof hyprlock || hyprlock" \
+      "hypridle locks before suspend"
+    assert_contains "${hypridleConf}" "on-timeout=pidof hyprlock || hyprlock" \
+      "hypridle timeout triggers lock"
+    assert_not_contains "${hypridleConf}" "immediate-render" \
+      "hypridle does not use --immediate-render (causes blank lock screen)"
 
-    assert_contains "${hyprlandConf}" "switch:on:Lid Switch, exec, pidof hyprlock || hyprlock --immediate-render; systemctl suspend" \
-      "lid-close binding uses immediate-render before suspend"
-    assert_contains "${startupLockScript}" "hyprlock_cmd=(hyprlock --immediate-render)" \
-      "startup lock wrapper launches hyprlock with immediate-render"
+    assert_contains "${hyprlandConf}" "switch:on:Lid Switch, exec, pidof hyprlock || hyprlock; systemctl suspend" \
+      "lid-close binding locks and suspends"
+    assert_contains "${startupLockScript}" "hyprlock_cmd=(hyprlock)" \
+      "startup lock wrapper launches hyprlock without --immediate-render"
 
-    assert_not_contains "${hyprlockConf}" "disable_loading_bar" \
-      "hyprlock config omits removed general.disable_loading_bar"
-    assert_not_contains "${hyprlockConf}" "no_fade_in" \
-      "hyprlock config omits removed general.no_fade_in"
-    assert_not_contains "${hyprlockConf}" "placeholder_color" \
-      "hyprlock config omits removed input-field.placeholder_color"
+    assert_contains "${hyprlockConf}" "source=" \
+      "hyprlock sources theme colors from theme hyprlock.conf"
+    assert_contains "${hyprlockConf}" "disable_loading_bar" \
+      "hyprlock general section is present"
+    assert_contains "${hyprlockConf}" "inner_color=\$inner_color" \
+      "hyprlock uses theme variable for inner_color"
+    assert_contains "${hyprlockConf}" "font_color=\$font_color" \
+      "hyprlock uses theme variable for font_color"
+    assert_contains "${hyprlockConf}" "placeholder_color=\$placeholder_color" \
+      "hyprlock uses theme variable for placeholder_color"
     if printf '%s\n' "$input_field_block" | grep -F "font_size" >/dev/null; then
-      echo "FAIL: hyprlock input-field omits removed font_size" >&2
-      exit 1
+      echo "PASS: hyprlock input-field includes font_size"
     else
-      echo "PASS: hyprlock input-field omits removed font_size"
+      echo "FAIL: hyprlock input-field missing font_size" >&2
+      exit 1
     fi
 
     export HOME="$PWD/home"


### PR DESCRIPTION
## Summary

- Restore theme-aware hyprlock colors — `source` directive and `$variable` references were replaced with hardcoded Catppuccin Mocha colors in #334, lost `general`, `font_size`, `placeholder_color` in #385
- Remove `--immediate-render` flag from hypridle, lid switch binding, and startup lock script — this flag draws before the background image loads, causing a blank lock screen

## Test plan

- [ ] Lock screen (`Super+L` or idle timeout) — background image should render, not blank
- [ ] Verify lock screen colors match active theme (royal-green: dark green background, gold accents)
- [ ] Test lid close on laptop — should lock with background visible
- [ ] Switch themes with `keystone-theme-switch` and verify lock screen picks up new colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)