### PR TITLE
feat(os): zfs-backup parity with nixos-config (local targets, poolImportServices)

### DIFF
--- a/conventions/os.zfs-backup.md
+++ b/conventions/os.zfs-backup.md
@@ -62,6 +62,48 @@ all configuration auto-derives from that single declaration.
 17. Syncoid SHOULD use `--compress=none` when sending raw-encrypted datasets — the
     data is already incompressible due to encryption.
 
+## Local (Same-Host) Targets
+
+A host MAY replicate a source pool to another pool on the same machine
+(e.g., `"ocean:ocean"` from a host whose hostname is `ocean`). These targets
+MUST be handled without SSH:
+
+17a. When a target's `hostKey` resolves to the current host, the module MUST
+     emit a syncoid command whose `target` is a local dataset path
+     (`<targetPool>/backups/<hostname>/<sourcePool>`) — NOT a
+     `user@host:dataset` URI.
+17b. Local-target syncoid services MUST NOT copy the host SSH key, MUST NOT
+     use `--sshkey`, and MUST NOT register a sync user on the "remote" side —
+     the source and target are the same machine.
+17c. Local-target syncoid services MUST still emit per-target Prometheus
+     metrics via `ExecStopPost`, matching remote targets for dashboard parity.
+17d. The receiver-side code path (sync user, `authorized_keys`, ZFS delegation)
+     MUST skip entries whose sender hostname equals the current hostname —
+     those are local targets, not incoming SSH backups.
+
+## Pool Import Services
+
+Hosts with non-boot ZFS pools (e.g., a secondary `ocean` pool on host `ocean`,
+a `lake` pool on host `maia`) must not start sanoid/syncoid/init services
+until the pool is imported. The module MUST expose a mechanism to wire these
+dependencies without per-host boilerplate in nixos-config.
+
+17e. The module MUST expose
+     `keystone.os.storage.zfs.backup.poolImportServices` as
+     `attrsOf str` — a map from local pool name to the name of the systemd
+     service that imports the pool (e.g., `{ ocean = "import-ocean"; }`).
+17f. For every syncoid service emitted on the sender, if either the source
+     pool OR (for local targets) the target pool has an entry in
+     `poolImportServices`, the service MUST have `after` and `requires`
+     set to the corresponding `<import>.service`.
+17g. On the receiver, the dataset initialization service MUST also depend on
+     the import services of any incoming target pool present in
+     `poolImportServices`, so ZFS delegation does not run before the pool
+     is imported.
+17h. Pools that do not appear in `poolImportServices` (e.g., `rpool`, which
+     is imported during stage-1 boot) MUST NOT contribute dependencies —
+     the option defaults to `{}` and missing pools silently add no deps.
+
 ## SSH Authentication
 
 18. Remote syncoid MUST authenticate using the host's SSH key

--- a/modules/os/default.nix
+++ b/modules/os/default.nix
@@ -385,9 +385,19 @@ in
             default = { };
             description = ''
               Map of local ZFS pool name to the systemd service that imports it.
-              Used to add after/requires dependencies on syncoid services and on
-              the receiver-side dataset initialization service so ZFS replication
-              does not start until non-boot pools are available.
+
+              Applied in two places, both guarded by per-pool membership in
+              this attrset:
+
+              - Sender side: each `syncoid-<name>.service` gains
+                `after`/`requires` on the import services for its source pool
+                and, for same-host (local) targets, its target pool. Syncoid
+                will not attempt replication before the relevant pools exist.
+              - Receiver side: the `zfs-backup-receiver-init.service` unit
+                (which runs `zfs create` and `zfs allow` for every incoming
+                backup) gains `after`/`requires` on the import services for
+                every incoming target pool. Dataset creation and permission
+                delegation cannot run before the target pool is imported.
 
               Only required for pools that are NOT imported automatically at boot
               (e.g., secondary storage pools like `ocean` on ocean or `lake` on maia).

--- a/modules/os/default.nix
+++ b/modules/os/default.nix
@@ -378,6 +378,26 @@ in
             - Or a kernel packages set (e.g., pkgs.linuxPackages_6_12)
           '';
         };
+
+        backup = {
+          poolImportServices = mkOption {
+            type = types.attrsOf types.str;
+            default = { };
+            description = ''
+              Map of local ZFS pool name to the systemd service that imports it.
+              Used to add after/requires dependencies on syncoid services and on
+              the receiver-side dataset initialization service so ZFS replication
+              does not start until non-boot pools are available.
+
+              Only required for pools that are NOT imported automatically at boot
+              (e.g., secondary storage pools like `ocean` on ocean or `lake` on maia).
+            '';
+            example = {
+              ocean = "import-ocean";
+              lake = "import-lake";
+            };
+          };
+        };
       };
     };
 

--- a/modules/os/zfs-backup.nix
+++ b/modules/os/zfs-backup.nix
@@ -231,6 +231,12 @@ let
   uniqueSenderHostnames = unique (map (b: b.senderHostname) incomingBackups);
   incomingTargetPools = unique (map (b: b.targetPool) incomingBackups);
 
+  # Receiver: pool-import service deps for target pools that are NOT
+  # imported at boot (e.g. ocean's `ocean` pool, maia's `lake` pool).
+  # Applied to the dataset-init/delegation oneshot unit so `zfs create` /
+  # `zfs allow` cannot run before the pool is imported.
+  receiverImportDeps = unique (importDepsFor incomingTargetPools);
+
   # ZFS binary (matches kernel module version)
   zfsBin = "${config.boot.zfs.package}/bin/zfs";
 
@@ -412,10 +418,25 @@ in
     })
 
     # --- Receiver: ZFS dataset initialization and permission delegation (convention rules 23-24) ---
+    # Implemented as a systemd oneshot so we can order it after non-boot
+    # pool imports (convention rule 17g). Running as an activation script
+    # would execute before late-imported pools are available.
     (mkIf hasIncomingBackups {
-      system.activationScripts.zfsBackupDatasets = {
-        deps = [ "users" ];
-        text = concatStringsSep "\n" (
+      systemd.services.zfs-backup-receiver-init = {
+        description = "Initialize ZFS backup datasets and delegate permissions";
+        wantedBy = [ "multi-user.target" ];
+        after = [
+          "zfs.target"
+          "zfs-import.target"
+          "local-fs.target"
+        ]
+        ++ receiverImportDeps;
+        requires = receiverImportDeps;
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        script = concatStringsSep "\n" (
           map (backup: ''
             # Create backup dataset hierarchy if it doesn't exist
             if ! ${zfsBin} list ${escapeShellArg "${backup.targetPool}/backups/${backup.senderHostname}/${backup.sourcePool}"} >/dev/null 2>&1; then

--- a/modules/os/zfs-backup.nix
+++ b/modules/os/zfs-backup.nix
@@ -4,7 +4,10 @@
 # user/dataset setup, and Prometheus metrics from keystone.hosts ZFS
 # backup topology.
 #
-# See conventions/os.zfs-backup.md (30 rules)
+# Supports both remote targets (SSH to another host) and local same-host
+# targets (pool-to-pool replication within one machine, no SSH).
+#
+# See conventions/os.zfs-backup.md
 # Follows the journal-remote.nix pattern of auto-deriving from keystone.hosts.
 {
   config,
@@ -18,8 +21,13 @@ let
   hostname = config.networking.hostName;
   hosts = config.keystone.hosts;
 
+  poolImportServices = osCfg.storage.zfs.backup.poolImportServices;
+
   # Find this host's entry in the registry
   currentHostEntry = findFirst (h: h.hostname == hostname) null (attrValues hosts);
+  # Find the *key* (not just the value) for this host — needed for local target matching,
+  # where target strings reference keystone.hosts attribute names (e.g. "ocean:ocean").
+  currentHostKey = findFirst (k: hosts.${k}.hostname == hostname) null (attrNames hosts);
 
   # Sender: does this host declare ZFS backups?
   hasBackups =
@@ -47,8 +55,31 @@ let
     in
     length parts == 2 && elemAt parts 0 != "" && elemAt parts 1 != "";
 
+  # Is this target a same-host (local) target?
+  isLocalTarget = targetStr: (parseTarget targetStr).hostKey == currentHostKey;
+
   # All target strings across all pools (for assertions)
   allTargetStrings = concatMap (pc: pc.targets) (attrValues backupDecls);
+
+  # Build a stable command name per (sourcePool, target) pair.
+  cmdNameFor =
+    sourcePool: targetStr:
+    let
+      parsed = parseTarget targetStr;
+    in
+    if isLocalTarget targetStr then
+      "${sourcePool}-local-${parsed.pool}"
+    else
+      "${sourcePool}-to-${parsed.hostKey}";
+
+  # Import service deps: for a list of pool names, return
+  # [ "import-foo.service" ... ] for any pool that has an entry in
+  # poolImportServices. Missing pools contribute nothing.
+  importDepsFor =
+    pools:
+    concatMap (
+      p: if hasAttr p poolImportServices then [ "${poolImportServices.${p}}.service" ] else [ ]
+    ) pools;
 
   # Build flat list of syncoid command definitions
   syncoidCmds =
@@ -59,37 +90,67 @@ let
           target:
           let
             parsed = parseTarget target;
+            local = isLocalTarget target;
             targetHost = hosts.${parsed.hostKey} or null;
-            sshTarget = if targetHost.sshTarget != null then targetHost.sshTarget else targetHost.hostname;
-            name = "${sourcePool}-to-${parsed.hostKey}";
+            sshTarget =
+              if targetHost != null && targetHost.sshTarget != null then
+                targetHost.sshTarget
+              else if targetHost != null then
+                targetHost.hostname
+              else
+                null;
+            name = cmdNameFor sourcePool target;
             keyDir = "/run/syncoid/${name}";
+            targetDataset = "${parsed.pool}/backups/${hostname}/${sourcePool}";
+            # Local: plain dataset path, no SSH.
+            # Remote: user@host:dataset.
+            finalTarget = if local then targetDataset else "${hostname}-sync@${sshTarget}:${targetDataset}";
+            # Common syncoid flags (convention rules 13-17).
+            commonExtraArgs = [
+              "--no-sync-snap"
+              "--skip-parent"
+              "--exclude-datasets=nix|docker|containers|images|libvirt"
+              "--compress=none"
+            ];
+            # Only remote transfers use the host SSH key via --sshkey.
+            extraArgs =
+              commonExtraArgs
+              ++ (
+                if local then
+                  [ ]
+                else
+                  [
+                    "--sshkey"
+                    "${keyDir}/ssh_key"
+                  ]
+              );
+            # Remote-only service overrides: provision the host SSH key
+            # and allow syncoid's sandbox to read it.
+            remoteServiceOverrides = {
+              serviceConfig = {
+                ExecStartPre = [
+                  "+${pkgs.coreutils}/bin/install -d -m 0700 ${keyDir}"
+                  "+${pkgs.coreutils}/bin/install -m 0600 /etc/ssh/ssh_host_ed25519_key ${keyDir}/ssh_key"
+                ];
+                ReadWritePaths = [ keyDir ];
+                ExecStopPost = [ "${backupMetricsScript} ${name}" ];
+              };
+            };
+            # Local-only service overrides: metrics only, no SSH key prep.
+            localServiceOverrides = {
+              serviceConfig = {
+                ExecStopPost = [ "${backupMetricsScript} ${name}" ];
+              };
+            };
           in
           if targetHost != null then
             [
               (nameValuePair name {
                 source = sourcePool;
-                # convention rules 13-17: raw send, no-sync-snap, skip-parent, exclude, compress
-                target = "${hostname}-sync@${sshTarget}:${parsed.pool}/backups/${hostname}/${sourcePool}";
+                target = finalTarget;
                 sendOptions = "w";
-                extraArgs = [
-                  "--no-sync-snap"
-                  "--skip-parent"
-                  "--exclude-datasets=nix|docker|containers|images|libvirt"
-                  "--compress=none"
-                  "--sshkey"
-                  "${keyDir}/ssh_key"
-                ];
-                # convention rules 18-21: SSH key handling with sandbox fix
-                service = {
-                  serviceConfig = {
-                    ExecStartPre = [
-                      "+${pkgs.coreutils}/bin/install -d -m 0700 ${keyDir}"
-                      "+${pkgs.coreutils}/bin/install -m 0600 /etc/ssh/ssh_host_ed25519_key ${keyDir}/ssh_key"
-                    ];
-                    ReadWritePaths = [ keyDir ];
-                    ExecStopPost = [ "${backupMetricsScript} ${name}" ];
-                  };
-                };
+                inherit extraArgs;
+                service = if local then localServiceOverrides else remoteServiceOverrides;
               })
             ]
           else
@@ -97,6 +158,35 @@ let
         ) poolCfg.targets;
     in
     flatten (mapAttrsToList mkCommands backupDecls);
+
+  # Per-syncoid-service pool-import dependencies. For each syncoid command,
+  # collect import deps for both the source pool and (for local targets) the
+  # target pool.
+  syncoidImportDeps =
+    let
+      mk =
+        sourcePool: poolCfg:
+        concatMap (
+          target:
+          let
+            parsed = parseTarget target;
+            local = isLocalTarget target;
+            name = cmdNameFor sourcePool target;
+            pools = [ sourcePool ] ++ (if local then [ parsed.pool ] else [ ]);
+            deps = unique (importDepsFor pools);
+          in
+          if hosts.${parsed.hostKey} or null != null && deps != [ ] then
+            [
+              (nameValuePair "syncoid-${name}" {
+                after = deps;
+                requires = deps;
+              })
+            ]
+          else
+            [ ]
+        ) poolCfg.targets;
+    in
+    builtins.listToAttrs (flatten (mapAttrsToList mk backupDecls));
 
   # Receiver: find all incoming backup connections targeting this host
   incomingBackups =
@@ -113,7 +203,13 @@ let
                   parsed = parseTarget target;
                   targetHostEntry = hosts.${parsed.hostKey} or null;
                 in
-                if targetHostEntry != null && targetHostEntry.hostname == hostname then
+                if
+                  targetHostEntry != null
+                  && targetHostEntry.hostname == hostname
+                  # Exclude same-host (local) targets — those are handled by the
+                  # sender-side syncoid command, not as incoming SSH backups.
+                  && hostCfg.hostname != hostname
+                then
                   {
                     senderHostname = hostCfg.hostname;
                     senderPublicKey = hostCfg.hostPublicKey;
@@ -133,6 +229,7 @@ let
 
   hasIncomingBackups = incomingBackups != [ ];
   uniqueSenderHostnames = unique (map (b: b.senderHostname) incomingBackups);
+  incomingTargetPools = unique (map (b: b.targetPool) incomingBackups);
 
   # ZFS binary (matches kernel module version)
   zfsBin = "${config.boot.zfs.package}/bin/zfs";
@@ -253,6 +350,13 @@ in
         interval = "hourly";
         commands = builtins.listToAttrs syncoidCmds;
       };
+    })
+
+    # --- Sender: pool-import service dependencies for syncoid services ---
+    # Wire after/requires onto syncoid services whose source or (for local
+    # targets) target pool has an entry in poolImportServices.
+    (mkIf (hasBackups && syncoidImportDeps != { }) {
+      systemd.services = syncoidImportDeps;
     })
 
     # --- Sender: snapshot metrics timer (convention rules 25-26) ---

--- a/tests/module/os-evaluation.nix
+++ b/tests/module/os-evaluation.nix
@@ -17,8 +17,15 @@
 let
   nixosSystem = import "${pkgs.path}/nixos/lib/eval-config.nix";
 
-  eval =
-    name: modules:
+  # Evaluate a config and emit service/socket names. When `check` is
+  # supplied it is called with the evaluated `config` and must return a
+  # shell snippet (runs inside `runCommand`) that fails the build when an
+  # invariant is violated. This turns eval tests into behavioral
+  # assertions rather than shape-only checks.
+  eval = name: modules: evalWith name modules (_: "");
+
+  evalWith =
+    name: modules: check:
     let
       result = nixosSystem {
         system = "x86_64-linux";
@@ -33,13 +40,18 @@ let
       };
       servicesJson = builtins.toJSON (builtins.attrNames result.config.systemd.services);
       socketsJson = builtins.toJSON (builtins.attrNames result.config.systemd.sockets);
+      checkScript = check result.config;
     in
     pkgs.runCommand "eval-${name}" { } ''
       echo "Evaluating ${name}..."
       echo "  Services: ${servicesJson}"
       echo "  Sockets: ${socketsJson}"
+      ${checkScript}
       touch $out
     '';
+
+  # Emit a value via toPretty for grepping in checks.
+  prettyFile = name: v: pkgs.writeText name (lib.generators.toPretty { } v);
 
   tests = {
     minimal-zfs = eval "minimal-zfs" [
@@ -293,132 +305,299 @@ let
       }
     ];
 
-    # ZFS backup with same-host (local) target — ocean backs up rpool → ocean pool on itself
-    zfs-backup-local = eval "zfs-backup-local" [
-      {
-        keystone.hosts = {
-          ocean = {
-            hostname = "ocean";
-            role = "server";
-            hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOcean ocean";
-            zfs = {
-              backups.rpool.targets = [
-                "ocean:ocean"
-                "maia:lake"
-              ];
+    # ZFS backup with same-host (local) target — ocean backs up rpool → ocean pool on itself.
+    # Behavioral: the local target must emit a plain-dataset syncoid command
+    # (no `user@host:` prefix, no `--sshkey`). A regression to `ocean:ocean`
+    # being treated as SSH to host `ocean` would fail this check.
+    zfs-backup-local =
+      evalWith "zfs-backup-local"
+        [
+          {
+            keystone.hosts = {
+              ocean = {
+                hostname = "ocean";
+                role = "server";
+                hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOcean ocean";
+                zfs = {
+                  backups.rpool.targets = [
+                    "ocean:ocean"
+                    "maia:lake"
+                  ];
+                };
+              };
+              maia = {
+                hostname = "maia";
+                role = "server";
+                sshTarget = "maia.ts";
+                hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMaia maia";
+              };
             };
-          };
-          maia = {
-            hostname = "maia";
-            role = "server";
-            sshTarget = "maia.ts";
-            hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMaia maia";
-          };
-        };
-        keystone.os = {
-          enable = true;
-          storage = {
-            type = "zfs";
-            devices = [ "/dev/vda" ];
-          };
-          users.testuser = {
-            fullName = "Test User";
-            initialPassword = "testpass";
-          };
-        };
-        networking.hostName = "ocean";
-        networking.hostId = "deadbeef";
-        fileSystems."/" = {
-          device = lib.mkForce "rpool/crypt/system";
-          fsType = lib.mkForce "zfs";
-        };
-      }
-    ];
+            keystone.os = {
+              enable = true;
+              storage = {
+                type = "zfs";
+                devices = [ "/dev/vda" ];
+              };
+              users.testuser = {
+                fullName = "Test User";
+                initialPassword = "testpass";
+              };
+            };
+            networking.hostName = "ocean";
+            networking.hostId = "deadbeef";
+            fileSystems."/" = {
+              device = lib.mkForce "rpool/crypt/system";
+              fsType = lib.mkForce "zfs";
+            };
+          }
+        ]
+        (
+          config:
+          let
+            cmds = config.services.syncoid.commands or { };
+            localName = "rpool-local-ocean";
+            remoteName = "rpool-to-maia";
+            localCmd = cmds.${localName} or null;
+            remoteCmd = cmds.${remoteName} or null;
+          in
+          ''
+            echo "== zfs-backup-local behavioral checks =="
 
-    # ZFS backup with poolImportServices wired — ocean imports its 'ocean' pool via a custom service
-    zfs-backup-pool-import = eval "zfs-backup-pool-import" [
-      {
-        keystone.hosts = {
-          ocean = {
-            hostname = "ocean";
-            role = "server";
-            hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOcean ocean";
-            zfs = {
-              backups.rpool.targets = [
-                "ocean:ocean"
-                "maia:lake"
-              ];
-            };
-          };
-          maia = {
-            hostname = "maia";
-            role = "server";
-            sshTarget = "maia.ts";
-            hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMaia maia";
-          };
-        };
-        keystone.os = {
-          enable = true;
-          storage = {
-            type = "zfs";
-            devices = [ "/dev/vda" ];
-            zfs.backup.poolImportServices = {
-              ocean = "import-ocean";
-            };
-          };
-          users.testuser = {
-            fullName = "Test User";
-            initialPassword = "testpass";
-          };
-        };
-        networking.hostName = "ocean";
-        networking.hostId = "deadbeef";
-        fileSystems."/" = {
-          device = lib.mkForce "rpool/crypt/system";
-          fsType = lib.mkForce "zfs";
-        };
-      }
-    ];
+            # Assert the local command is declared.
+            if [ "${if localCmd == null then "missing" else "ok"}" != "ok" ]; then
+              echo "FAIL: expected syncoid command '${localName}' for local target 'ocean:ocean'"
+              exit 1
+            fi
 
-    # ZFS backup receiver — host targeted by another host's backups
-    zfs-backup-receiver = eval "zfs-backup-receiver" [
-      {
-        keystone.hosts = {
-          workstation = {
-            hostname = "workstation";
-            role = "client";
-            hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest123 workstation";
-            zfs = {
-              backups.rpool.targets = [
-                "ocean:ocean"
-              ];
+            # Assert the local command's target is a plain dataset path — no '@'
+            # (user@host) and no ':' (host:dataset). A regression to treating
+            # 'ocean:ocean' as an SSH target would produce 'ocean-sync@ocean:ocean/...'.
+            localTarget=${lib.escapeShellArg (if localCmd == null then "" else localCmd.target)}
+            echo "  local target: $localTarget"
+            case "$localTarget" in
+              *@*) echo "FAIL: local target contains '@' (SSH user prefix): $localTarget"; exit 1;;
+              *:*) echo "FAIL: local target contains ':' (SSH host:dataset): $localTarget"; exit 1;;
+            esac
+
+            # Assert the local command does NOT carry --sshkey in extraArgs.
+            localExtraArgs=${
+              prettyFile "local-extra" (if localCmd == null then [ ] else localCmd.extraArgs or [ ])
+            }
+            if ${pkgs.gnugrep}/bin/grep -q -- '--sshkey' "$localExtraArgs"; then
+              echo "FAIL: local syncoid command carries --sshkey"
+              cat "$localExtraArgs"
+              exit 1
+            fi
+
+            # Assert NO command of the SSH-style shape exists for this local target
+            # (i.e. no "rpool-to-ocean" command with an SSH target).
+            ${
+              if cmds ? "rpool-to-ocean" then
+                ''
+                  echo "FAIL: unexpected SSH-style command 'rpool-to-ocean' was emitted for a local target"
+                  exit 1
+                ''
+              else
+                ''
+                  echo "  confirmed no rpool-to-ocean SSH-style command"
+                ''
+            }
+
+            # Sanity: the remote target (maia:lake) still uses SSH-style form.
+            remoteTarget=${lib.escapeShellArg (if remoteCmd == null then "" else remoteCmd.target)}
+            echo "  remote target: $remoteTarget"
+            case "$remoteTarget" in
+              *@*:*) : ;;
+              *) echo "FAIL: remote target is not in user@host:dataset form: $remoteTarget"; exit 1;;
+            esac
+          ''
+        );
+
+    # ZFS backup with poolImportServices wired — ocean imports its 'ocean' pool via a custom service.
+    # Behavioral: the resulting syncoid and receiver-init units must carry
+    # `after`/`requires` on `import-ocean.service`.
+    zfs-backup-pool-import =
+      evalWith "zfs-backup-pool-import"
+        [
+          {
+            keystone.hosts = {
+              ocean = {
+                hostname = "ocean";
+                role = "server";
+                hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOcean ocean";
+                zfs = {
+                  backups.rpool.targets = [
+                    "ocean:ocean"
+                    "maia:lake"
+                  ];
+                };
+              };
+              maia = {
+                hostname = "maia";
+                role = "server";
+                sshTarget = "maia.ts";
+                hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMaia maia";
+              };
             };
-          };
-          ocean = {
-            hostname = "ocean";
-            role = "server";
-            hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOcean ocean";
-          };
-        };
-        keystone.os = {
-          enable = true;
-          storage = {
-            type = "zfs";
-            devices = [ "/dev/vda" ];
-          };
-          users.testuser = {
-            fullName = "Test User";
-            initialPassword = "testpass";
-          };
-        };
-        networking.hostName = "ocean";
-        networking.hostId = "deadbeef";
-        fileSystems."/" = {
-          device = lib.mkForce "rpool/crypt/system";
-          fsType = lib.mkForce "zfs";
-        };
-      }
-    ];
+            keystone.os = {
+              enable = true;
+              storage = {
+                type = "zfs";
+                devices = [ "/dev/vda" ];
+                zfs.backup.poolImportServices = {
+                  ocean = "import-ocean";
+                };
+              };
+              users.testuser = {
+                fullName = "Test User";
+                initialPassword = "testpass";
+              };
+            };
+            networking.hostName = "ocean";
+            networking.hostId = "deadbeef";
+            fileSystems."/" = {
+              device = lib.mkForce "rpool/crypt/system";
+              fsType = lib.mkForce "zfs";
+            };
+          }
+        ]
+        (
+          config:
+          let
+            syncoidUnit = config.systemd.services."syncoid-rpool-local-ocean" or null;
+            receiverUnit = config.systemd.services."zfs-backup-receiver-init" or null;
+            afterFile = prettyFile "syncoid-after" (
+              if syncoidUnit == null then [ ] else syncoidUnit.after or [ ]
+            );
+            requiresFile = prettyFile "syncoid-requires" (
+              if syncoidUnit == null then [ ] else syncoidUnit.requires or [ ]
+            );
+          in
+          ''
+            echo "== zfs-backup-pool-import behavioral checks =="
+
+            if [ "${if syncoidUnit == null then "missing" else "ok"}" != "ok" ]; then
+              echo "FAIL: expected syncoid-rpool-local-ocean unit to exist"
+              exit 1
+            fi
+
+            # Sender side: syncoid unit for the local target must depend on import-ocean.service.
+            if ! ${pkgs.gnugrep}/bin/grep -q 'import-ocean.service' ${afterFile}; then
+              echo "FAIL: syncoid-rpool-local-ocean.after is missing import-ocean.service"
+              cat ${afterFile}
+              exit 1
+            fi
+            if ! ${pkgs.gnugrep}/bin/grep -q 'import-ocean.service' ${requiresFile}; then
+              echo "FAIL: syncoid-rpool-local-ocean.requires is missing import-ocean.service"
+              cat ${requiresFile}
+              exit 1
+            fi
+            echo "  sender syncoid unit depends on import-ocean.service"
+
+            # Receiver side: the dataset-init oneshot must also depend on import-ocean.service.
+            # This host (ocean) receives its own local backup into pool 'ocean'.
+            ${
+              if receiverUnit == null then
+                ''
+                  echo "  (no zfs-backup-receiver-init — host has no incoming backups)"
+                ''
+              else
+                ''
+                  receiverAfter=${prettyFile "recv-after" (receiverUnit.after or [ ])}
+                  receiverRequires=${prettyFile "recv-requires" (receiverUnit.requires or [ ])}
+                  if ! ${pkgs.gnugrep}/bin/grep -q 'import-ocean.service' "$receiverAfter"; then
+                    echo "FAIL: zfs-backup-receiver-init.after is missing import-ocean.service"
+                    cat "$receiverAfter"
+                    exit 1
+                  fi
+                  if ! ${pkgs.gnugrep}/bin/grep -q 'import-ocean.service' "$receiverRequires"; then
+                    echo "FAIL: zfs-backup-receiver-init.requires is missing import-ocean.service"
+                    cat "$receiverRequires"
+                    exit 1
+                  fi
+                  echo "  receiver init unit depends on import-ocean.service"
+                ''
+            }
+          ''
+        );
+
+    # ZFS backup receiver — host targeted by another host's backups.
+    # Behavioral: with poolImportServices set for the incoming target pool,
+    # the zfs-backup-receiver-init unit must carry after/requires on
+    # import-ocean.service.
+    zfs-backup-receiver =
+      evalWith "zfs-backup-receiver"
+        [
+          {
+            keystone.hosts = {
+              workstation = {
+                hostname = "workstation";
+                role = "client";
+                hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest123 workstation";
+                zfs = {
+                  backups.rpool.targets = [
+                    "ocean:ocean"
+                  ];
+                };
+              };
+              ocean = {
+                hostname = "ocean";
+                role = "server";
+                hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOcean ocean";
+              };
+            };
+            keystone.os = {
+              enable = true;
+              storage = {
+                type = "zfs";
+                devices = [ "/dev/vda" ];
+                zfs.backup.poolImportServices = {
+                  ocean = "import-ocean";
+                };
+              };
+              users.testuser = {
+                fullName = "Test User";
+                initialPassword = "testpass";
+              };
+            };
+            networking.hostName = "ocean";
+            networking.hostId = "deadbeef";
+            fileSystems."/" = {
+              device = lib.mkForce "rpool/crypt/system";
+              fsType = lib.mkForce "zfs";
+            };
+          }
+        ]
+        (
+          config:
+          let
+            receiverUnit = config.systemd.services."zfs-backup-receiver-init" or null;
+            afterFile = prettyFile "recv-after" (
+              if receiverUnit == null then [ ] else receiverUnit.after or [ ]
+            );
+            requiresFile = prettyFile "recv-requires" (
+              if receiverUnit == null then [ ] else receiverUnit.requires or [ ]
+            );
+          in
+          ''
+            echo "== zfs-backup-receiver behavioral checks =="
+            if [ "${if receiverUnit == null then "missing" else "ok"}" != "ok" ]; then
+              echo "FAIL: expected zfs-backup-receiver-init unit to exist"
+              exit 1
+            fi
+            if ! ${pkgs.gnugrep}/bin/grep -q 'import-ocean.service' ${afterFile}; then
+              echo "FAIL: zfs-backup-receiver-init.after is missing import-ocean.service"
+              cat ${afterFile}
+              exit 1
+            fi
+            if ! ${pkgs.gnugrep}/bin/grep -q 'import-ocean.service' ${requiresFile}; then
+              echo "FAIL: zfs-backup-receiver-init.requires is missing import-ocean.service"
+              cat ${requiresFile}
+              exit 1
+            fi
+            echo "  receiver init unit depends on import-ocean.service"
+          ''
+        );
   };
 in
 pkgs.runCommand "test-os-evaluation"

--- a/tests/module/os-evaluation.nix
+++ b/tests/module/os-evaluation.nix
@@ -293,6 +293,93 @@ let
       }
     ];
 
+    # ZFS backup with same-host (local) target — ocean backs up rpool → ocean pool on itself
+    zfs-backup-local = eval "zfs-backup-local" [
+      {
+        keystone.hosts = {
+          ocean = {
+            hostname = "ocean";
+            role = "server";
+            hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOcean ocean";
+            zfs = {
+              backups.rpool.targets = [
+                "ocean:ocean"
+                "maia:lake"
+              ];
+            };
+          };
+          maia = {
+            hostname = "maia";
+            role = "server";
+            sshTarget = "maia.ts";
+            hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMaia maia";
+          };
+        };
+        keystone.os = {
+          enable = true;
+          storage = {
+            type = "zfs";
+            devices = [ "/dev/vda" ];
+          };
+          users.testuser = {
+            fullName = "Test User";
+            initialPassword = "testpass";
+          };
+        };
+        networking.hostName = "ocean";
+        networking.hostId = "deadbeef";
+        fileSystems."/" = {
+          device = lib.mkForce "rpool/crypt/system";
+          fsType = lib.mkForce "zfs";
+        };
+      }
+    ];
+
+    # ZFS backup with poolImportServices wired — ocean imports its 'ocean' pool via a custom service
+    zfs-backup-pool-import = eval "zfs-backup-pool-import" [
+      {
+        keystone.hosts = {
+          ocean = {
+            hostname = "ocean";
+            role = "server";
+            hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOcean ocean";
+            zfs = {
+              backups.rpool.targets = [
+                "ocean:ocean"
+                "maia:lake"
+              ];
+            };
+          };
+          maia = {
+            hostname = "maia";
+            role = "server";
+            sshTarget = "maia.ts";
+            hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMaia maia";
+          };
+        };
+        keystone.os = {
+          enable = true;
+          storage = {
+            type = "zfs";
+            devices = [ "/dev/vda" ];
+            zfs.backup.poolImportServices = {
+              ocean = "import-ocean";
+            };
+          };
+          users.testuser = {
+            fullName = "Test User";
+            initialPassword = "testpass";
+          };
+        };
+        networking.hostName = "ocean";
+        networking.hostId = "deadbeef";
+        fileSystems."/" = {
+          device = lib.mkForce "rpool/crypt/system";
+          fsType = lib.mkForce "zfs";
+        };
+      }
+    ];
+
     # ZFS backup receiver — host targeted by another host's backups
     zfs-backup-receiver = eval "zfs-backup-receiver" [
       {


### PR DESCRIPTION
## Summary

Follow-up to #214, which promoted ZFS backup config from `nixos-config` into keystone as `modules/os/zfs-backup.nix`. Two capabilities present in the original `nixos-config/hosts/common/optional/zfs.backup.nix` were not written into `conventions/os.zfs-backup.md` and were therefore lost in the promotion. This PR restores them and documents them.

### Gap 1 — Local same-host targets

`hosts.nix` in nixos-config sets `ocean.zfs.backups.rpool.targets = [ \"ocean:ocean\" \"maia:lake\" ]`. The `\"ocean:ocean\"` entry means \"on host ocean, replicate rpool to the ocean pool locally — no SSH.\" The current keystone module unconditionally builds `${hostname}-sync@${sshTarget}:...` and would try to SSH ocean → ocean.

Now: when a target's `hostKey` resolves to the current host, the syncoid command writes directly to the local dataset path, skips `--sshkey`, does not copy the host SSH key, and is not registered as an incoming SSH backup on the receiver path.

### Gap 2 — `poolImportServices`

Non-boot pools (ocean's `ocean` pool, maia's `lake` pool) need sanoid/syncoid/init services to wait for pool import. The reference module exposed `my.zfs.backup.poolImportServices` and wired `after`/`requires` onto the matching syncoid services.

Now: keystone exposes `keystone.os.storage.zfs.backup.poolImportServices` (attrsOf str). For each syncoid service, if the source pool OR (for local targets) the target pool has an entry, the service gets `after`/`requires = [<import>.service]`.

## Commits

- `feat(os): add poolImportServices option to zfs-backup` — declare the new option under `keystone.os.storage.zfs.backup`.
- `feat(os): support local targets and pool-import deps in zfs-backup` — rework `modules/os/zfs-backup.nix` to detect local targets and wire import-service dependencies.
- `test(os): cover zfs-backup local target and poolImportServices` — two new evaluation cases in `tests/module/os-evaluation.nix`.
- `docs(conventions): document local targets and poolImportServices` — rules 17a-17h in `conventions/os.zfs-backup.md` so the next promotion cannot regress these features.

## Verification

```
nix build .#checks.x86_64-linux.os-evaluation
```

Passes; builds `eval-zfs-backup-local` and `eval-zfs-backup-pool-import` alongside the existing sender/receiver cases.

## Follow-up

Deleting `~/.keystone/repos/ncrmro/nixos-config/hosts/common/optional/zfs.backup.nix` and replacing the consumer config with the keystone module is blocked on this PR merging. That cleanup will be a separate nixos-config PR.

## Test plan

- [ ] `nix build .#checks.x86_64-linux.os-evaluation` passes locally (confirmed)
- [ ] CI passes on GitHub
- [ ] Nixos-config follow-up can remove the legacy module without regressions on ocean (local target) and maia (non-boot lake pool)