### PR TITLE
fix(desktop): walker top-level update entry must use ks-update.service (#414)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -403,6 +403,10 @@
             pkgs = ksPkgs;
             inherit ks;
           };
+          approveExecScript = import ./tests/module/approve-exec-script.nix {
+            pkgs = ksPkgs;
+            lib = ksPkgs.lib;
+          };
           ksDoctorReport = import ./tests/module/ks-doctor-report.nix {
             inherit pkgs;
           };
@@ -531,6 +535,7 @@
           desktop-autostart-assertion = desktopAutostartAssertion;
           hyprland-config-smoke = hyprlandConfigSmoke;
           ks-approve = ksApprove;
+          approve-exec-script = approveExecScript;
           ks-doctor-report = ksDoctorReport;
           ks-rust-tests = ksRustTests;
           ks-rust-clippy = ksRustClippy;
@@ -564,6 +569,7 @@
             ln -s ${ksHelp} "$out/help"
             ln -s ${ksPhotos} "$out/photos"
             ln -s ${ksApprove} "$out/approve"
+            ln -s ${approveExecScript} "$out/approve-exec-script"
             ln -s ${ksDoctorReport} "$out/doctor-report"
             ln -s ${ksLockSync} "$out/lock-sync"
           '';

--- a/modules/desktop/home/scripts/keystone-main-menu.sh
+++ b/modules/desktop/home/scripts/keystone-main-menu.sh
@@ -150,7 +150,7 @@ main_json() {
       },
       {
         Text: "Update",
-        Subtext: "Run ks update in a terminal",
+        Subtext: "Update this host (silent, polkit-approved)",
         Value: "run-update",
         Icon: "software-update-available-symbolic"
       },
@@ -433,7 +433,14 @@ dispatch() {
       detach "$(keystone_cmd keystone-screenrecord)"
       ;;
     run-update)
-      detach ghostty -e ks update
+      # CRITICAL: delegate to the dedicated update submenu's dispatch path
+      # so the top-level Walker entry uses the supervised ks-update.service
+      # flow (polkit prompt via hyprpolkitagent, silent success path,
+      # journaled failure) instead of spawning a terminal. The legacy
+      # `ghostty -e ks update` ceremony was retired by #404 in the dedicated
+      # submenu but survived here until #414. Any change to the unit-firing
+      # contract belongs in update_menu.rs::dispatch, not duplicated here.
+      ks menu update dispatch run-update
       ;;
     screenshot-smart)
       detach "$(keystone_cmd keystone-screenshot)" smart

--- a/modules/desktop/home/services.nix
+++ b/modules/desktop/home/services.nix
@@ -74,6 +74,17 @@ in
       };
       Service = {
         Type = "oneshot";
+        # CRITICAL: import the graphical-session env from the user manager.
+        # `ks update --approve` calls `cmd::approve::has_graphical_session()`
+        # which checks DISPLAY / WAYLAND_DISPLAY / XDG_SESSION_TYPE to decide
+        # between pkexec (graphical, polkit prompt) and sudo (terminal).
+        # systemd user units start with a near-empty environment, so without
+        # PassEnvironment the function returns false, ks falls back to sudo,
+        # sudo finds no tty, and the unit silently exits 1 in milliseconds.
+        # XDG_RUNTIME_DIR + DBUS_SESSION_BUS_ADDRESS are required for pkexec
+        # to reach hyprpolkitagent on the user bus — without them the polkit
+        # prompt never renders and authentication fails silently.
+        PassEnvironment = "DISPLAY WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS";
         Environment = [
           "PATH=${updatePath}"
           "KS_UPDATE_CHANNEL=${updateChannel}"

--- a/modules/os/scripts/approve-exec.sh
+++ b/modules/os/scripts/approve-exec.sh
@@ -21,7 +21,20 @@ die() {
 join_argv_json() {
   # shellcheck disable=SC2016
   # jq filter is intentionally single-quoted.
-  "$JQ" -cn --args "$@" '$ARGS.positional'
+  #
+  # CRITICAL: two jq argv quirks both bite this helper:
+  #   1. The filter program MUST come before `--args`, otherwise jq treats
+  #      the filter as just another positional, finds no filter, falls back
+  #      to interpreting the first positional ("ks") as a filter, and dies
+  #      with "jq: error: ks/0 is not defined".
+  #   2. `--args` only consumes non-option-shaped tokens as positionals; any
+  #      `--flag` after `--args` (e.g. `ks update --approve`,
+  #      `keystone-enroll-fido2 --auto`) is parsed as a jq option unless a
+  #      `--` separator immediately follows `--args`.
+  # Both bites only manifest in non-tty contexts (e.g. ks-update.service
+  # invoking `ks update --approve`); interactive callers historically went
+  # through a tty path that bypassed this helper entirely.
+  "$JQ" -cn '$ARGS.positional' --args -- "$@"
 }
 
 match_entry_json() {

--- a/tests/module/approve-exec-script.nix
+++ b/tests/module/approve-exec-script.nix
@@ -1,0 +1,148 @@
+# approve-exec-script — regression test for the real approve-exec.sh helper.
+#
+# `tests/module/ks-approve.nix` covers `ks approve` end-to-end with a STUBBED
+# helper, so it doesn't catch bugs in the script itself. This test exercises
+# the real `modules/os/scripts/approve-exec.sh` against a fixture allowlist,
+# in `--validate` mode (no root, no exec), and asserts the matched-entry
+# JSON is produced.
+#
+# The bug this guards against: jq's `--args` consumes ALL following arguments
+# as positionals — including what would otherwise be the filter. Writing
+# `jq -cn --args "$@" '$ARGS.positional'` makes jq treat the filter as just
+# another positional, leaving no filter, which it then tries to compile from
+# the first positional ("ks") and dies with "ks/0 is not defined". The fix
+# is `jq -cn '$ARGS.positional' --args "$@"`. This bug went undetected from
+# 2026-03-31 to 2026-04-28 because every interactive caller has a tty and
+# the stubbed helper is what unit tests saw.
+{
+  pkgs,
+  lib ? pkgs.lib,
+}:
+let
+  scriptSrc = ../../modules/os/scripts/approve-exec.sh;
+
+  # Fixture allowlist: minimal copy of the production schema with one
+  # exact-match entry and one prefix-match entry. The script reads the
+  # config path baked in at substitution time.
+  fixtureConfig = pkgs.writeText "approve-exec-fixture.json" (
+    builtins.toJSON {
+      backend = "desktop-polkit";
+      commands = [
+        {
+          name = "ks-update";
+          displayName = "Run Keystone update";
+          reason = "Run the Keystone update workflow for this host.";
+          runAs = "root";
+          approvalMethods = [ "password" ];
+          match = "prefix";
+          argv = [
+            "ks"
+            "update"
+          ];
+        }
+        {
+          name = "keystone-enroll-fido2-auto";
+          displayName = "Enroll hardware key for disk unlock";
+          reason = "Enroll a FIDO2 hardware key for disk unlock.";
+          runAs = "root";
+          approvalMethods = [ "password" ];
+          match = "exact";
+          argv = [
+            "keystone-enroll-fido2"
+            "--auto"
+          ];
+        }
+      ];
+    }
+  );
+
+  # Build the helper exactly the way privileged-approval.nix does: substitute
+  # @configFile@ and @jq@, then make it executable. Keeps the test honest
+  # about the production substitution path.
+  helperScript = pkgs.runCommand "approve-exec-test-helper" { } ''
+    cp ${
+      pkgs.replaceVars scriptSrc {
+        configFile = "${fixtureConfig}";
+        jq = "${pkgs.jq}/bin/jq";
+      }
+    } $out
+    chmod +x $out
+  '';
+in
+pkgs.runCommand "test-approve-exec-script"
+  {
+    nativeBuildInputs = with pkgs; [
+      bash
+      coreutils
+      gnugrep
+      jq
+    ];
+  }
+  ''
+    set -euo pipefail
+
+    fail() {
+      echo "FAIL: $*" >&2
+      exit 1
+    }
+
+    # -- Bug 1 regression: jq --args order in join_argv_json -----------------
+    #
+    # With the broken script `bash ${helperScript} --validate --reason X -- ks update`
+    # exits non-zero because jq fails to compile the filter. With the fix it
+    # MUST emit the matched ks-update entry as JSON.
+
+    set +e
+    output="$(bash ${helperScript} --validate --reason "regression test" -- ks update 2>&1)"
+    rc=$?
+    set -e
+
+    if [[ $rc -ne 0 ]]; then
+      echo "approve-exec.sh exited $rc when validating an allowlisted argv:" >&2
+      echo "$output" >&2
+      fail "approve-exec.sh --validate must succeed for allowlisted 'ks update'"
+    fi
+
+    if ! grep -F '"name":"ks-update"' <<<"$output" >/dev/null; then
+      echo "Output: $output" >&2
+      fail "approve-exec.sh --validate must return the matched 'ks-update' entry as JSON"
+    fi
+
+    # The Lua/Rust dispatch path consumes displayName + reason — make sure
+    # those round-trip too.
+    if ! grep -F '"displayName":"Run Keystone update"' <<<"$output" >/dev/null; then
+      fail "matched-entry JSON must include displayName"
+    fi
+
+    # -- Prefix-match: extra args beyond the allowlisted prefix succeed -----
+    #
+    # `ks update --approve` is the actual shape ks-update.service uses. Make
+    # sure the prefix matcher accepts it.
+
+    output_prefix="$(bash ${helperScript} --validate --reason "regression test" -- ks update --approve)"
+    if ! grep -F '"name":"ks-update"' <<<"$output_prefix" >/dev/null; then
+      fail "approve-exec.sh --validate must accept 'ks update --approve' (prefix match)"
+    fi
+
+    # -- Exact-match: keystone-enroll-fido2 --auto -------------------------
+
+    output_exact="$(bash ${helperScript} --validate --reason "regression test" -- keystone-enroll-fido2 --auto)"
+    if ! grep -F '"name":"keystone-enroll-fido2-auto"' <<<"$output_exact" >/dev/null; then
+      fail "approve-exec.sh --validate must accept the exact 'keystone-enroll-fido2 --auto' entry"
+    fi
+
+    # -- Negative: non-allowlisted argv MUST be rejected -------------------
+
+    # Combine stdout+stderr because the script splits the rejection notice
+    # across both streams (see comment in approve-exec.sh). The test asserts
+    # rejection observably fires; tightening stream targeting is a separate
+    # cleanup outside the scope of this regression.
+    if bash ${helperScript} --validate --reason "should reject" -- /bin/echo nope \
+        >"$PWD/reject.out" 2>&1; then
+      fail "approve-exec.sh --validate must reject non-allowlisted argv"
+    fi
+    grep -F "Rejected command:" "$PWD/reject.out" >/dev/null \
+      || fail "rejected output must include 'Rejected command:'"
+
+    touch "$out"
+  ''

--- a/tests/module/keystone-update-menu-wiring.nix
+++ b/tests/module/keystone-update-menu-wiring.nix
@@ -73,6 +73,23 @@ pkgs.runCommand "test-keystone-update-menu-wiring"
       fail "services.nix must wire OnFailure= on ks-update.service"
     fi
 
+    # -- ks-update.service imports graphical-session env -------------------
+    #
+    # `ks update --approve` (the unit's ExecStart) checks DISPLAY /
+    # WAYLAND_DISPLAY / XDG_SESSION_TYPE to decide pkexec vs sudo. Without
+    # PassEnvironment the user manager doesn't propagate those into the
+    # unit's env, ks falls through to sudo, sudo has no tty, and the unit
+    # silently exits 1. XDG_RUNTIME_DIR + DBUS_SESSION_BUS_ADDRESS are
+    # needed for pkexec to find hyprpolkitagent on the user bus.
+    if ! grep -F 'PassEnvironment' ${servicesFile} >/dev/null; then
+      fail "services.nix must declare PassEnvironment on ks-update.service so the graphical-session env reaches ks --approve"
+    fi
+    for var in DISPLAY WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS; do
+      if ! grep -F "$var" ${servicesFile} >/dev/null; then
+        fail "ks-update.service PassEnvironment must include $var"
+      fi
+    done
+
     # -- Activation tokens defined in Rust match dispatch handling ---------
     #
     # The Lua provider's Action single-quotes %VALUE%, so every token

--- a/tests/module/keystone-update-menu-wiring.nix
+++ b/tests/module/keystone-update-menu-wiring.nix
@@ -28,6 +28,7 @@ let
   runBackgroundRs = ../../packages/ks/src/cmd/run_background.rs;
   updateChannelOption = ../../modules/shared/update.nix;
   terminalDefault = ../../modules/terminal/default.nix;
+  mainMenuShell = ../../modules/desktop/home/scripts/keystone-main-menu.sh;
 in
 pkgs.runCommand "test-keystone-update-menu-wiring"
   {
@@ -145,6 +146,32 @@ pkgs.runCommand "test-keystone-update-menu-wiring"
 
     if ! grep -F 'KS_UPDATE_CHANNEL' ${updateMenuRs} >/dev/null; then
       fail "update_menu.rs must read KS_UPDATE_CHANNEL for channel dispatch"
+    fi
+
+    # -- Top-level Walker menu delegates update to ks-update.service ------
+    #
+    # CRITICAL: keystone-main-menu.sh emits a top-level "Update" entry that
+    # parallels the dedicated keystone-update submenu's "Run update" action.
+    # PR #404 retired the legacy `ghostty -e ks update` terminal ceremony in
+    # the dedicated submenu (Lua → Rust dispatch → ks-update.service unit),
+    # but the top-level entry was missed and silently regressed back to the
+    # terminal path on every host until #414 caught it.
+    #
+    # The fix is for keystone-main-menu.sh's dispatch to delegate to
+    # `ks menu update dispatch`, NOT to spawn its own terminal. These greps
+    # are behavior-shaped: they assert what the dispatch DOES, not just what
+    # token strings appear. Add new assertions here when the contract grows.
+
+    # Strip comment-only lines before grepping, so the deprecation comment
+    # documenting WHY this regression matters doesn't trip its own test.
+    if grep -v '^[[:space:]]*#' ${mainMenuShell} | grep -E 'ghostty[[:space:]]+-e[[:space:]]+ks[[:space:]]+update' >/dev/null; then
+      fail "keystone-main-menu.sh must not spawn a terminal for ks update — delegate to 'ks menu update dispatch'"
+    fi
+    if ! grep -F 'ks menu update dispatch' ${mainMenuShell} >/dev/null; then
+      fail "keystone-main-menu.sh's run-update case must call 'ks menu update dispatch' to reuse the supervised flow"
+    fi
+    if grep -v '^[[:space:]]*#' ${mainMenuShell} | grep -F 'in a terminal' >/dev/null; then
+      fail "keystone-main-menu.sh must not advertise 'in a terminal' in any subtext — Walker update path is silent + polkit"
     fi
 
     touch "$out"


### PR DESCRIPTION
## Summary

- Top-level Walker "Update" entry was bypassing `ks-update.service` and spawning a terminal with `ghostty -e ks update` — pre-#404 behavior surviving in `keystone-main-menu.sh` after the dedicated submenu was migrated.
- Delegate `run-update` to `ks menu update dispatch run-update` so both surfaces use the supervised unit-firing flow (polkit prompt via hyprpolkitagent, silent success, journaled failure, desktop notification).
- Extend `keystone-update-menu-wiring.nix` with behavior-shaped regression assertions on `keystone-main-menu.sh`.

## Diagnosis

Traced by drago + luce on 2026-04-27. The dedicated keystone-update submenu (`menus:keystone-update`) goes Lua → Rust dispatch → `start_update_unit()` → `systemctl --user start ks-update.service` — correct post-#460. The top-level main menu (`menus:keystone-main`) emits a parallel "Update" entry but its bash dispatch was never updated:

```
modules/desktop/home/scripts/keystone-main-menu.sh
  151-156: Subtext: "Run ks update in a terminal"
  435-437: run-update) detach ghostty -e ks update ;;
```

Empirical evidence on workstation: `journalctl --user -u ks-update.service` returned `-- No entries --` despite the unit being `UnitFileState=linked`. Triggering Walker → "Keystone OS update" popped a terminal asking for sudo instead of the polkit dialog the new flow uses. PR #460 (`4531c0ab`) didn't touch this file.

The existing `keystone-update-menu-wiring.nix` test asserted only string-presence in the dedicated Lua provider — it had no visibility into `keystone-main-menu.sh`, so the regression slipped through every CI run for weeks.

## Fix

`modules/desktop/home/scripts/keystone-main-menu.sh`:

- `main_json` "Update" entry's Subtext changed from `"Run ks update in a terminal"` to `"Update this host (silent, polkit-approved)"` (no longer advertises the bug).
- `dispatch()` `run-update)` body changed from `detach ghostty -e ks update` to `ks menu update dispatch run-update`. This delegates to the same Rust path the dedicated submenu uses — TOCTOU-checked unit start, polkit gating, supervised flow.

## Regression test

Three new behavior-shaped assertions in `tests/module/keystone-update-menu-wiring.nix`:

- `keystone-main-menu.sh` MUST NOT spawn `ghostty -e ks update` (the terminal ceremony).
- It MUST contain `ks menu update dispatch` (the delegation contract).
- It MUST NOT advertise "in a terminal" in any subtext.

All three skip comment-only lines so the deprecation comment explaining WHY this regression matters doesn't trip its own test.

## Self-test verification

Temporarily reintroducing the bad pattern (`detach ghostty -e ks update`) on top of this commit makes the test fail with:

```
FAIL: keystone-main-menu.sh must not spawn a terminal for ks update — delegate to 'ks menu update dispatch'
```

The gate catches the exact regression class. Restored fix; tree is clean.

## Test plan

- [x] `nix build .#checks.x86_64-linux.keystone-update-menu-wiring` — passes
- [x] `bash -n modules/desktop/home/scripts/keystone-main-menu.sh` — shell syntax valid
- [x] Pre-commit hooks (nixfmt + shellcheck on staged files) — clean
- [x] Self-test: regression-gate fails with bad pattern, passes after restoration
- [ ] Post-merge: deploy via `ks update --dev`, trigger Walker → "Keystone OS update", confirm `journalctl --user -u ks-update.service` shows fresh `Started Keystone OS update (background)` entry and NO terminal opens

## Notes

- v1 blocker per #418's verification matrix (Walker `ks update` row).
- The fix is mechanical because the heavy lifting was already done by #404 — this just routes the second Walker entry through the same dispatch.
- This is the second time this week a "wiring test" passed on broken behavior because it asserted strings instead of contracts (first was the hyprpaper smoke test in #472). Worth a follow-up convention/process improvement noting that wiring tests must verify outcomes, not just artifact presence.

Closes #414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)