### PR TITLE
docs(conventions): add os.systemd-over-activation rule

### DIFF
--- a/conventions/archetypes.yaml
+++ b/conventions/archetypes.yaml
@@ -64,6 +64,7 @@ archetypes:
       - tool.zk-notes
       - process.enable-by-default
       - os.zfs-backup
+      - os.systemd-over-activation
       - tool.stalwart
       - process.vcs-context-continuity
 
@@ -131,6 +132,7 @@ archetypes:
       - tool.github
       - tool.journal-remote
       - os.zfs-backup
+      - os.systemd-over-activation
       - tool.cloudflare-workers
       - tool.zk
       - process.knowledge-management

--- a/conventions/os.systemd-over-activation.md
+++ b/conventions/os.systemd-over-activation.md
@@ -64,10 +64,11 @@ the ZFS backup receiver fix — see `os.zfs-backup` rule 17g.
 ## Observability requirements
 
 9. Any module that provides a long-running or failure-prone systemd oneshot
-   SHOULD expose the unit's state to Prometheus via the
-   `node_systemd` exporter (already enabled fleet-wide) rather than
-   inventing a custom metric for success/failure. See
-   `process.grafana-dashboard-development` for how to surface it.
+   SHOULD expose the unit's state to Prometheus via the node exporter
+   `systemd` collector (for example, the `node_systemd_unit_*` metrics,
+   already enabled fleet-wide) rather than inventing a custom metric for
+   success/failure. See `process.grafana-dashboard-development` for how to
+   surface it.
 
 ## Golden example
 

--- a/conventions/os.systemd-over-activation.md
+++ b/conventions/os.systemd-over-activation.md
@@ -1,0 +1,121 @@
+# Convention: Prefer systemd units over activation scripts (os.systemd-over-activation)
+
+Standards for choosing between `system.activationScripts` and `systemd.services`
+in NixOS modules. The default is **systemd**; activation scripts are the narrow
+exception, not the norm.
+
+This convention exists because `system.activationScripts` is outside systemd's
+dependency graph. Anything that needs ordering against a unit (pool imports,
+network-online, mounts, secret decryption, container runtimes) cannot express
+that edge from an activation script and will race at boot. Rediscovered during
+the ZFS backup receiver fix — see `os.zfs-backup` rule 17g.
+
+## When a systemd oneshot is required
+
+1. `system.activationScripts` MUST NOT be used when the work has any of the
+   following properties:
+   - Invokes a service-touching external binary — anything that talks to a
+     subsystem systemd manages (e.g., `zfs`, `zpool`, `mount`, `umount`,
+     `systemctl`, `docker`, `podman`, `curl`, `openssl`, `ssh`, `pg_dump`,
+     `redis-cli`). Basic coreutils filesystem setup against permitted paths
+     (`mkdir`, `install`, `ln`, `chmod`, `chown` under `/var/lib/<service>`,
+     `/etc`, `/nix`, `/root`) is explicitly exempt and is covered by rules
+     4–5.
+   - Depends on a non-`rpool` ZFS pool, a non-root mount, a network
+     interface, or a service that systemd brings up after activation runs.
+   - Needs to retry, be re-triggered manually, or produce a failure state
+     that is visible in `systemctl status` / `journalctl -u`.
+   - Participates in the systemd ordering graph (expects `After=`,
+     `Requires=`, `Wants=`, `PartOf=`, or `ConditionPathExists=`).
+2. Work that matches any clause in rule 1 MUST be expressed as a
+   `systemd.services.<name>` oneshot with `Type = "oneshot"`,
+   `RemainAfterExit = true`, an explicit `wantedBy` target, and any
+   required `after`/`requires` wiring on services it depends on.
+3. The oneshot unit SHOULD set appropriate hardening options (`ProtectSystem`,
+   `PrivateTmp`, `NoNewPrivileges`, `DynamicUser` where applicable) rather
+   than running fully privileged just because activation scripts do.
+
+## When an activation script is still appropriate
+
+4. `system.activationScripts` MAY be used for work that meets ALL of the
+   following:
+   - Runs entirely against the local filesystem under `/nix`, `/etc`, or a
+     path guaranteed to exist before systemd (`/var/lib`, `/root`).
+   - Has no dependency on any systemd unit, pool, mount, or network state.
+   - Is idempotent and cheap enough to run on every `nixos-rebuild switch`.
+   - Would not benefit from a failure state visible in `systemctl`.
+5. Typical good fits are: creating a directory under `/var/lib/<service>`
+   that a service will own at runtime, writing a static marker file,
+   regenerating a config template that is consumed by a service unit
+   (which is then restarted by the module's normal wiring).
+6. When in doubt, choose a systemd unit. The reverse refactor
+   (systemd → activation script) is almost never required; the forward
+   refactor (activation script → systemd oneshot) is common and disruptive.
+
+## Home-Manager activation
+
+7. `home.activation` is a separate mechanism and is NOT covered by this
+   convention. See `tool.nix` rules 17-21 for home-manager activation
+   script requirements.
+8. Rule 1 still applies in spirit for home-manager: if a home-manager
+   activation step must wait for a user systemd unit or an agenix secret
+   file, express the dependency via `systemd.user.services` instead.
+
+## Observability requirements
+
+9. Any module that provides a long-running or failure-prone systemd oneshot
+   SHOULD expose the unit's state to Prometheus via the
+   `node_systemd` exporter (already enabled fleet-wide) rather than
+   inventing a custom metric for success/failure. See
+   `process.grafana-dashboard-development` for how to surface it.
+
+## Golden example
+
+The ZFS backup receiver initialization was originally written as a
+`system.activationScripts` entry that ran `zfs create` and `zfs allow`
+against backup datasets. On hosts with non-boot ZFS pools (ocean's `ocean`
+pool, maia's `lake` pool), the script raced the systemd pool-import units
+and silently failed when the pool was not yet available. The fix converted
+the work into a systemd oneshot so ordering is enforceable:
+
+```nix
+# WRONG — activation script cannot express "after import-ocean.service"
+system.activationScripts.zfs-backup-receiver-init = {
+  text = ''
+    ${zfs} create -p ocean/backups/workstation/rpool || true
+    ${zfs} allow workstation-sync receive,create,mount,rollback,destroy \
+      ocean/backups/workstation/rpool
+  '';
+};
+
+# RIGHT — systemd oneshot with explicit ordering on the pool-import unit
+systemd.services.zfs-backup-receiver-init = {
+  description = "Initialize ZFS backup receiver datasets and delegations";
+  wantedBy = [ "multi-user.target" ];
+  after = [ "import-ocean.service" ];
+  requires = [ "import-ocean.service" ];
+  serviceConfig = {
+    Type = "oneshot";
+    RemainAfterExit = true;
+  };
+  script = ''
+    ${zfs} create -p ocean/backups/workstation/rpool || true
+    ${zfs} allow workstation-sync receive,create,mount,rollback,destroy \
+      ocean/backups/workstation/rpool
+  '';
+};
+```
+
+The systemd form makes the failure visible in `systemctl status
+zfs-backup-receiver-init`, keeps the work out of the `nixos-rebuild`
+output stream, and — critically — guarantees it does not run until the
+pool is imported. See `os.zfs-backup` rules 17d–17h for the domain-specific
+application of this convention.
+
+## Cross-references
+
+- `os.zfs-backup` — domain application of rule 1, especially for receiver
+  pool-import ordering.
+- `tool.nix` rules 17-21 — home-manager activation script rules (different
+  mechanism, overlapping spirit).
+- `process.grafana-dashboard-development` — surfacing oneshot unit state.

--- a/conventions/os.zfs-backup.md
+++ b/conventions/os.zfs-backup.md
@@ -167,3 +167,10 @@ cat /var/lib/prometheus-node-exporter/zfs_backup_rpool-to-ocean.prom
 # Full fleet check
 ks doctor
 ```
+
+## Related conventions
+
+- `os.systemd-over-activation` — receiver-side dataset initialization and
+  permission delegation MUST run as a systemd oneshot ordered after the
+  relevant pool-import unit, not as a `system.activationScripts` entry.
+  Rule 17g depends on that ordering edge being expressible.

--- a/conventions/tool.nix.md
+++ b/conventions/tool.nix.md
@@ -31,6 +31,12 @@
 15. NixOS modules SHOULD have VM tests (`nixos/tests`) for non-trivial behavior.
 16. Flake checks (`nix flake check`) MUST pass before pushing.
 
+## NixOS System Activation
+
+For NixOS `system.activationScripts` vs `systemd.services` oneshots, see
+`os.systemd-over-activation`. Default to systemd; activation scripts are the
+narrow exception.
+
 ## Home-Manager File Management
 
 17. Config files that the managed tool modifies at runtime MUST NOT use `home.file` with `.text` or `.source`, because home-manager creates an immutable Nix store symlink that the tool cannot write to.

--- a/flake.lock
+++ b/flake.lock
@@ -58,6 +58,39 @@
         "type": "github"
       }
     },
+    "aquamarine_2": {
+      "inputs": {
+        "hyprutils": [
+          "hyprpaper",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprpaper",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprpaper",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprpaper",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772460678,
+        "narHash": "sha256-NYaWs8fYJ38IgFld0hGSdT2LEVhrgO8SiRReBjIH7YY=",
+        "owner": "hyprwm",
+        "repo": "aquamarine",
+        "rev": "5d2cb726b16ee349df443f84b64cff53221b6983",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "aquamarine",
+        "type": "github"
+      }
+    },
     "blueprint": {
       "inputs": {
         "nixpkgs": [
@@ -513,7 +546,7 @@
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_7"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -863,6 +896,46 @@
         "type": "github"
       }
     },
+    "hyprpaper": {
+      "inputs": {
+        "aquamarine": "aquamarine_2",
+        "hyprgraphics": [
+          "hyprland",
+          "hyprgraphics"
+        ],
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "hyprtoolkit": "hyprtoolkit_2",
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "hyprwire": "hyprwire_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_5"
+      },
+      "locked": {
+        "lastModified": 1776428411,
+        "narHash": "sha256-r5UxYGVPFpSZDSeiEFNtFupfO6jiY1SNo4u8LIF/czI=",
+        "owner": "hyprwm",
+        "repo": "hyprpaper",
+        "rev": "14a5fd94fc862a66f60a7331208c59938129ef36",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprpaper",
+        "type": "github"
+      }
+    },
     "hyprtoolkit": {
       "inputs": {
         "aquamarine": [
@@ -907,6 +980,51 @@
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
         "rev": "5cfe0743f0e608e1462972303778d8a0859ee63e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprtoolkit",
+        "type": "github"
+      }
+    },
+    "hyprtoolkit_2": {
+      "inputs": {
+        "aquamarine": [
+          "hyprpaper",
+          "aquamarine"
+        ],
+        "hyprgraphics": [
+          "hyprpaper",
+          "hyprgraphics"
+        ],
+        "hyprlang": [
+          "hyprpaper",
+          "hyprlang"
+        ],
+        "hyprutils": [
+          "hyprpaper",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprpaper",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprpaper",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprpaper",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772462885,
+        "narHash": "sha256-5pHXrQK9zasMnIo6yME6EOXmWGFMSnCITcfKshhKJ9I=",
+        "owner": "hyprwm",
+        "repo": "hyprtoolkit",
+        "rev": "9af245a69fa6b286b88ddfc340afd288e00a6998",
         "type": "github"
       },
       "original": {
@@ -986,6 +1104,35 @@
         "owner": "hyprwm",
         "repo": "hyprwire",
         "rev": "06c7f1f8c4194786c8400653c4efc49dc14c0f3a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprwire",
+        "type": "github"
+      }
+    },
+    "hyprwire_2": {
+      "inputs": {
+        "hyprutils": [
+          "hyprpaper",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprpaper",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprpaper",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772463520,
+        "narHash": "sha256-GIjASzYnV4fK19HnyJKmHyqyxHxIpjusK9foEA4Yo+4=",
+        "owner": "hyprwm",
+        "repo": "hyprwire",
+        "rev": "4e1933ae5602b350c5b6633f5c932549c9b8aca2",
         "type": "github"
       },
       "original": {
@@ -1075,7 +1222,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_5",
+        "systems": "systems_6",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -1380,6 +1527,7 @@
         "himalaya": "himalaya",
         "home-manager": "home-manager_2",
         "hyprland": "hyprland",
+        "hyprpaper": "hyprpaper",
         "kinda-nvim-hx": "kinda-nvim-hx",
         "lanzaboote": "lanzaboote",
         "lfs-s3-src": "lfs-s3-src",
@@ -1565,6 +1713,21 @@
     },
     "systems_5": {
       "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
@@ -1578,7 +1741,7 @@
         "type": "github"
       }
     },
-    "systems_6": {
+    "systems_7": {
       "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
@@ -1593,7 +1756,7 @@
         "type": "github"
       }
     },
-    "systems_7": {
+    "systems_8": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1660,7 +1823,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_6"
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1771062828,

--- a/modules/.deepreview
+++ b/modules/.deepreview
@@ -32,11 +32,13 @@ systemd_over_activation:
          `podman`, `nerdctl`, `curl`, `wget`, `openssl`, `ssh`, `scp`, `rsync`,
          `git` (beyond config-only operations), `pg_dump`, `mysql`, `redis-cli`,
          or any binary that performs I/O against a service → FLAG.
-      2. **Depends on a non-rpool ZFS pool, a non-root mount, a network
-         interface, or a service that comes up later.** Look for references
-         to pool names other than `rpool` (e.g., `ocean`, `lake`, `tank`,
-         `storage`), to mount points outside `/`, `/nix`, `/etc`, `/var`,
-         `/run`, or to URLs/hostnames → FLAG.
+      2. **Depends on a non-rpool ZFS pool, a mount point other than the
+         root filesystem, a network interface, or a service that comes up
+         later.** Look for references to pool names other than `rpool`
+         (e.g., `ocean`, `lake`, `tank`, `storage`), to mount points other
+         than the root filesystem, or to paths rooted somewhere other than
+         `/nix`, `/etc`, `/var`, `/run`, `/root`, or `/var/lib`, or to
+         URLs/hostnames → FLAG.
       3. **Needs retry, manual re-trigger, or failure-state visibility.** If
          the script uses `|| true` to swallow errors, retries in a loop, or
          its failure would meaningfully break a dependent service → FLAG.

--- a/modules/.deepreview
+++ b/modules/.deepreview
@@ -1,0 +1,88 @@
+# =====================================================================
+# Prefer systemd over activation scripts
+# Enforces os.systemd-over-activation: system.activationScripts must not
+# carry work that requires systemd ordering, external binaries, or
+# failure-state visibility. Such work belongs in a systemd oneshot unit.
+# =====================================================================
+systemd_over_activation:
+  description: "Flag system.activationScripts entries that should be systemd oneshot units per os.systemd-over-activation."
+  match:
+    include:
+      - "**/*.nix"
+    exclude:
+      - "desktop/home/**"
+      - "terminal/**"
+      - "notes/**"
+  review:
+    strategy: individual
+    instructions: |
+      This rule enforces `os.systemd-over-activation`. The default in NixOS
+      modules is a systemd oneshot; `system.activationScripts` is the narrow
+      exception. Work that needs ordering, failure visibility, or touches
+      external state MUST be a `systemd.services.<name>` oneshot instead.
+
+      ## What to look for in the diff
+
+      Scan the changed file for any new or modified `system.activationScripts.*`
+      entry. For each one, determine whether it violates any of the rule-1
+      disqualifiers in `conventions/os.systemd-over-activation.md`:
+
+      1. **Invokes a non-trivial external binary.** If the script text contains
+         calls to `zfs`, `zpool`, `mount`, `umount`, `systemctl`, `docker`,
+         `podman`, `nerdctl`, `curl`, `wget`, `openssl`, `ssh`, `scp`, `rsync`,
+         `git` (beyond config-only operations), `pg_dump`, `mysql`, `redis-cli`,
+         or any binary that performs I/O against a service → FLAG.
+      2. **Depends on a non-rpool ZFS pool, a non-root mount, a network
+         interface, or a service that comes up later.** Look for references
+         to pool names other than `rpool` (e.g., `ocean`, `lake`, `tank`,
+         `storage`), to mount points outside `/`, `/nix`, `/etc`, `/var`,
+         `/run`, or to URLs/hostnames → FLAG.
+      3. **Needs retry, manual re-trigger, or failure-state visibility.** If
+         the script uses `|| true` to swallow errors, retries in a loop, or
+         its failure would meaningfully break a dependent service → FLAG.
+         Activation-script failures are buried in rebuild output and have no
+         `systemctl status` equivalent.
+      4. **Expresses or requires ordering against a systemd unit.** If the
+         script comment, script text, or the surrounding module mentions
+         `After=`, `Before=`, `Requires=`, `Wants=`, `PartOf=`, or references
+         another service by name → FLAG. That ordering is inexpressible from
+         an activation script.
+
+      ## What to pass
+
+      Activation scripts that meet ALL of these are acceptable:
+
+      - Operate only on `/nix`, `/etc`, `/var/lib/<service>`, `/root`, or
+        a directory guaranteed by stage-1 boot.
+      - Do not invoke a service-touching external binary.
+      - Are idempotent and cheap on every rebuild.
+      - Do not need failure-state visibility.
+
+      Typical good fits: creating a directory that a service will own at
+      runtime, writing a static marker, regenerating a config template
+      consumed by a unit that is restarted by the module.
+
+      ## How to flag
+
+      For each violating activation script, report:
+
+      - The file and line of the `system.activationScripts.<name>` entry.
+      - Which disqualifier(s) from rules 1-4 above applies, with a quoted
+        excerpt from the script text.
+      - A concrete migration sketch: the equivalent `systemd.services.<name>`
+        oneshot skeleton with `Type = "oneshot"`, `RemainAfterExit = true`,
+        a reasonable `wantedBy`, and the specific `after`/`requires` edges
+        that were impossible to express in the activation script.
+      - A reference to the specific rule number in
+        `conventions/os.systemd-over-activation.md` that is being violated.
+
+      If the diff only modifies an existing acceptable activation script
+      (e.g., fixing a typo in a `mkdir -p /var/lib/foo` entry), return PASS.
+
+      ## Home-Manager exemption
+
+      `home.activation` and `home-manager.users.*.home.activation` are NOT
+      covered by this rule (they are governed by `tool.nix` rules 17-21).
+      If the file under review is a home-manager module, return PASS for
+      any activation entries — those are home-manager, not NixOS system
+      activation.


### PR DESCRIPTION
## Summary
- Add `conventions/os.systemd-over-activation.md` — prefer systemd oneshot units over `system.activationScripts` when work needs ordering, external-binary I/O, failure-state visibility, or retry.
- Add `modules/.deepreview` with a `systemd_over_activation` rule that flags violating activation-script entries on any `modules/**/*.nix` change.
- Wire the new convention into the `engineer` and `keystone-developer` archetypes next to `os.zfs-backup`.
- Cross-reference from `tool.nix` and `os.zfs-backup` (rule 17g depends on this convention being enforced).

## Why now
Rediscovered during PR #403 (zfs-backup parity). The receiver-side ZFS initialization lived in an activation script and silently raced `import-ocean.service` / `import-lake.service` on hosts with non-boot pools — an ordering edge that is structurally inexpressible from an activation script. Converting to a systemd oneshot with `after`/`requires` fixed it. This PR promotes the lesson from zfs-specific to cross-module: any module touching service-owned state should default to systemd.

## Test plan
- [x] `nix build .#keystone-conventions` bundles the new file.
- [x] `nix flake check --no-build` evaluates (pre-existing `agent-evaluation` cache miss unrelated).
- [ ] DeepWork review on a follow-up PR that touches `system.activationScripts` exercises the new rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)