### PR TITLE
fix(os): auto-derive adminUsername from wheel user

### DIFF
--- a/modules/os/default.nix
+++ b/modules/os/default.nix
@@ -27,6 +27,10 @@ with lib;
 let
   cfg = config.keystone.os;
 
+  # Users in keystone.os.users whose extraGroups contains "wheel". Used to
+  # auto-derive adminUsername when the consumer hasn't set it explicitly.
+  wheelUserNames = filter (n: elem "wheel" (cfg.users.${n}.extraGroups or [ ])) (attrNames cfg.users);
+
   # Look up the current host in the registry to access per-host metadata (e.g. baremetal).
   currentHost = findFirst (h: h.hostname == config.networking.hostName) null (
     attrValues config.keystone.hosts
@@ -572,9 +576,21 @@ in
     adminUsername = mkOption {
       type = types.str;
       default = "admin";
+      defaultText = literalExpression ''
+        If exactly one entry in keystone.os.users has "wheel" in extraGroups,
+        that username is used. If multiple wheel users exist, evaluation fails
+        with an assertion (set adminUsername explicitly). Otherwise "admin".
+      '';
       description = ''
-        Unix username for the administrator account. Defaults to "admin".
-        Set via admin.username in mkSystemFlake.
+        Unix username for the administrator account.
+
+        Default resolution precedence:
+          1. An explicit assignment wins (highest precedence).
+          2. If exactly one keystone.os.users entry has "wheel" in extraGroups,
+             that username is used.
+          3. If multiple wheel users exist, evaluation fails — set
+             adminUsername explicitly.
+          4. Otherwise falls back to "admin".
       '';
       example = "noah";
     };
@@ -621,6 +637,12 @@ in
 
   config = mkIf cfg.enable {
     keystone.security.privilegedApproval.enable = mkDefault true;
+
+    # Auto-derive adminUsername when exactly one user has "wheel" in extraGroups.
+    # Multiple wheel users is an explicit error (see assertions below) so the
+    # consumer knows to set adminUsername; zero wheel users falls through to
+    # the literal "admin" default from the option declaration.
+    keystone.os.adminUsername = mkIf (length wheelUserNames == 1) (mkDefault (head wheelUserNames));
 
     nix.settings.substituters = mkIf cfg.binaryCaches.ksSystems.enable (mkBefore [
       cfg.binaryCaches.ksSystems.url
@@ -682,6 +704,21 @@ in
         assertion =
           !cfg.storage.hibernate.enable || cfg.storage.swap.size != "0" && cfg.storage.swap.size != "";
         message = "Hibernation requires swap to be enabled (storage.swap.size must not be '0' or empty)";
+      }
+      # CRITICAL: silently picking one of several wheel users would mislead
+      # downstream consumers that key off adminUsername (e.g. systemFlake.path).
+      # When multiple wheel users exist, adminUsername must be set explicitly
+      # to one of them.
+      {
+        assertion = length wheelUserNames <= 1 || elem cfg.adminUsername wheelUserNames;
+        message = ''
+          keystone.os.users has multiple entries with "wheel" in extraGroups
+          (${concatStringsSep ", " wheelUserNames}), so keystone cannot
+          auto-derive keystone.os.adminUsername. Set it explicitly to one of
+          those usernames, e.g.:
+
+            keystone.os.adminUsername = "${head wheelUserNames}";
+        '';
       }
     ];
 

--- a/tests/module/os-evaluation.nix
+++ b/tests/module/os-evaluation.nix
@@ -41,6 +41,83 @@ let
       touch $out
     '';
 
+  # Evaluate a module set and assert that keystone.os.adminUsername resolves
+  # to the expected value. Used to pin the auto-derivation precedence.
+  assertAdminUsername =
+    name: expected: modules:
+    let
+      result = nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          self.nixosModules.operating-system
+          {
+            system.stateVersion = "25.05";
+            boot.loader.systemd-boot.enable = true;
+          }
+        ]
+        ++ modules;
+      };
+      actual = result.config.keystone.os.adminUsername;
+    in
+    pkgs.runCommand "admin-username-${name}" { } ''
+      if [ "${actual}" != "${expected}" ]; then
+        echo "FAIL: ${name}: expected adminUsername=${expected}, got ${actual}" >&2
+        exit 1
+      fi
+      echo "OK: ${name}: adminUsername=${actual}"
+      touch $out
+    '';
+
+  # Evaluate a module set and assert that the multi-wheel assertion triggers.
+  # The keystone.os.adminUsername itself still resolves (to "admin"), but the
+  # assertion on config.assertions flags the ambiguity. We probe that list.
+  assertMultiWheelError =
+    name: modules:
+    let
+      result = nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          self.nixosModules.operating-system
+          {
+            system.stateVersion = "25.05";
+            boot.loader.systemd-boot.enable = true;
+          }
+        ]
+        ++ modules;
+      };
+      failing = builtins.filter (a: !a.assertion) result.config.assertions;
+      hasExpected = builtins.any (a: lib.hasInfix "multiple entries with \"wheel\"" a.message) failing;
+    in
+    pkgs.runCommand "admin-username-fails-${name}" { } ''
+      ${
+        if hasExpected then
+          ''echo "OK: ${name}: multi-wheel assertion fired"''
+        else
+          ''
+            echo "FAIL: ${name}: expected multi-wheel assertion to fire" >&2
+            exit 1
+          ''
+      }
+      touch $out
+    '';
+
+  # Shared boilerplate for adminUsername tests — minimal storage + filesystem
+  # so the OS module evaluates far enough to populate adminUsername.
+  adminBase = {
+    keystone.os = {
+      enable = true;
+      storage = {
+        type = "zfs";
+        devices = [ "/dev/vda" ];
+      };
+    };
+    networking.hostId = "deadbeef";
+    fileSystems."/" = {
+      device = lib.mkForce "rpool/crypt/system";
+      fsType = lib.mkForce "zfs";
+    };
+  };
+
   tests = {
     minimal-zfs = eval "minimal-zfs" [
       {
@@ -329,6 +406,81 @@ let
         fileSystems."/" = {
           device = lib.mkForce "rpool/crypt/system";
           fsType = lib.mkForce "zfs";
+        };
+      }
+    ];
+
+    # adminUsername auto-derivation: single wheel user wins.
+    admin-username-single-wheel = assertAdminUsername "single-wheel" "alice" [
+      adminBase
+      {
+        keystone.os.users.alice = {
+          fullName = "Alice";
+          extraGroups = [ "wheel" ];
+          initialPassword = "pw";
+        };
+        keystone.os.users.bob = {
+          fullName = "Bob";
+          initialPassword = "pw";
+        };
+      }
+    ];
+
+    # adminUsername auto-derivation: zero wheel users falls back to "admin".
+    admin-username-no-wheel = assertAdminUsername "no-wheel" "admin" [
+      adminBase
+      {
+        keystone.os.users.alice = {
+          fullName = "Alice";
+          initialPassword = "pw";
+        };
+      }
+    ];
+
+    # adminUsername auto-derivation: explicit assignment always wins.
+    admin-username-explicit-wins = assertAdminUsername "explicit-wins" "bob" [
+      adminBase
+      {
+        keystone.os.adminUsername = "bob";
+        keystone.os.users.alice = {
+          fullName = "Alice";
+          extraGroups = [ "wheel" ];
+          initialPassword = "pw";
+        };
+      }
+    ];
+
+    # adminUsername auto-derivation: multiple wheel users fires the assertion.
+    admin-username-multi-wheel-fails = assertMultiWheelError "multi-wheel" [
+      adminBase
+      {
+        keystone.os.users.alice = {
+          fullName = "Alice";
+          extraGroups = [ "wheel" ];
+          initialPassword = "pw";
+        };
+        keystone.os.users.bob = {
+          fullName = "Bob";
+          extraGroups = [ "wheel" ];
+          initialPassword = "pw";
+        };
+      }
+    ];
+
+    # Multi-wheel with explicit adminUsername matching one of them is valid.
+    admin-username-multi-wheel-explicit = assertAdminUsername "multi-wheel-explicit" "bob" [
+      adminBase
+      {
+        keystone.os.adminUsername = "bob";
+        keystone.os.users.alice = {
+          fullName = "Alice";
+          extraGroups = [ "wheel" ];
+          initialPassword = "pw";
+        };
+        keystone.os.users.bob = {
+          fullName = "Bob";
+          extraGroups = [ "wheel" ];
+          initialPassword = "pw";
         };
       }
     ];


### PR DESCRIPTION
Closes #455.

## Problem

`keystone.os.adminUsername` previously defaulted to the literal `"admin"`. Fleets where the real admin is a differently-named user (flagged via `extraGroups = [ "wheel" ]`) silently got the wrong username. During verification of #449/#450 this broke deploys: `keystone.systemFlake.path` is computed from `adminUsername`, so the pointer file was written to `/home/admin/.keystone/...` on hosts whose actual admin is `ncrmro`.

## Change

`adminUsername` now resolves in this order:

1. **Explicit assignment wins** (unchanged — `mkDefault` preserves this).
2. **Single wheel user** — if exactly one `keystone.os.users` entry has `"wheel"` in `extraGroups`, that username becomes the default.
3. **Multiple wheel users** — evaluation fails via an assertion pointing the user at the ambiguity. Silent picking would be worse than crashing.
4. **No wheel users** — falls back to the literal `"admin"` (current behavior).

## Implementation notes

- Computed `wheelUserNames` in the module's top-level `let` block.
- In the `config` block, `keystone.os.adminUsername = mkIf (length wheelUserNames == 1) (mkDefault (head wheelUserNames));` — `mkDefault` keeps explicit assignments winning.
- Added a multi-wheel assertion: `length wheelUserNames <= 1 || elem cfg.adminUsername wheelUserNames`. This lets a consumer disambiguate by explicitly naming the admin.
- Out of scope per the brief: did **not** add a `username` field to the `admin` submodule (the brief's precedence step 2 is a future hook).

## Tests

Added five cases to `tests/module/os-evaluation.nix`:

| Case | Expectation |
|---|---|
| `admin-username-single-wheel` | one wheel user → `adminUsername = "alice"` |
| `admin-username-no-wheel` | zero wheel users → `adminUsername = "admin"` |
| `admin-username-explicit-wins` | explicit assignment beats auto-derivation |
| `admin-username-multi-wheel-fails` | multi-wheel with no explicit setting → assertion fires |
| `admin-username-multi-wheel-explicit` | multi-wheel with explicit setting → valid |

All pass locally:

```
$ nix build .#checks.x86_64-linux.os-evaluation
$ ls -l result
lrwxrwxrwx result -> /nix/store/.../test-os-evaluation
```

## Validation

- `nix build .#checks.x86_64-linux.os-evaluation` — passes, including all 5 new admin-username cases.
- `nix flake check --no-build` — pre-existing store-path error in `keystone-conventions.drv` reproduces on clean `main`; unrelated.
- No deploy run (`ks update` / `ks switch` untouched).