### PR TITLE
docs(conventions): clarify PR issue refs and milestone assignment

### DIFF
--- a/conventions/process.pr-shepherding.md
+++ b/conventions/process.pr-shepherding.md
@@ -23,43 +23,68 @@ verification — without waiting for the user to nudge each step forward.
 
 ## Issue Linkage
 
-6. PRs MUST reference their originating issue in the body using `Closes #N`
-   or `Fixes #N` to auto-close on merge.
-7. If multiple issues are addressed, each MUST be referenced explicitly.
-8. PRs without an originating issue SHOULD still reference related issues
-   with `Refs #N` for traceability.
+6. Every PR MUST link its originating issue in the body. Orphan PRs (no
+   issue) MUST NOT be opened — create the issue first.
+7. Closing keywords (`Closes #N`, `Fixes #N`, `Resolves #N`, case-insensitive)
+   MUST be used ONLY when this PR fully resolves the referenced issue. On
+   merge, the forge auto-closes the issue.
+8. Plain references (`#N`, or the human-readable `Part of #N` /
+   `Contributes to #N`) MUST be used when the PR implements only part of the
+   issue, or is one of several PRs under a tracking issue or epic. The issue
+   MUST remain open after merge so remaining work stays visible.
+9. If multiple issues are addressed, each MUST be referenced explicitly. The
+   closing-vs-plain rule applies per issue — a single PR MAY close one issue
+   while plain-referencing another.
+10. Cross-repo refs MUST use `owner/repo#N` (GitHub) or `org/repo#N`
+    (Forgejo). Bare `#N` is ambiguous across repos.
+
+## Milestone Assignment
+
+11. When a milestone exists for the current work stream, the PR and its
+    originating issue MUST be assigned to it. Milestones are the unit of
+    stakeholder-visible progress — an unassigned PR is invisible on the
+    project board (see `process.project-board`).
+12. Milestones have NO closing keyword. Assignment is via the milestone field
+    on the PR/issue (`gh pr edit N --milestone "<name>"`,
+    `gh issue edit N --milestone "<name>"`), NOT the PR body.
+13. Forges close milestones only when every contained issue is closed —
+    merging a PR does not close its milestone directly.
+14. If no milestone fits, the engineering agent MUST check with the product
+    agent before creating one. Milestones are a product artifact owned by the
+    product archetype (see `process.agentic-team`), not an engineering
+    convenience.
 
 ## Undraft and Review
 
-9.  Once CI is green and all PR-body tasks are checked off, the agent MUST
+15. Once CI is green and all PR-body tasks are checked off, the agent MUST
     mark the PR ready for review (`gh pr ready` on GitHub, remove `WIP:`
     prefix on Forgejo).
-10. The agent MUST request reviewers per `process.code-review-ownership`.
+16. The agent MUST request reviewers per `process.code-review-ownership`.
     Copilot SHOULD also be requested as a supplementary reviewer per
     `process.copilot-agent`.
-11. The agent MUST watch for review feedback and address every comment per
+17. The agent MUST watch for review feedback and address every comment per
     `process.pr-review-response` — fixing or explaining each one, replying
     on the PR, and re-requesting review.
-12. After pushing review fixes, the agent MUST re-watch CI to green before
+18. After pushing review fixes, the agent MUST re-watch CI to green before
     re-requesting review.
 
 ## Merge
 
-13. When CI is green and approval exists, the agent SHOULD enable auto-merge
+19. When CI is green and approval exists, the agent SHOULD enable auto-merge
     via `gh pr merge --auto --squash --delete-branch` on GitHub, or merge
     explicitly on Forgejo per `process.continuous-integration` rules 23-24.
-14. If the repository uses a merge queue, the agent MUST wait for the PR to
+20. If the repository uses a merge queue, the agent MUST wait for the PR to
     enter and exit the queue successfully — not just for the merge button.
-15. When the user has requested merge, the agent MUST stay engaged through
+21. When the user has requested merge, the agent MUST stay engaged through
     the full merge lifecycle (queue entry, queue exit, default branch
     verification) and confirm completion.
 
 ## Post-Merge Verification
 
-16. After merge, the agent MUST verify that the default branch CI is green
+22. After merge, the agent MUST verify that the default branch CI is green
     on the merge commit. If post-merge CI fails, the agent MUST flag it
     immediately.
-17. If the repository has a deploy pipeline, the agent SHOULD watch for
+23. If the repository has a deploy pipeline, the agent SHOULD watch for
     successful deployment and report the outcome.
-18. The agent MUST clean up the worktree after merge per
+24. The agent MUST clean up the worktree after merge per
     `process.feature-delivery`.

--- a/modules/terminal/conventions.nix
+++ b/modules/terminal/conventions.nix
@@ -138,7 +138,14 @@ let
 
         - Push PRs as draft initially. Watch CI to green before undrafting.
         - Once green, undraft, request reviewers (CODEOWNERS + Copilot), and address all review comments.
-        - PRs MUST reference their originating issue. Use `Closes #N` or `Fixes #N` in the PR body to auto-close on merge.
+        - Every PR MUST link its originating issue in the PR body.
+        - Use a **closing keyword** (`Closes #N`, `Fixes #N`, `Resolves #N`) ONLY when this PR fully resolves the issue — the forge auto-closes it on merge.
+        - Use a **plain reference** (`#N`, or `Part of #N` / `Contributes to #N` for clarity) when the PR implements only part of the issue or is one of several PRs under a tracking issue or epic. The issue MUST remain open after merge.
+        - For cross-repo refs use `owner/repo#N` (GitHub) or `org/repo#N` (Forgejo).
+        - If there is no issue, open one first — do not create orphan PRs.
+        - Assign the PR and its originating issue to a **milestone** when one exists for the current work stream. Milestones are the unit of stakeholder-visible progress — an unassigned PR is invisible on the project board.
+        - Milestones have no closing keyword. Assign via the milestone field (`gh pr edit N --milestone "<name>"`), not the PR body.
+        - If no milestone fits, check with the product agent before creating one — milestones are a product artifact, not an engineering convenience.
         - After approval, enable auto-merge or merge explicitly. If a merge queue exists, wait for it to complete.
         - After merge, verify default branch CI is green on the merge commit. Report deployment status if applicable.
         - When the user requests merge, stay engaged through the full lifecycle (queue, verification) and confirm completion.


### PR DESCRIPTION
Distinguish closing keywords (Closes/Fixes/Resolves — auto-close on merge) from plain references (#N, Part of #N — issue stays open) so partial- implementation PRs under a tracking issue do not prematurely close it. Add milestone assignment rules: assign via the milestone field, not the PR body, and defer milestone creation to the product agent.

Updates both the inlined PR shepherding block in modules/terminal/conventions.nix (which ships into every archetype's CLAUDE.md/AGENTS.md/GEMINI.md) and the full process.pr-shepherding convention.