### PR TITLE
feat(installer): aarch64 pi sd-image installer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -646,7 +646,24 @@
       #   nix build .#packages.aarch64-linux.pi-installer
       # Requires either an aarch64 builder or boot.binfmt.emulatedSystems.
       packages.aarch64-linux = {
-        pi-installer = self.lib.mkInstallerSdImage { inherit nixpkgs; };
+        # TODO: replace with auto-collection from keystone.keys registry
+        # (see vega parity-research). Hardcoded here to avoid flake-output
+        # recursion into consumer nixosConfigurations.
+        pi-installer = self.lib.mkInstallerSdImage {
+          inherit nixpkgs;
+          sshKeys = [
+            # ncrmro host keys
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOyrDBVcGK+pUZOTUA7MLoD5vYK/kaPF6TNNyoDmwNl2 ncrmro@ncrmro-laptop-fw7k"
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGiFUbcDdzBGNgo7GdRvuRvZ9Yf195pIm2jbiM0uJwW0 ncrmro@ncrmro-workstation"
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEE6cFSyJoiaURB7+961zETflBNPJUZszH9xyowzbpNu ncrmro@ocean"
+            "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCUAyM7/owpfpJPuzQMmkmnlAcqB91QIfVsj1TueIU3hUtoHGR6FcKfFgJA5gkhww10A91M6iPSHD2kd/BNBGD4= ncrmro@ncrmro-laptop"
+            # ncrmro hardware keys
+            "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAILEOo3uKwbDN1SJemQx8UPVXv0TjKn2VfZSTVFfp3tlcAAAACnNzaDpuY3Jtcm8= ncrmro-yubi-black"
+            "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIDtwsz3zAJokZ3rnVyXUxmeUGba61b8KIW3u4aE52dK2AAAAFXNzaDpuY3Jtcm8teXViaS1ncmVlbg== ncrmro-yubi-green"
+            # drago agent (ocean/workstation fleet access)
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID9TbHc93b0RWSekJcUmlDkw0UulfzkbJqdd0ejfuV2C agent-drago"
+          ];
+        };
       };
 
       # Development shell

--- a/flake.nix
+++ b/flake.nix
@@ -173,6 +173,15 @@
         }
       ];
 
+      # Shared aarch64 SD-image installer module list for Raspberry Pi hosts.
+      piInstallerModules = [
+        "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64-installer.nix"
+        ./modules/sd-installer.nix
+        {
+          nixpkgs.overlays = [ self.overlays.default ];
+        }
+      ];
+
       templateLib = import ./lib/templates.nix {
         inherit
           self
@@ -202,6 +211,20 @@
               }
             ];
           }).config.system.build.isoImage;
+
+        # Build an aarch64 Raspberry Pi SD-image installer with the given SSH
+        # keys baked in. Output is a flashable .img.zst under result/sd-image/.
+        mkInstallerSdImage =
+          {
+            nixpkgs,
+            sshKeys ? [ ],
+          }:
+          (nixpkgs.lib.nixosSystem {
+            system = "aarch64-linux";
+            modules = piInstallerModules ++ [
+              { keystone.piInstaller.sshKeys = sshKeys; }
+            ];
+          }).config.system.build.sdImage;
       };
 
       # ISO configuration without SSH keys (use lib.mkInstallerIso for keys)
@@ -210,6 +233,10 @@
         keystoneIso = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
           modules = installerModules "x86_64-linux";
+        };
+        keystonePiInstaller = nixpkgs.lib.nixosSystem {
+          system = "aarch64-linux";
+          modules = piInstallerModules;
         };
       };
 
@@ -614,6 +641,13 @@
             ;
           keystone-ha-tui-client = pkgs.callPackage ./packages/keystone-ha/tui { };
         };
+
+      # aarch64 Pi SD installer image. Build with:
+      #   nix build .#packages.aarch64-linux.pi-installer
+      # Requires either an aarch64 builder or boot.binfmt.emulatedSystems.
+      packages.aarch64-linux = {
+        pi-installer = self.lib.mkInstallerSdImage { inherit nixpkgs; };
+      };
 
       # Development shell
       devShells.x86_64-linux =

--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -88,6 +88,16 @@ in
       readOnly = true;
       description = "The installer ISO image derivation with SSH keys baked in.";
     };
+
+    sdImage = mkOption {
+      type = types.package;
+      readOnly = true;
+      description = ''
+        The aarch64 Raspberry Pi SD-image installer derivation with SSH keys
+        baked in. Build via `build-pi-installer` or reference from a consumer
+        flake to flash a ready-to-boot installer card.
+      '';
+    };
   };
 
   config = mkIf osCfg.enable {
@@ -157,20 +167,51 @@ in
       in
       isoSystem.config.system.build.isoImage;
 
-    # System-wide build-iso command.
-    # Uses unsafeDiscardStringContext so the ISO isn't built during nixos-rebuild —
+    # Pi SD-image installer — nested aarch64 eval, same SSH keys as the ISO.
+    # Always built for aarch64-linux regardless of host arch; requires an
+    # aarch64 builder or boot.binfmt.emulatedSystems = [ "aarch64-linux" ]
+    # on the building host.
+    keystone.os.installer.sdImage =
+      let
+        sdSystem = import "${pkgs.path}/nixos/lib/eval-config.nix" {
+          system = "aarch64-linux";
+          modules = [
+            "${pkgs.path}/nixos/modules/installer/sd-card/sd-image-aarch64-installer.nix"
+            ./sd-installer.nix
+            {
+              nixpkgs.overlays = [ keystoneInputs.keystoneOverlay ];
+              keystone.piInstaller.sshKeys = installerCfg.sshKeys;
+            }
+          ];
+        };
+      in
+      sdSystem.config.system.build.sdImage;
+
+    # System-wide build commands.
+    # Uses unsafeDiscardStringContext so images aren't built during nixos-rebuild —
     # the .drv file exists from evaluation, but outputs are only realized on demand.
     environment.systemPackages =
       let
-        drvPath = builtins.unsafeDiscardStringContext installerCfg.isoImage.drvPath;
+        isoDrv = builtins.unsafeDiscardStringContext installerCfg.isoImage.drvPath;
+        sdDrv = builtins.unsafeDiscardStringContext installerCfg.sdImage.drvPath;
       in
       [
         (pkgs.writeShellScriptBin "build-iso" ''
           echo "Building installer ISO (${toString (length installerCfg.sshKeys)} SSH keys)..."
-          nix build '${drvPath}^*' -o installer-iso "$@"
+          nix build '${isoDrv}^*' -o installer-iso "$@"
           iso=$(find installer-iso/iso -name '*.iso' 2>/dev/null | head -1)
           if [ -n "$iso" ]; then
             echo "ISO: $iso ($(du -h "$iso" | cut -f1))"
+          fi
+        '')
+        (pkgs.writeShellScriptBin "build-pi-installer" ''
+          echo "Building Pi SD-image installer (${toString (length installerCfg.sshKeys)} SSH keys)..."
+          echo "Note: requires aarch64 builder or boot.binfmt.emulatedSystems = [ \"aarch64-linux\" ]."
+          nix build '${sdDrv}^*' -o pi-installer "$@"
+          img=$(find pi-installer/sd-image -name '*.img.zst' 2>/dev/null | head -1)
+          if [ -n "$img" ]; then
+            echo "Image: $img ($(du -h "$img" | cut -f1))"
+            echo "Flash: zstdcat \"$img\" | sudo dd of=/dev/sdX bs=4M status=progress conv=fsync"
           fi
         '')
       ];

--- a/modules/sd-installer.nix
+++ b/modules/sd-installer.nix
@@ -116,5 +116,23 @@ in
 
     # The aarch64 sd-image-installer profile sets the system to aarch64-linux
     # and uses generic-extlinux-compatible bootloader — nothing else to wire.
+
+    # Why: on first-boot testing (see PR #396), both Pi HDMI connectors
+    # reported disconnected via HPD and vc4 failed with
+    # "Cannot find any crtc or sizes" because /boot/firmware/config.txt was
+    # empty. Force HDMI hotplug and safe mode so the installer always lights
+    # up a screen for interactive recovery, even with quirky monitors/KVMs.
+    # The upstream sd-image-aarch64 profile copies config.txt from the
+    # raspberrypifw store path (mode 0444), so we must restore write
+    # permission before appending. populateFirmwareCommands runs with the
+    # working dir already parent-of `firmware/`, so use a relative path.
+    sdImage.populateFirmwareCommands = lib.mkAfter ''
+      chmod +w firmware/config.txt
+      cat >> firmware/config.txt <<EOF
+      hdmi_force_hotplug=1
+      hdmi_safe=1
+      disable_overscan=1
+      EOF
+    '';
   };
 }

--- a/modules/sd-installer.nix
+++ b/modules/sd-installer.nix
@@ -1,0 +1,120 @@
+# aarch64 SD-image installer for Raspberry Pi
+#
+# Parallel to iso-installer.nix but builds a flashable .img.zst via the
+# upstream sd-image-aarch64-installer profile. Intended to be flashed to an
+# SD card, booted on a Pi, and used as the install/rescue environment for
+# deploying keystone Pi hosts (nixos-anywhere or manual disko + nixos-install).
+#
+# The installer itself boots via extlinux (the stock NixOS aarch64 sd-image
+# bootloader). The *installed* system uses pftf/RPi4 UEFI + systemd-boot per
+# keystone.os.storage.platform = "pi"; nothing on this installer image needs
+# to change when the target system's boot stack changes.
+#
+# Usage (from flake.nix via lib.mkInstallerSdImage):
+#   keystone.piInstaller.sshKeys = [ "ssh-ed25519 AAAAC3..." ];
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  installerCfg = config.keystone.piInstaller;
+in
+{
+  options.keystone.piInstaller = {
+    sshKeys = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "SSH public keys for root access on the Pi SD installer.";
+    };
+
+    version = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0";
+      description = "Installer version embedded in the image basename.";
+    };
+  };
+
+  config = {
+    # The live installer builds the target system before first boot, so it
+    # needs the shared Keystone cache.
+    nix.settings.substituters = lib.mkBefore [ "https://ks-systems.cachix.org" ];
+    nix.settings.trusted-public-keys = lib.mkBefore [
+      "ks-systems.cachix.org-1:Abbd38auzcLIfJUtX7kSD6zdGUU4v831Sb2KfajR5Mo="
+    ];
+
+    # Pi SD cards are slow + usually small memory; zram swap gives nixos-install
+    # some headroom when the cache is cold.
+    zramSwap.enable = true;
+
+    # Key-based root SSH for remote install (nixos-anywhere).
+    services.openssh = {
+      enable = true;
+      settings = {
+        PermitRootLogin = lib.mkForce "yes";
+        PasswordAuthentication = false;
+        PubkeyAuthentication = true;
+      };
+      extraConfig = "UseDNS no";
+    };
+    users.users.root.openssh.authorizedKeys.keys = installerCfg.sshKeys;
+    systemd.services.sshd.wantedBy = lib.mkForce [ "multi-user.target" ];
+
+    # Stock DHCP — no NetworkManager overhead on the installer.
+    networking.wireless.enable = lib.mkForce false;
+    networking.useDHCP = lib.mkForce true;
+
+    # Tools needed for installation + recovery.
+    environment.systemPackages = with pkgs; [
+      git
+      curl
+      wget
+      htop
+      lsof
+      rsync
+      jq
+      parted
+      cryptsetup
+      util-linux
+      dosfstools
+      e2fsprogs
+      nix
+      nixos-install-tools
+      disko
+      shadow
+      iproute2
+      tpm2-tools
+      sbctl
+      # ZFS utilities (installed Pi hosts use ZFS root).
+      config.boot.zfs.package
+    ];
+
+    # ZFS support in the installer so disko/nixos-anywhere can lay down pools.
+    boot.supportedFilesystems = [ "zfs" ];
+    boot.zfs.forceImportRoot = false;
+    boot.kernelModules = [ "zfs" ];
+
+    # ZFS hostId: the sd-image-installer profile already sets one, don't clobber it.
+
+    # Trim docs to keep the image small.
+    documentation.enable = false;
+    documentation.nixos.enable = false;
+
+    # sd-image output filename.
+    image.baseName = lib.mkForce "keystone-pi-installer-${installerCfg.version}";
+
+    # Pin stateVersion so rebuilds don't silently drift.
+    system.stateVersion = "25.05";
+
+    # Expand rootfs on first boot so the installer has working space beyond
+    # the baked-in partition size.
+    sdImage.expandOnBoot = true;
+
+    # Keep a copy of the keystone modules on the installer for offline reference.
+    environment.etc."keystone-modules".source = ../modules;
+
+    # The aarch64 sd-image-installer profile sets the system to aarch64-linux
+    # and uses generic-extlinux-compatible bootloader — nothing else to wire.
+  };
+}


### PR DESCRIPTION
## Summary
- New `modules/sd-installer.nix` — flashable Raspberry Pi installer, parallel to `modules/iso-installer.nix`. Pre-bakes ZFS, disko, nixos-install-tools, root SSH via `keystone.piInstaller.sshKeys`.
- New `lib.mkInstallerSdImage` builder, `nixosConfigurations.keystonePiInstaller`, and `packages.aarch64-linux.pi-installer`.
- Intended as the install/rescue environment for Pi hosts running `keystone.os.storage.platform = "pi"` (see #395). The installed system boots via pftf/RPi4 UEFI + systemd-boot; this installer image itself uses the stock extlinux bootloader and doesn't need pftf.

## Build
```bash
# On an aarch64 host, or with boot.binfmt.emulatedSystems = [ "aarch64-linux" ] on x86:
nix build .#packages.aarch64-linux.pi-installer
# Output: result/sd-image/keystone-pi-installer-0.0.0.img.zst
```

## Flash
```bash
zstdcat result/sd-image/*.img.zst | sudo dd of=/dev/sdX bs=4M status=progress conv=fsync
sudo sync
```

## Deploy flow (end to end)
1. Build + flash this installer to an SD card.
2. Boot Pi, note its IP.
3. From workstation, add a Pi host entry to nixos-config with `storage.platform = "pi"` + `pi.uefiFirmware` (pftf release fetchzip).
4. `nix run github:nix-community/nixos-anywhere -- --flake '.#pi-host' root@<pi-ip>` — nixos-anywhere runs disko remotely, writes ESP (with pftf) + ZFS pool, installs system.
5. Reboot. Pi now boots pftf → systemd-boot → NixOS on ZFS.

## Test plan
- [x] `nix eval .#packages.aarch64-linux.pi-installer.drvPath` succeeds (verified locally)
- [ ] Full build on aarch64 builder / binfmt-emulated x86
- [ ] Flash + boot on Pi 5, verify SSH reachable with baked-in key
- [ ] `nixos-anywhere` deploy onto the booted installer produces a working pi-uefi ZFS system (blocked on #395 landing)
- [ ] x86 ISO path unaffected (`nix build .#iso`)

## Follow-ups (not in this PR)
- `ks build-pi-installer --ssh-key ...` CLI shim paralleling the existing ISO build command
- Bake a default pftf release into the installer so first-boot `ks install` can populate the target ESP without the consumer fetching pftf themselves
- Pi 4 vs Pi 5 device-tree variants (sd-image-aarch64 covers both by default, but worth confirming on hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)