### PR TITLE
fix(os): require explicit users.<name>.admin = true for admin identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ for full control over your configuration.
             storage.devices = [ "/dev/disk/by-id/nvme-..." ];
             users.admin = {
               fullName = "Admin";
-              extraGroups = [ "wheel" ];
+              admin = true;
               authorizedKeys = [ "ssh-ed25519 ..." ];
             };
           };

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -54,15 +54,21 @@ let
         # Tailscale requires hosts registry — template configs don't have one
         tailscale.enable = lib.mkDefault false;
         inherit
-          admin
           adminUsername
-          users
           storage
           secureBoot
           tpm
           ssh
           remoteUnlock
           ;
+        # Merge the admin user into users at adminUsername with admin = true.
+        # This is the single source of truth for administrator identity;
+        # other entries in users are regular (non-admin) users.
+        users = users // {
+          ${adminUsername} = admin // {
+            admin = true;
+          };
+        };
       };
 
       nix.settings.trusted-users = [

--- a/modules/os/default.nix
+++ b/modules/os/default.nix
@@ -12,9 +12,12 @@
 # Usage:
 #   keystone.os = {
 #     enable = true;
-#     admin.fullName = "System Administrator";
 #     storage.devices = [ "/dev/disk/by-id/..." ];
-#     users.alice = { fullName = "Alice"; email = "alice@example.com"; };
+#     users.alice = {
+#       fullName = "Alice";
+#       email = "alice@example.com";
+#       admin = true;  # Exactly one user MUST be flagged admin.
+#     };
 #   };
 #
 {
@@ -33,12 +36,16 @@ let
   );
   isBaremetal = currentHost != null && currentHost.baremetal;
 
-  fullNameFor =
-    name:
-    if name == "admin" && cfg.admin != null then
-      cfg.admin.fullName
-    else
-      config.keystone.os.users.${name}.fullName;
+  # Users explicitly flagged as the fleet administrator.
+  #
+  # CRITICAL: adminUsername and downstream path derivations (systemFlake.path,
+  # admin home directory) need a single unambiguous admin. The users.nix
+  # assertions enforce that exactly one user has admin = true; the derivation
+  # below reads this list without touching adminUsername so there is no cycle
+  # between the option and its consumers.
+  adminFlaggedUserNames = filter (n: cfg.users.${n}.admin or false) (attrNames cfg.users);
+
+  fullNameFor = name: config.keystone.os.users.${name}.fullName;
 
   # User submodule type definition
   userSubmodule = types.submodule (
@@ -79,6 +86,23 @@ let
             "wheel"
             "networkmanager"
           ];
+        };
+
+        admin = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Designate this user as the fleet administrator.
+
+            Exactly one user across keystone.os.users MUST have admin = true.
+            Admin users are automatically added to the wheel group, and their
+            username becomes the default for keystone.os.adminUsername.
+
+            Give additional users that need sudo but are not the canonical
+            admin their own extraGroups = [ "wheel" ] — admin-ness is an
+            identity fact (path derivations, home directory), not an
+            authorization fact.
+          '';
         };
 
         initialPassword = mkOption {
@@ -572,29 +596,22 @@ in
     adminUsername = mkOption {
       type = types.str;
       default = "admin";
+      defaultText = literalExpression ''
+        The name of the keystone.os.users.<name> entry with admin = true.
+        Falls back to the literal "admin" only when no user is flagged —
+        which is itself a configuration error caught by assertion.
+      '';
       description = ''
-        Unix username for the administrator account. Defaults to "admin".
+        Unix username for the administrator account.
+
+        By default this derives from the user flagged
+        keystone.os.users.<name>.admin = true. An explicit assignment still
+        wins (via mkDefault), but MUST name the admin-flagged user —
+        otherwise evaluation fails with an assertion pointing at the drift.
+
         Set via admin.username in mkSystemFlake.
       '';
       example = "noah";
-    };
-
-    admin = mkOption {
-      type = types.nullOr (userSubmodule);
-      default = null;
-      description = ''
-        Canonical default administrator for this Keystone multi-host system.
-        Keystone synthesizes the user account named by adminUsername from this
-        definition and grants administrator privileges automatically.
-      '';
-      example = literalExpression ''
-        {
-          fullName = "System Administrator";
-          email = "admin@example.com";
-          initialPassword = "changeme";
-          terminal.enable = true;
-        }
-      '';
     };
 
     users = mkOption {
@@ -621,6 +638,13 @@ in
 
   config = mkIf cfg.enable {
     keystone.security.privilegedApproval.enable = mkDefault true;
+
+    # Derive adminUsername from the user flagged admin = true.
+    # mkDefault keeps explicit assignments winning; consistency with the
+    # admin flag is validated by assertions in modules/os/users.nix.
+    keystone.os.adminUsername = mkIf (adminFlaggedUserNames != [ ]) (
+      mkDefault (head adminFlaggedUserNames)
+    );
 
     nix.settings.substituters = mkIf cfg.binaryCaches.ksSystems.enable (mkBefore [
       cfg.binaryCaches.ksSystems.url

--- a/modules/os/users.nix
+++ b/modules/os/users.nix
@@ -20,25 +20,21 @@ let
   osCfg = config.keystone.os;
   cfg = osCfg.users;
   adminUsername = osCfg.adminUsername;
-  legacyAdminCfg = if cfg ? admin then cfg.admin else null;
-  effectiveAdminCfg = if osCfg.admin != null then osCfg.admin else legacyAdminCfg;
-  effectiveUsers =
-    (removeAttrs cfg [ "admin" ])
-    // optionalAttrs (effectiveAdminCfg != null) {
-      ${adminUsername} = effectiveAdminCfg // {
-        extraGroups = unique ([ "wheel" ] ++ effectiveAdminCfg.extraGroups);
-      };
-    };
-  # Admin can be either an explicit keystone.os.admin or any user with wheel group
-  hasAdmin =
-    effectiveAdminCfg != null || any (u: elem "wheel" u.extraGroups) (attrValues effectiveUsers);
+
+  # CRITICAL: admin identity is a single fact. Exactly one user has admin =
+  # true; that user owns adminUsername, which downstream derivations
+  # (systemFlake.path, admin home directory) depend on. Authorization is
+  # separate — add extraGroups = [ "wheel" ] to any other user that needs
+  # sudo.
+  adminUsersNames = filter (n: cfg.${n}.admin or false) (attrNames cfg);
+
   keysCfg = config.keystone.keys;
   hostname = config.networking.hostName;
   immichServiceCfg = config.keystone.services.immich;
 
   # Whether the keystone desktop NixOS module is imported (gates home-manager desktop config)
   hasDesktopModule = options.keystone ? desktop;
-  desktopUsers = filterAttrs (_: userCfg: userCfg.desktop.enable) effectiveUsers;
+  desktopUsers = filterAttrs (_: userCfg: userCfg.desktop.enable) cfg;
   desktopUsernames = attrNames desktopUsers;
   inferredDesktopUser = if desktopUsernames == [ ] then null else head desktopUsernames;
   desktopAccessGroups = [
@@ -63,7 +59,7 @@ let
 
   screenshotUsers = filterAttrs (
     _: userCfg: userCfg.desktop.enable && userCfg.desktop.screenshotSync.enable
-  ) effectiveUsers;
+  ) cfg;
 
   immichServerUrl =
     let
@@ -88,7 +84,7 @@ let
 in
 {
   config = mkMerge [
-    (mkIf (osCfg.enable && effectiveUsers != { }) {
+    (mkIf (osCfg.enable && cfg != { }) {
       # Enable ZFS delegation for non-root users (only if using ZFS)
       boot.extraModprobeConfig = mkIf useZfs ''
         options zfs zfs_admin_snapshot=1
@@ -105,12 +101,34 @@ in
       # Assertions
       assertions = [
         {
-          assertion = hasAdmin;
-          message = "Keystone OS requires an administrator — set keystone.os.admin or add a user with 'wheel' in extraGroups.";
+          assertion = length adminUsersNames == 1;
+          message =
+            if adminUsersNames == [ ] then
+              ''
+                Keystone OS requires an administrator. Set admin = true on
+                exactly one entry in keystone.os.users.
+              ''
+            else
+              ''
+                Multiple users are flagged keystone.os.users.<name>.admin = true:
+                ${concatStringsSep ", " adminUsersNames}.
+
+                Exactly one user must be the admin — it owns adminUsername and
+                downstream path derivations. Give the others
+                extraGroups = [ "wheel" ] if they need sudo.
+              '';
         }
         {
-          assertion = !(osCfg.admin != null && legacyAdminCfg != null);
-          message = "Define the administrator in keystone.os.admin, not both keystone.os.admin and keystone.os.users.admin.";
+          # adminUsername must name the admin-flagged user. Explicit assignments
+          # still win (via mkDefault in default.nix) but cannot drift from the
+          # flag — silent mismatch would break systemFlake.path.
+          assertion = adminUsersNames == [ ] || elem adminUsername adminUsersNames;
+          message = ''
+            keystone.os.adminUsername = "${adminUsername}" but that user is
+            not flagged admin = true. Set admin = true on
+            keystone.os.users.${adminUsername} or remove the explicit
+            adminUsername assignment.
+          '';
         }
         {
           assertion =
@@ -123,7 +141,7 @@ in
         {
           assertion =
             let
-              uids = filter (u: u != null) (mapAttrsToList (_: u: u.uid) effectiveUsers);
+              uids = filter (u: u != null) (mapAttrsToList (_: u: u.uid) cfg);
               uniqueUids = unique uids;
             in
             length uids == length uniqueUids;
@@ -137,7 +155,7 @@ in
             assertion = userCfg.desktop.enable;
             message = "User '${username}' enables desktop.screenshotSync but desktop.enable is false.";
           }
-        ) effectiveUsers
+        ) cfg
       )
       ++ optionals (screenshotUsers != { }) [
         {
@@ -175,17 +193,11 @@ in
                 };
             '';
           }
-        ) effectiveUsers
+        ) cfg
       );
 
       warnings =
-        optional (osCfg.admin != null && legacyAdminCfg != null) ''
-          Both keystone.os.admin and keystone.os.users.admin are set. Use keystone.os.admin only.
-        ''
-        ++ optional (osCfg.admin == null && legacyAdminCfg != null) ''
-          keystone.os.users.admin is deprecated. Move the administrator definition to keystone.os.admin.
-        ''
-        ++ concatLists (
+        concatLists (
           mapAttrsToList (
             username: userCfg:
             optional
@@ -235,13 +247,13 @@ in
                   mode = "0400";
                 }
               ))
-            ) effectiveUsers
+            ) cfg
           )
         )
       );
 
       # Enable zsh system-wide if any user has terminal enabled
-      programs.zsh.enable = mkIf (any (u: u.terminal.enable) (attrValues effectiveUsers)) true;
+      programs.zsh.enable = mkIf (any (u: u.terminal.enable) (attrValues cfg)) true;
 
       # Generate NixOS users
       users.users = mapAttrs (username: userCfg: {
@@ -252,6 +264,7 @@ in
         createHome = !useZfs; # Let ZFS dataset provide home when using ZFS
         extraGroups = unique (
           userCfg.extraGroups
+          ++ optionals userCfg.admin [ "wheel" ]
           ++ optionals (hasDesktopModule && userCfg.desktop.enable) desktopAccessGroups
           ++ (optionals useZfs [ "zfs" ])
         );
@@ -260,7 +273,7 @@ in
         # Read all keys from keystone.keys registry
         openssh.authorizedKeys.keys = if keysCfg ? ${username} then keysCfg.${username}.allKeys else [ ];
         shell = mkIf userCfg.terminal.enable pkgs.zsh;
-      }) effectiveUsers;
+      }) cfg;
 
       # Home directory ownership for ext4 (ZFS handles this in its service)
       systemd.services.create-user-homes = mkIf (!useZfs) {
@@ -285,7 +298,7 @@ in
               fi
               chown ${username}:users /home/${username}
               chmod 700 /home/${username}
-            '') effectiveUsers
+            '') cfg
           )}
         '';
       };
@@ -341,12 +354,7 @@ in
     # because the module system only reads the mkIf's `content` attribute.
     (optionalAttrs (options ? home-manager) {
       home-manager =
-        mkIf
-          (
-            osCfg.enable
-            && effectiveUsers != { }
-            && any (u: u.terminal.enable || u.desktop.enable) (attrValues effectiveUsers)
-          )
+        mkIf (osCfg.enable && cfg != { } && any (u: u.terminal.enable || u.desktop.enable) (attrValues cfg))
           {
             useGlobalPkgs = mkDefault true;
             useUserPackages = mkDefault true;
@@ -403,7 +411,7 @@ in
                     };
                   }
                 )
-            ) (filterAttrs (_: u: u.terminal.enable || u.desktop.enable) effectiveUsers);
+            ) (filterAttrs (_: u: u.terminal.enable || u.desktop.enable) cfg);
           };
     })
 

--- a/tests/module/agent-evaluation.nix
+++ b/tests/module/agent-evaluation.nix
@@ -329,6 +329,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
         };
         fileSystems."/" = {
@@ -350,6 +351,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
             terminal.enable = true;
             email = "testuser@example.com";
             capabilities = [ "ks" ];
@@ -375,6 +377,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
             terminal.enable = true;
             email = "testuser@example.com";
             capabilities = [ "ks" ];
@@ -399,6 +402,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents.drago = {
             fullName = "Drago";
@@ -468,6 +472,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents.researcher = {
             fullName = "Research Agent";
@@ -494,6 +499,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents = {
             researcher = {
@@ -528,6 +534,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents.researcher = {
             uid = 4050;
@@ -554,6 +561,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents.researcher = {
             fullName = "Research Agent";
@@ -583,6 +591,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents.researcher = {
             fullName = "Research Agent";
@@ -613,6 +622,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents.researcher = {
             fullName = "Research Agent";
@@ -638,6 +648,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents.researcher = {
             fullName = "Research Agent";
@@ -667,6 +678,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents.drago = {
             fullName = "Drago";
@@ -692,6 +704,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents.drago = {
             fullName = "Drago";
@@ -820,6 +833,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents.researcher = {
             fullName = "Research Agent";
@@ -851,6 +865,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
           agents.researcher = {
             fullName = "Research Agent";
@@ -986,6 +1001,7 @@ let
             users.testuser = {
               fullName = "Test User";
               initialPassword = "testpass";
+              admin = true;
               desktop = {
                 enable = true;
                 screenshotSync.enable = true;

--- a/tests/module/os-evaluation.nix
+++ b/tests/module/os-evaluation.nix
@@ -41,6 +41,83 @@ let
       touch $out
     '';
 
+  # Evaluate a module set and assert keystone.os.adminUsername resolves
+  # to `expected`. Pins the auto-derivation from the admin flag.
+  assertAdminUsername =
+    name: expected: modules:
+    let
+      result = (import "${pkgs.path}/nixos/lib/eval-config.nix") {
+        system = "x86_64-linux";
+        modules = [
+          self.nixosModules.operating-system
+          {
+            system.stateVersion = "25.05";
+            boot.loader.systemd-boot.enable = true;
+          }
+        ]
+        ++ modules;
+      };
+      actual = result.config.keystone.os.adminUsername;
+    in
+    pkgs.runCommand "admin-username-${name}" { } ''
+      if [ "${actual}" != "${expected}" ]; then
+        echo "FAIL: ${name}: expected adminUsername=${expected}, got ${actual}" >&2
+        exit 1
+      fi
+      echo "OK: ${name}: adminUsername=${actual}"
+      touch $out
+    '';
+
+  # Evaluate a module set and assert at least one failing assertion contains
+  # `expectedText`. adminUsername itself still resolves (to its default) —
+  # the assertion list is what flags the invalid config.
+  assertHasFailingAssertion =
+    name: expectedText: modules:
+    let
+      result = (import "${pkgs.path}/nixos/lib/eval-config.nix") {
+        system = "x86_64-linux";
+        modules = [
+          self.nixosModules.operating-system
+          {
+            system.stateVersion = "25.05";
+            boot.loader.systemd-boot.enable = true;
+          }
+        ]
+        ++ modules;
+      };
+      failing = builtins.filter (a: !a.assertion) result.config.assertions;
+      matched = builtins.any (a: lib.hasInfix expectedText a.message) failing;
+    in
+    pkgs.runCommand "admin-assertion-${name}" { } ''
+      ${
+        if matched then
+          ''echo "OK: ${name}: assertion containing '${expectedText}' fired"''
+        else
+          ''
+            echo "FAIL: ${name}: expected a failing assertion containing '${expectedText}'" >&2
+            exit 1
+          ''
+      }
+      touch $out
+    '';
+
+  # Minimal storage + fs so the OS module evaluates far enough to populate
+  # users and assertions. Shared by every admin-flag test below.
+  adminBase = {
+    keystone.os = {
+      enable = true;
+      storage = {
+        type = "zfs";
+        devices = [ "/dev/vda" ];
+      };
+    };
+    networking.hostId = "deadbeef";
+    fileSystems."/" = {
+      device = lib.mkForce "rpool/crypt/system";
+      fsType = lib.mkForce "zfs";
+    };
+  };
+
   tests = {
     minimal-zfs = eval "minimal-zfs" [
       {
@@ -53,6 +130,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
         };
         networking.hostId = "deadbeef";
@@ -98,7 +176,7 @@ let
           users.admin = {
             fullName = "Admin User";
             email = "admin@example.com";
-            extraGroups = [ "wheel" ];
+            admin = true;
             initialPassword = "adminpass";
             terminal.enable = true;
             zfs.quota = "100G";
@@ -123,6 +201,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
         };
         fileSystems."/" = {
@@ -145,6 +224,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
         };
         fileSystems."/" = {
@@ -172,6 +252,7 @@ let
             users.testuser = {
               fullName = "Test User";
               initialPassword = "testpass";
+              admin = true;
             };
           };
         };
@@ -203,6 +284,7 @@ let
             users.testuser = {
               fullName = "Test User";
               initialPassword = "testpass";
+              admin = true;
             };
           };
         };
@@ -233,6 +315,7 @@ let
             users.testuser = {
               fullName = "Test User";
               initialPassword = "testpass";
+              admin = true;
             };
           };
         };
@@ -282,6 +365,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
         };
         networking.hostName = "workstation";
@@ -322,6 +406,7 @@ let
           users.testuser = {
             fullName = "Test User";
             initialPassword = "testpass";
+            admin = true;
           };
         };
         networking.hostName = "ocean";
@@ -329,6 +414,78 @@ let
         fileSystems."/" = {
           device = lib.mkForce "rpool/crypt/system";
           fsType = lib.mkForce "zfs";
+        };
+      }
+    ];
+
+    # Single admin flag → adminUsername derives to that user.
+    admin-username-single-admin = assertAdminUsername "single-admin" "alice" [
+      adminBase
+      {
+        keystone.os.users.alice = {
+          fullName = "Alice";
+          initialPassword = "pw";
+          admin = true;
+        };
+        keystone.os.users.bob = {
+          fullName = "Bob";
+          initialPassword = "pw";
+        };
+      }
+    ];
+
+    # Explicit adminUsername matching the admin flag → valid.
+    admin-username-explicit-matches = assertAdminUsername "explicit-matches" "alice" [
+      adminBase
+      {
+        keystone.os.adminUsername = "alice";
+        keystone.os.users.alice = {
+          fullName = "Alice";
+          initialPassword = "pw";
+          admin = true;
+        };
+      }
+    ];
+
+    # No admin-flagged user → "requires an administrator" assertion fires.
+    admin-username-no-admin-fails = assertHasFailingAssertion "no-admin" "requires an administrator" [
+      adminBase
+      {
+        keystone.os.users.alice = {
+          fullName = "Alice";
+          initialPassword = "pw";
+        };
+      }
+    ];
+
+    # Two admin-flagged users → "Multiple users are flagged" assertion fires.
+    admin-username-multi-admin-fails =
+      assertHasFailingAssertion "multi-admin" "Multiple users are flagged"
+        [
+          adminBase
+          {
+            keystone.os.users.alice = {
+              fullName = "Alice";
+              initialPassword = "pw";
+              admin = true;
+            };
+            keystone.os.users.bob = {
+              fullName = "Bob";
+              initialPassword = "pw";
+              admin = true;
+            };
+          }
+        ];
+
+    # Explicit adminUsername disagreeing with the admin flag → mismatch assertion fires.
+    admin-username-mismatch-fails = assertHasFailingAssertion "mismatch" "not flagged admin = true" [
+      adminBase
+      {
+        keystone.os.adminUsername = "bob";
+        keystone.os.users.alice = {
+          fullName = "Alice";
+          initialPassword = "pw";
+          admin = true;
         };
       }
     ];


### PR DESCRIPTION
Closes #455. Replaces #456.

## Problem

`keystone.os.adminUsername` defaulted to the literal `"admin"`. Downstream derivations (`systemFlake.path`, admin home directory, notebook roots) silently pointed at `/home/admin/...` on hosts whose actual admin was a differently-named user. The previous signal for "who is the admin" was heuristic: "any user with `wheel` in `extraGroups`" or a separate `keystone.os.admin` submodule — which conflated *authorization* (sudo) with *identity* (path derivation) and silently picked a candidate when multiple wheel users existed.

## Change

Admin identity is now a single declarative fact on the user:

```nix
keystone.os.users.alice = {
  fullName = "Alice";
  admin = true;   # exactly one user in users MUST set this
};
```

Behavior:

1. `admin = true` auto-adds `wheel` to the user's `extraGroups` (admin ⇒ sudo, not the reverse).
2. `keystone.os.adminUsername` defaults (via `mkDefault`) to the admin-flagged user's name.
3. Explicit `adminUsername` assignments still win, but **must** name the admin-flagged user — mismatch fails eval.
4. Zero or multiple admin-flagged users fail eval with a helpful assertion.

Give additional users sudo by adding `extraGroups = [ "wheel" ]` directly — they're authorized but not the canonical admin.

## Removed

- `keystone.os.admin` submodule (separate singleton for the canonical admin).
- Legacy `keystone.os.users.admin` literal fallback.
- The wheel-group-sniffing heuristic for admin identity.

## Public API preserved

`mkSystemFlake { admin = { username, fullName, sshKeys, ... }; }` continues to work unchanged. Internally the helper now writes `keystone.os.users.<username>.admin = true` instead of setting the removed `keystone.os.admin` submodule — so every existing consumer flake evaluates as before.

## Tests

Added five cases in `tests/module/os-evaluation.nix`:

| Case | Expectation |
|---|---|
| `admin-username-single-admin` | one `admin = true` user → `adminUsername` derives to that user |
| `admin-username-explicit-matches` | explicit `adminUsername` matching the flag is valid |
| `admin-username-no-admin-fails` | zero admins → "requires an administrator" assertion fires |
| `admin-username-multi-admin-fails` | two admins → "Multiple users are flagged" assertion fires |
| `admin-username-mismatch-fails` | explicit `adminUsername` disagreeing with the flag → mismatch assertion fires |

Existing nine fixtures updated to mark their test user `admin = true`.

## Validation

```
$ nix build .#checks.x86_64-linux.os-evaluation
# 6 new derivations build clean; existing 9 fixtures still evaluate.

$ nix build .#checks.x86_64-linux.template-evaluation --rebuild
# Output JSON byte-for-byte matches the pre-refactor cache — mkSystemFlake
# produces an identical NixOS config for all 10 template archetypes.
```

`nix flake check --no-build` reproduces a pre-existing `keystone-conventions.drv` store-path error on clean `main` that is unrelated to this change.

## Why replace #456

#456 extended the wheel-sniffing heuristic to also derive `adminUsername`. That preserved the root cause — admin-ness keyed off an authorization group — and turned any second wheel user into an eval-time crash. This PR instead makes admin identity explicit and orthogonal to wheel, which is the shape the rest of the module should converge on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)