### PR TITLE
fix(desktop): auto-gate Walker Photos on Immich + api-key, warn on missing secret

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -452,6 +452,9 @@
           desktopWalkerSurfaces = import ./tests/module/desktop-walker-surfaces.nix {
             inherit pkgs;
           };
+          desktopPhotosAutoGate = import ./tests/module/desktop-photos-auto-gate.nix {
+            inherit pkgs;
+          };
           desktopAutostartAssertion = import ./tests/module/desktop-autostart-assertion.nix {
             pkgs = ksPkgs;
             lib = ksPkgs.lib;
@@ -509,6 +512,7 @@
           keystone-fingerprint-menu = keystoneFingerprintMenu;
           hyprland-bindings-agent-conflict = hyprlandBindingsAgentConflict;
           desktop-walker-surfaces = desktopWalkerSurfaces;
+          desktop-photos-auto-gate = desktopPhotosAutoGate;
           desktop-autostart-assertion = desktopAutostartAssertion;
           hyprland-config-smoke = hyprlandConfigSmoke;
           ks-approve = ksApprove;
@@ -566,6 +570,7 @@
             mkdir -p "$out"
             ln -s ${hyprlandBindingsAgentConflict} "$out/hyprland-bindings-agent-conflict"
             ln -s ${desktopWalkerSurfaces} "$out/desktop-walker-surfaces"
+            ln -s ${desktopPhotosAutoGate} "$out/desktop-photos-auto-gate"
             ln -s ${desktopAutostartAssertion} "$out/desktop-autostart-assertion"
             ln -s ${hyprlandConfigSmoke} "$out/hyprland-config-smoke"
           '';

--- a/modules/desktop/home/default.nix
+++ b/modules/desktop/home/default.nix
@@ -2,11 +2,25 @@
   config,
   lib,
   pkgs,
+  # Receive the NixOS-level config so that home-manager option defaults can key
+  # off fleet-level and OS-level state (e.g. keystone.services.immich.host,
+  # age.secrets). Follows the pattern used in modules/terminal/default.nix:9.
+  osConfig ? null,
   ...
 }:
 with lib;
 let
   cfg = config.keystone.desktop;
+
+  # Photos auto-enable signals. Fleet Immich host + this user's agenix
+  # api-key secret declaration. When the fleet runs Immich but the secret
+  # is missing, modules/os/users.nix emits a warning with remediation.
+  osc = osConfig;
+  fleetImmichHost = attrByPath [ "keystone" "services" "immich" "host" ] null osc;
+  fleetHasImmich = fleetImmichHost != null;
+  photosUser = config.home.username or null;
+  hasPhotosApiKey =
+    photosUser != null && hasAttrByPath [ "age" "secrets" "${photosUser}-immich-api-key" ] osc;
 in
 {
   imports = [
@@ -63,13 +77,26 @@ in
     };
 
     # Top-level Walker main-menu surfaces. Each gates one hard-coded entry in
-    # keystone-main-menu's main_json via KEYSTONE_MENU_SHOW_* env vars. Default
-    # to keystone.experimental so only stable surfaces appear by default.
+    # keystone-main-menu's main_json via KEYSTONE_MENU_SHOW_* env vars.
+    #
+    # Photos gates on actual Immich availability (fleet Immich host + user's
+    # api-key secret), not on keystone.experimental — hiding the entry on
+    # fleets without Photos is the correct default. agents and contexts
+    # remain keystone.experimental-gated.
     photos.enable = mkOption {
       type = types.bool;
-      default = config.keystone.experimental;
-      defaultText = literalExpression "config.keystone.experimental";
-      description = "Show the Photos entry in the Mod+Escape Walker main menu.";
+      default = fleetHasImmich && hasPhotosApiKey;
+      defaultText = literalExpression ''
+        osConfig.keystone.services.immich.host != null
+        && osConfig.age.secrets ? "<username>-immich-api-key"
+      '';
+      description = ''
+        Show the Photos entry in the Mod+Escape Walker main menu.
+        Auto-enabled when the fleet runs Immich (keystone.services.immich.host)
+        AND the user's agenix secret <username>-immich-api-key is declared.
+        modules/os/users.nix emits a warning with remediation steps when the
+        fleet has Immich but the secret is missing.
+      '';
     };
 
     agents.enable = mkOption {

--- a/modules/os/users.nix
+++ b/modules/os/users.nix
@@ -209,6 +209,35 @@ in
               ''
           ) screenshotUsers
         )
+        ++ concatLists (
+          mapAttrsToList (
+            username: userCfg:
+            optional
+              (
+                userCfg.desktop.enable
+                && immichServiceCfg.host != null
+                && !(config.age.secrets ? "${username}-immich-api-key")
+              )
+              ''
+                Walker Photos is available on this fleet (keystone.services.immich.host = "${immichServiceCfg.host}"), but agenix secret "${username}-immich-api-key" is not declared for user '${username}'.
+
+                The Photos entry in the Walker main menu will stay hidden until the secret exists. To enable it:
+
+                1. Add to agenix-secrets/secrets.nix:
+                   "secrets/${username}-immich-api-key.age".publicKeys = adminKeys ++ [ systems.${hostname} ];
+                2. Create the secret with the user's Immich API key:
+                   cd agenix-secrets && agenix -e secrets/${username}-immich-api-key.age
+                3. If keystone.secrets.repo is null, declare it in host config:
+                   age.secrets.${username}-immich-api-key = {
+                     file = "${"$"}{inputs.agenix-secrets}/secrets/${username}-immich-api-key.age";
+                     owner = "${username}";
+                     mode = "0400";
+                   };
+
+                TODO: automate Immich API key provisioning and secret enrollment from Keystone tooling.
+              ''
+          ) (filterAttrs (_: u: u.desktop.enable) effectiveUsers)
+        )
         ++ optional (hasDesktopModule && length desktopUsernames > 1) ''
           Multiple users have keystone.os.users.<name>.desktop.enable = true. Keystone defaulted keystone.desktop.user to "${inferredDesktopUser}".
 

--- a/tests/module/desktop-photos-auto-gate.nix
+++ b/tests/module/desktop-photos-auto-gate.nix
@@ -1,0 +1,95 @@
+# Red/green gate for GitHub issue #399 (engineering #400) — auto-gate the
+# Walker Photos entry on fleet Immich + user's api-key secret, and emit an
+# eval-time warning with remediation steps when the fleet runs Immich but
+# the secret is missing. Each assertion encodes one ISSUE-REQ from #400.
+# Expected to fail on the base commit and pass once #400 lands.
+{ pkgs }:
+pkgs.runCommand "test-desktop-photos-auto-gate"
+  {
+    nativeBuildInputs = with pkgs; [ gnugrep ];
+  }
+  ''
+    set -euo pipefail
+
+    repo="${../..}"
+    desktop_home="$repo/modules/desktop/home/default.nix"
+    os_users="$repo/modules/os/users.nix"
+
+    fail() {
+      echo "FAIL: $1" >&2
+      exit 1
+    }
+
+    # ISSUE-REQ-1, 5: the module must receive osConfig as an argument so the
+    # default can read fleet-level and OS-level config. `osConfig ? null`
+    # preserves standalone home-manager eval.
+    if ! grep -F 'osConfig ? null' "$desktop_home" >/dev/null; then
+      fail "ISSUE-REQ-1/5: modules/desktop/home/default.nix must accept 'osConfig ? null' as a module argument"
+    fi
+
+    # ISSUE-REQ-1: photos.enable default must read the fleet Immich host.
+    # Using a multiline-friendly pattern since the default is an expression
+    # block spanning several lines.
+    if ! grep -E '"keystone"[[:space:]]+"services"[[:space:]]+"immich"[[:space:]]+"host"' "$desktop_home" >/dev/null \
+      && ! grep -F 'keystone.services.immich.host' "$desktop_home" >/dev/null; then
+      fail "ISSUE-REQ-1: photos.enable default must reference osConfig.keystone.services.immich.host"
+    fi
+
+    # ISSUE-REQ-1: photos.enable default must also require the user's
+    # per-user Immich API key secret declaration.
+    if ! grep -F '-immich-api-key' "$desktop_home" >/dev/null; then
+      fail "ISSUE-REQ-1: photos.enable default must gate on the user's <username>-immich-api-key secret"
+    fi
+    if ! grep -E 'age[[:space:]]*\.?[[:space:]]*secrets|age"[[:space:]]+"secrets' "$desktop_home" >/dev/null; then
+      fail "ISSUE-REQ-1: photos.enable default must read osConfig.age.secrets to detect the api-key secret"
+    fi
+
+    # ISSUE-REQ-3: agents.enable and contexts.enable defaults stay wired to
+    # config.keystone.experimental. Regression guard — starts GREEN, must
+    # stay GREEN after implementation.
+    if ! grep -E 'agents\.enable = mkOption' "$desktop_home" >/dev/null; then
+      fail "ISSUE-REQ-3: agents.enable option must remain declared in modules/desktop/home/default.nix"
+    fi
+    if ! grep -E 'contexts\.enable = mkOption' "$desktop_home" >/dev/null; then
+      fail "ISSUE-REQ-3: contexts.enable option must remain declared in modules/desktop/home/default.nix"
+    fi
+    # Both options must keep their experimental default. Check by counting:
+    # there must still be at least two `default = config.keystone.experimental`
+    # occurrences (one for agents, one for contexts).
+    experimental_defaults=$(grep -c 'default = config.keystone.experimental' "$desktop_home" || true)
+    if [[ "$experimental_defaults" -lt 2 ]]; then
+      fail "ISSUE-REQ-3: agents.enable and contexts.enable must keep default = config.keystone.experimental (found $experimental_defaults occurrences, expected >= 2)"
+    fi
+
+    # ISSUE-REQ-2: modules/os/users.nix must contain a Walker-Photos
+    # warning block, mirroring the screenshotSync warning.
+    if ! grep -F 'Walker Photos' "$os_users" >/dev/null; then
+      fail "ISSUE-REQ-2: modules/os/users.nix must contain a 'Walker Photos' warning block"
+    fi
+
+    # ISSUE-REQ-2: the warning must name the per-user api-key secret by
+    # referencing the Nix interpolation literal ''${username}-immich-api-key.
+    if ! grep -F "\''${username}-immich-api-key" "$os_users" >/dev/null; then
+      fail "ISSUE-REQ-2: the Walker Photos warning must reference the \$\{username\}-immich-api-key secret literal"
+    fi
+
+    # ISSUE-REQ-2: the warning must reference immichServiceCfg.host or
+    # keystone.services.immich.host as the gate it fires under.
+    if ! grep -E 'immichServiceCfg\.host|keystone\.services\.immich\.host' "$os_users" >/dev/null; then
+      fail "ISSUE-REQ-2: the Walker Photos warning must guard on keystone.services.immich.host"
+    fi
+
+    # ISSUE-REQ-2: the warning must list all 3 remediation anchors.
+    if ! grep -F "secrets/\''${username}-immich-api-key.age" "$os_users" >/dev/null; then
+      fail "ISSUE-REQ-2: the Walker Photos warning must list the secrets.nix recipient step (secrets/\$\{username\}-immich-api-key.age)"
+    fi
+    if ! grep -F 'agenix -e secrets' "$os_users" >/dev/null; then
+      fail "ISSUE-REQ-2: the Walker Photos warning must include the 'agenix -e secrets/...' remediation command"
+    fi
+    # The warning must include the age.secrets host declaration snippet.
+    if ! grep -F "age.secrets.\''${username}-immich-api-key" "$os_users" >/dev/null; then
+      fail "ISSUE-REQ-2: the Walker Photos warning must list the age.secrets.\$\{username\}-immich-api-key host declaration"
+    fi
+
+    touch "$out"
+  ''

--- a/tests/module/desktop-photos-auto-gate.nix
+++ b/tests/module/desktop-photos-auto-gate.nix
@@ -37,7 +37,7 @@ pkgs.runCommand "test-desktop-photos-auto-gate"
 
     # ISSUE-REQ-1: photos.enable default must also require the user's
     # per-user Immich API key secret declaration.
-    if ! grep -F '-immich-api-key' "$desktop_home" >/dev/null; then
+    if ! grep -F -- '-immich-api-key' "$desktop_home" >/dev/null; then
       fail "ISSUE-REQ-1: photos.enable default must gate on the user's <username>-immich-api-key secret"
     fi
     if ! grep -E 'age[[:space:]]*\.?[[:space:]]*secrets|age"[[:space:]]+"secrets' "$desktop_home" >/dev/null; then


### PR DESCRIPTION
## Summary
Auto-gate the Walker Photos top-level entry on two signals: the fleet runs Immich (`keystone.services.immich.host`) AND the user has an `<username>-immich-api-key` agenix secret declared. When the fleet runs Immich but the secret is missing, `ks build` emits a warning with concrete agenix remediation steps (mirrors the existing `screenshotSync` warning in `modules/os/users.nix:191-209`).

Parent product issue: #399
Engineering issue: #400

## Task Checklist
- [x] Failing tests committed (\`test(desktop): add failing tests for #399\`)
- [x] Task 1: Tighten \`keystone.desktop.photos.enable\` default to gate on fleet Immich + api-key (ISSUE-REQ-1, 4, 5)
- [x] Task 2: Append Walker-Photos warning to \`modules/os/users.nix\` mirroring the \`screenshotSync\` pattern (ISSUE-REQ-2)
- [x] Task 3: \`agents.enable\` / \`contexts.enable\` defaults regression-guarded via test (ISSUE-REQ-3)

## Test plan
- [x] \`nix build .#checks.x86_64-linux.desktop-photos-auto-gate\` passes (all 13 assertions green)
- [x] \`nix build .#checks.x86_64-linux.check-desktop\` passes locally
- [ ] \`nix flake check --no-build\`
- [ ] \`nix flake check\`
- [ ] \`ks build\` on a host with fleet Immich + secret → Photos visible, no warning
- [ ] \`ks build\` on a host with fleet Immich but secret removed → warning with remediation prints

🤖 Generated with [Claude Code](https://claude.com/claude-code)