### PR TITLE
test(desktop): align hyprpaper smoke test with block-form wallpaper rendering

### DIFF
--- a/tests/module/hyprland-config-smoke.nix
+++ b/tests/module/hyprland-config-smoke.nix
@@ -85,8 +85,10 @@ pkgs.runCommand "hyprland-config-smoke"
 
     assert_contains "${hyprpaperConf}" "preload=/home/testuser/.config/keystone/current/background" \
       "hyprpaper preloads the theme background before assigning wallpaper"
-    assert_contains "${hyprpaperConf}" "wallpaper=,/home/testuser/.config/keystone/current/background" \
-      "hyprpaper assigns the theme background to all monitors"
+    assert_contains "${hyprpaperConf}" "monitor=*" \
+      "hyprpaper wallpaper block targets all monitors with wildcard"
+    assert_contains "${hyprpaperConf}" "path=/home/testuser/.config/keystone/current/background" \
+      "hyprpaper wallpaper block points at the theme background"
 
     assert_contains "${hypridleConf}" "lock_cmd=pidof hyprlock || hyprlock" \
       "hypridle lock command invokes hyprlock"


### PR DESCRIPTION
## Why

The `validate / desktop` job has been failing on `main` since commit
[`df4c7bf8`](https://github.com/ncrmro/keystone/commit/df4c7bf8)
(`fix(desktop): use wallpaper block form with monitor=* for hyprpaper 0.8.3+`).
That commit correctly migrated `modules/desktop/home/hyprland/hyprpaper.nix`
from the legacy bare-shorthand wallpaper form to the hyprlang
special-category block form, but did not update
`tests/module/hyprland-config-smoke.nix`, which still asserts the old
`wallpaper=,<path>` shorthand line.

This pre-existing failure is also blocking PR #466, which surfaces the
same `validate / desktop` failure unrelated to its own changes.

## What

Update the hyprpaper assertion to match the rendered block form. The
home-manager generator renders `services.hyprpaper.settings.wallpaper`
as:

```
wallpaper {
  monitor=*
  path=/home/testuser/.config/keystone/current/background
}
```

(`importantPrefixes` includes `"monitor"`, so the `monitor=` line is
emitted before `path=`.)

The single broken assertion is replaced with two `assert_contains`
calls — one for `monitor=*` and one for the `path=` line — keeping the
same `grep -F` substring style used by every other assertion in the
file. No other assertions are touched.

## Test plan

- [x] `nix build .#checks.x86_64-linux.hyprland-config-smoke` — all 16 PASS lines, including the new wallpaper block assertions
- [x] `nix build .#checks.x86_64-linux.check-desktop` — green
- [ ] CI `validate / desktop` passes on this PR
- [ ] Re-run PR #466 after this lands; it should no longer hit the same `validate / desktop` failure

## References

- Module change that introduced the rendering mismatch: `df4c7bf8`
- Failing run on main: https://github.com/ncrmro/keystone/actions/runs/24869191662/job/72811832693
- Failing run on PR #466 (same root cause): https://github.com/ncrmro/keystone/actions/runs/24935674426/job/73020718822