### PR TITLE
feat(os): kodi kiosk + pi-uefi zfs platform

### DIFF
--- a/modules/os/default.nix
+++ b/modules/os/default.nix
@@ -231,6 +231,7 @@ in
     ./ssh.nix
     ./eternal-terminal.nix
     ./airplay.nix
+    ./kodi.nix
     ./mail.nix
     ./git-server
     ./agents
@@ -267,6 +268,79 @@ in
           - zfs: Full features (snapshots, compression, checksums, native encryption)
           - ext4: Simple/legacy (LUKS encryption only, no advanced features)
         '';
+      };
+
+      platform = mkOption {
+        type = types.enum [
+          "uefi"
+          "pi"
+        ];
+        default = "uefi";
+        description = ''
+          Hardware/boot platform. Selects bootloader, firmware partition layout, and
+          encryption defaults.
+          - uefi: x86_64 UEFI with systemd-boot, LUKS credstore, optional TPM2 unlock.
+          - pi: Raspberry Pi (aarch64) booting pftf/RPi4 UEFI firmware + systemd-boot.
+            No LUKS credstore (no TPM on Pi); use native ZFS encryption if needed.
+            Consumers must supply pftf firmware files via storage.pi.uefiFirmware.
+        '';
+      };
+
+      pi = {
+        bootMedium = mkOption {
+          type = types.enum [
+            "sd"
+            "external"
+          ];
+          default = "external";
+          description = ''
+            Where the Pi firmware + /boot lives:
+            - sd: firmware/boot + ZFS root share a single SD/eMMC device
+              (storage.devices[0] is partitioned: firmware + zfs).
+              Convenient but writes wear the SD card.
+            - external: SD holds only firmware + /boot (via storage.pi.bootDevice);
+              ZFS pool lives on storage.devices (USB/NVMe). Recommended for servers.
+          '';
+        };
+
+        bootDevice = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "/dev/disk/by-id/mmc-SC64G_0x12345678";
+          description = ''
+            Device holding the Pi firmware and /boot partition when
+            storage.pi.bootMedium = "external". Ignored when bootMedium = "sd"
+            (the first entry of storage.devices is used instead).
+          '';
+        };
+
+        firmwareSize = mkOption {
+          type = types.str;
+          default = "1G";
+          description = ''
+            Size of the FAT32 ESP partition. Holds pftf/RPi4 UEFI firmware plus
+            systemd-boot, kernels, and initrds — keep ≥1G for multiple generations.
+          '';
+        };
+
+        uefiFirmware = mkOption {
+          type = types.attrsOf types.path;
+          default = { };
+          example = literalExpression ''
+            {
+              "RPI_EFI.fd" = "''${pftf}/RPI_EFI.fd";
+              "config.txt" = "''${pftf}/config.txt";
+              "bcm2711-rpi-4-b.dtb" = "''${pftf}/bcm2711-rpi-4-b.dtb";
+              # ...firmware blobs from pftf/RPi4 release zip
+            }
+          '';
+          description = ''
+            Files from the pftf/RPi4 UEFI firmware release to drop onto the ESP
+            (via boot.loader.systemd-boot.extraFiles). Consumers fetch a specific
+            pftf release and map its files here — no fixed default because pftf
+            versions change and belong in host config.
+          '';
+        };
       };
 
       devices = mkOption {

--- a/modules/os/default.nix
+++ b/modules/os/default.nix
@@ -732,6 +732,13 @@ in
         assertion = !cfg.storage.enable || cfg.storage.type == "ext4" -> cfg.storage.mode == "single";
         message = "ext4 only supports single-disk mode";
       }
+      {
+        assertion = !cfg.storage.enable || !(cfg.storage.platform == "pi" && cfg.storage.type == "ext4");
+        message = ''
+          keystone.os.storage.platform = "pi" + type = "ext4" is not yet
+          implemented. Use type = "zfs" on Pi hosts, or platform = "uefi" for ext4.
+        '';
+      }
       # Non-storage assertions
       {
         assertion = cfg.remoteUnlock.enable -> (cfg.remoteUnlock.authorizedKeys != [ ] || cfg.users != { });

--- a/modules/os/kodi.nix
+++ b/modules/os/kodi.nix
@@ -1,0 +1,93 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+with lib;
+let
+  cfg = config.keystone.os.services.kodi;
+in
+{
+  options.keystone.os.services.kodi = {
+    enable = mkEnableOption "Kodi media center in kiosk mode (auto-login, fullscreen)";
+
+    user = mkOption {
+      type = types.str;
+      default = "kodi";
+      description = "User account Kodi runs as. Created as a system user if it does not already exist.";
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.kodi-wayland;
+      defaultText = literalExpression "pkgs.kodi-wayland";
+      description = "Kodi package to use. For headless GBM (no compositor), set to `pkgs.kodi-gbm`.";
+    };
+
+    cec.enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable HDMI-CEC support so a TV remote can control Kodi. Adds the Kodi user to the `dialout` group for /dev/cec* access.";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Open ports for Kodi JSON-RPC, web interface, and UPnP/DLNA discovery.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.${cfg.user} = mkDefault {
+      isSystemUser = true;
+      createHome = true;
+      home = "/var/lib/kodi";
+      group = cfg.user;
+      extraGroups = [
+        "audio"
+        "video"
+        "input"
+      ]
+      ++ optional cfg.cec.enable "dialout";
+      description = "Kodi kiosk user";
+    };
+    users.groups.${cfg.user} = mkDefault { };
+
+    environment.systemPackages = [ cfg.package ] ++ optionals cfg.cec.enable [ pkgs.libcec ];
+
+    # Cage is a minimal Wayland kiosk compositor: one fullscreen client, no decorations.
+    # Pairs with greetd for passwordless auto-login on tty1.
+    services.greetd = {
+      enable = true;
+      settings.default_session = {
+        command = "${pkgs.cage}/bin/cage -s -- ${cfg.package}/bin/kodi-standalone";
+        user = cfg.user;
+      };
+    };
+
+    hardware.graphics.enable = true;
+    # Kodi needs a running PipeWire/PulseAudio for audio; assume the host enables one.
+    # CRITICAL: do not enable sound here — conflicts with host-level audio stack choice.
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [
+        8080 # web interface
+        9090 # JSON-RPC websocket
+        9777 # event server
+      ];
+      allowedUDPPorts = [
+        1900 # SSDP / UPnP
+        9777
+      ];
+    };
+
+    services.avahi = {
+      enable = true;
+      publish = {
+        enable = true;
+        userServices = true;
+      };
+    };
+  };
+}

--- a/modules/os/kodi.nix
+++ b/modules/os/kodi.nix
@@ -61,7 +61,9 @@ in
     services.greetd = {
       enable = true;
       settings.default_session = {
-        command = "${pkgs.cage}/bin/cage -s -- ${cfg.package}/bin/kodi-standalone";
+        # XDG_SESSION_CLASS=user ensures pam_systemd registers this as a
+        # real user session, not a greeter — required for polkit/device access.
+        command = "${pkgs.coreutils}/bin/env XDG_SESSION_CLASS=user ${pkgs.cage}/bin/cage -s -- ${cfg.package}/bin/kodi-standalone";
         user = cfg.user;
       };
     };
@@ -78,12 +80,14 @@ in
       ];
       allowedUDPPorts = [
         1900 # SSDP / UPnP
+        5353 # mDNS (Avahi service discovery)
         9777
       ];
     };
 
     services.avahi = {
       enable = true;
+      openFirewall = mkDefault cfg.openFirewall;
       publish = {
         enable = true;
         userServices = true;

--- a/modules/os/storage.nix
+++ b/modules/os/storage.nix
@@ -386,6 +386,50 @@ in
               For multi-disk pools set bootMedium = "external".
             '';
           }
+          {
+            assertion = cfg.pi.bootMedium != "external" || length cfg.devices > 0;
+            message = ''
+              keystone.os.storage.pi.bootMedium = "external" requires at least one
+              device in keystone.os.storage.devices for the ZFS pool.
+            '';
+          }
+          {
+            assertion = cfg.pi.bootMedium != "external" || !(lib.elem cfg.pi.bootDevice cfg.devices);
+            message = ''
+              keystone.os.storage.pi.bootDevice (${toString cfg.pi.bootDevice}) must not
+              also appear in keystone.os.storage.devices — disko cannot manage the same
+              physical disk twice. Remove it from devices or switch to bootMedium = "sd".
+            '';
+          }
+          {
+            assertion = cfg.pi.uefiFirmware != { };
+            message = ''
+              keystone.os.storage.pi.uefiFirmware is empty. The Pi UEFI boot path
+              requires pftf/RPi4 firmware files on the ESP — fetch a pftf release
+              and map its files here, or the Pi will not boot.
+            '';
+          }
+          {
+            assertion = config.networking.hostId != "";
+            message = ''
+              networking.hostId must be set for ZFS pool identity on the Pi platform.
+              Pick a stable 8-hex-char value (e.g. `networking.hostId = "deadbeef";`).
+            '';
+          }
+          {
+            assertion = !enableSwap;
+            message = ''
+              keystone.os.storage.swap is not yet supported on platform = "pi".
+              Set storage.swap.size = "0" (or use zram via zramSwap) until Pi swap
+              layout is implemented.
+            '';
+          }
+          {
+            assertion = !cfg.hibernate.enable;
+            message = ''
+              keystone.os.storage.hibernate is not supported on platform = "pi".
+            '';
+          }
         ];
 
         boot.supportedFilesystems = [ "zfs" ];

--- a/modules/os/storage.nix
+++ b/modules/os/storage.nix
@@ -61,8 +61,8 @@ let
 in
 {
   config = mkMerge [
-    # ZFS configuration
-    (mkIf (osCfg.enable && cfg.enable && cfg.type == "zfs") {
+    # ZFS configuration — UEFI platform (x86_64, systemd-boot, LUKS credstore)
+    (mkIf (osCfg.enable && cfg.enable && cfg.type == "zfs" && cfg.platform == "uefi") {
       # Ensure ZFS support is enabled
       boot.supportedFilesystems = [ "zfs" ];
 
@@ -349,6 +349,201 @@ in
       boot.kernelModules = [ "zfs" ];
       boot.extraModulePackages = [ config.boot.kernelPackages.${pkgs.zfs.kernelModuleAttribute} ];
     })
+
+    # ZFS configuration — Pi platform (aarch64, UEFI via pftf/RPi4, systemd-boot)
+    #
+    # The Pi boots pftf/RPi4 UEFI firmware from the ESP, which then loads systemd-boot
+    # — same boot stack as x86 UEFI hosts. The Pi EEPROM must be configured to allow
+    # SD/USB boot; the pftf firmware files must be present on the ESP (handled by
+    # boot.loader.systemd-boot.extraFiles below).
+    #
+    # Two sub-layouts selected by cfg.pi.bootMedium:
+    #   sd       — single-device: ESP (with pftf firmware) + zfs partition on cfg.devices[0]
+    #   external — ESP on cfg.pi.bootDevice; zfs pool on cfg.devices (multi-disk ok)
+    #
+    # No LUKS credstore: Pi has no TPM. For at-rest encryption use native ZFS
+    # encryption with an agenix-delivered keyfile (follow-up).
+    #
+    # Consumers MUST set networking.hostId (required by ZFS for pool identity).
+    (mkIf (osCfg.enable && cfg.enable && cfg.type == "zfs" && cfg.platform == "pi") (
+      let
+        piBootDevice = if cfg.pi.bootMedium == "sd" then firstDevice else cfg.pi.bootDevice;
+      in
+      {
+        assertions = [
+          {
+            assertion = cfg.pi.bootMedium == "sd" || cfg.pi.bootDevice != null;
+            message = ''
+              keystone.os.storage.pi.bootDevice must be set when
+              keystone.os.storage.pi.bootMedium = "external".
+            '';
+          }
+          {
+            assertion = cfg.pi.bootMedium != "sd" || length cfg.devices == 1;
+            message = ''
+              keystone.os.storage.pi.bootMedium = "sd" requires exactly one device in
+              keystone.os.storage.devices (the SD/eMMC card is both boot and pool).
+              For multi-disk pools set bootMedium = "external".
+            '';
+          }
+        ];
+
+        boot.supportedFilesystems = [ "zfs" ];
+
+        boot.kernelPackages =
+          if cfg.zfs.kernel == "latest" then
+            pkgs.linuxPackages_latest
+          else if cfg.zfs.kernel == "default" then
+            pkgs.linuxPackages
+          else
+            cfg.zfs.kernel;
+
+        # Pi boot: pftf/RPi4 UEFI firmware loads systemd-boot from the ESP.
+        boot.loader.systemd-boot.enable = true;
+        boot.loader.efi.canTouchEfiVariables = false; # pftf doesn't persist EFI vars
+        boot.loader.generic-extlinux-compatible.enable = false;
+
+        # Drop the pftf UEFI firmware onto the ESP alongside systemd-boot.
+        # Override cfg.pi.uefiFirmware to pin a specific pftf release.
+        boot.loader.systemd-boot.extraFiles = cfg.pi.uefiFirmware;
+
+        boot.initrd.systemd.enable = true;
+
+        boot.zfs = {
+          forceImportRoot = false;
+          allowHibernation = false;
+          devNodes = importDir;
+        };
+
+        boot.kernelParams = [
+          "zfs.zfs_arc_max=${toString arcMaxBytes}"
+        ];
+
+        boot.kernelModules = [ "zfs" ];
+        boot.extraModulePackages = [ config.boot.kernelPackages.${pkgs.zfs.kernelModuleAttribute} ];
+
+        services.zfs = {
+          autoScrub = mkIf cfg.zfs.autoScrub {
+            enable = true;
+            interval = "weekly";
+          };
+          trim = {
+            enable = true;
+            interval = "weekly";
+          };
+        };
+
+        disko.devices = {
+          disk =
+            let
+              # Boot disk: ESP holds pftf UEFI firmware + systemd-boot entries.
+              bootDisk = {
+                bootdisk = {
+                  type = "disk";
+                  device = piBootDevice;
+                  content = {
+                    type = "gpt";
+                    partitions = {
+                      esp = {
+                        name = "ESP";
+                        size = cfg.pi.firmwareSize;
+                        type = "EF00";
+                        content = {
+                          type = "filesystem";
+                          format = "vfat";
+                          mountpoint = "/boot";
+                          mountOptions = [ "umask=0077" ];
+                        };
+                      };
+                      # On bootMedium = "sd", the rest of the SD becomes the zfs partition.
+                      zfs = mkIf (cfg.pi.bootMedium == "sd") {
+                        end = "-0";
+                        content = {
+                          type = "zfs";
+                          pool = "rpool";
+                        };
+                      };
+                    };
+                  };
+                };
+              };
+
+              # External pool disks: whole-partition ZFS, no ESP/firmware on these.
+              mkPoolDisk = idx: device: {
+                name = "pool${toString idx}";
+                value = {
+                  type = "disk";
+                  inherit device;
+                  content = {
+                    type = "gpt";
+                    partitions.zfs = {
+                      end = "-0";
+                      content = {
+                        type = "zfs";
+                        pool = "rpool";
+                      };
+                    };
+                  };
+                };
+              };
+
+              poolDisks =
+                if cfg.pi.bootMedium == "external" then
+                  builtins.listToAttrs (imap0 mkPoolDisk cfg.devices)
+                else
+                  { };
+            in
+            bootDisk // poolDisks;
+
+          zpool.rpool = {
+            type = "zpool";
+            mode = zfsVdevType;
+            rootFsOptions = {
+              mountpoint = "none";
+              compression = cfg.zfs.compression;
+              acltype = "posixacl";
+              xattr = "sa";
+              atime = cfg.zfs.atime;
+              "com.sun:auto-snapshot" = "true";
+            };
+            options.ashift = "12";
+            datasets = {
+              root = {
+                type = "zfs_fs";
+                mountpoint = "/";
+              };
+              nix = {
+                type = "zfs_fs";
+                mountpoint = "/nix";
+                options."com.sun:auto-snapshot" = "false";
+              };
+              var = {
+                type = "zfs_fs";
+                mountpoint = "/var";
+              };
+            };
+          };
+        };
+
+        fileSystems = {
+          "/" = {
+            device = "rpool/root";
+            fsType = "zfs";
+            options = [ "zfsutil" ];
+          };
+          "/nix" = {
+            device = "rpool/nix";
+            fsType = "zfs";
+            options = [ "zfsutil" ];
+          };
+          "/var" = {
+            device = "rpool/var";
+            fsType = "zfs";
+            options = [ "zfsutil" ];
+          };
+        };
+      }
+    ))
 
     # ext4 configuration (simpler alternative to ZFS)
     (mkIf (osCfg.enable && cfg.enable && cfg.type == "ext4") {


### PR DESCRIPTION
## Summary
- New `keystone.os.services.kodi` module — greetd+cage kiosk launching Kodi fullscreen on tty1, with HDMI-CEC and firewall ports for JSON-RPC/UPnP. Parallels `os/airplay.nix`.
- New `keystone.os.storage.platform = "pi"` — Raspberry Pi aarch64 hosts boot pftf/RPi4 UEFI firmware + systemd-boot, sharing the ZFS storage shape with the existing `"uefi"` x86 path but without LUKS/TPM (Pi has no TPM).
- Pi disko: FAT32 ESP + ZFS pool. Two layouts via `storage.pi.bootMedium`: `sd` (single device) or `external` (SD holds ESP, pool on attached USB/NVMe).

Motivation: enables a Pi-based media appliance host composition (Kodi kiosk + Jellyfin client pointing at existing server) while keeping Pi servers on ZFS per convention. Approach informed by https://carlosvaz.com/posts/nixos-on-raspberry-pi-4-with-uefi-and-zfs/ — pftf/RPi4 UEFI proved more reliable for ZFS-on-Pi than the stock extlinux path.

## Consumer contract (Pi hosts)
```nix
keystone.os.storage = {
  platform = "pi";
  type = "zfs";
  devices = [ "/dev/disk/by-id/usb-..." ];
  pi = {
    bootMedium = "external";
    bootDevice = "/dev/disk/by-id/mmc-...";
    uefiFirmware = { /* pftf release files mapped to ESP paths */ };
  };
};
networking.hostId = "deadbeef";
```

## Test plan
- [ ] `nix flake check` on keystone
- [ ] Build a Pi host in nixos-config with `storage.platform = "pi"` + `services.kodi.enable`
- [ ] Flash + boot Pi 5, verify pftf loads systemd-boot, systemd-boot loads NixOS, ZFS root mounts
- [ ] Verify Kodi launches fullscreen under cage, HDMI-CEC responds to TV remote
- [ ] Confirm x86 `platform = "uefi"` hosts unchanged (regression — build ncrmro-workstation)

## Follow-ups (not in this PR)
- Native ZFS encryption via agenix keyfile for Pi (no TPM available)
- `storage.platform = "pi"` + `type = "ext4"` combination
- Example host under `examples/` showing the full Pi media appliance composition

🤖 Generated with [Claude Code](https://claude.com/claude-code)