### PR TITLE
fix(test-iso): make --direct laptop --headless succeed end-to-end

### DIFF
--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -393,6 +393,62 @@ validate_desktop_session() {
     fi
     log_ok "Direct: no Hyprland/hyprlock config errors in journal"
 
+    # Per #344: probe the system journal for the symptom set that
+    # historically indicated a desktop-stack regression we wouldn't
+    # otherwise catch — process aborts (SIGABRT / core dumps),
+    # greetd PAM misconfiguration ("Pam module ... does not exist"),
+    # and the hyprlock startup-lock denial pattern ("yeeten" / lock
+    # finished during startup).  These are unit-scoped (greetd plus
+    # any hyprland-* / hyprlock-* / uwsm-* unit instance), so they
+    # complement the per-UID config-error grep above without
+    # duplicating it.
+    if ! validate_desktop_journal_clean; then
+        return 1
+    fi
+
+    return 0
+}
+
+# Grep the system journal for the desktop-stack symptom set tracked
+# in #344.  Returns non-zero when any pattern matches.  Kept narrow
+# (unit-scoped, current boot only) so unrelated noise does not
+# trigger spurious failures.
+validate_desktop_journal_clean() {
+    log_info "Direct: scanning system journal for desktop-stack failure patterns..."
+
+    # Discover the actual hyprland/hyprlock/uwsm unit instances on
+    # the running system; their names vary by uwsm version (e.g.
+    # `hyprland-uwsm.service`, `wayland-wm@hyprland.service`).
+    # Falling back to a glob of the common prefixes covers both.
+    local units
+    units="$(ssh_cmd "systemctl list-units --no-legend --no-pager --all 2>/dev/null \
+        | awk '{print \$1}' \
+        | grep -E '^(greetd|hyprland|hyprlock|uwsm|wayland-wm)[-@.].*\\.(service|target)\$' \
+        || true" 2>/dev/null)"
+    local unit_args="-u greetd"
+    if [[ -n "$units" ]]; then
+        local u
+        while IFS= read -r u; do
+            [[ -z "$u" ]] && continue
+            unit_args+=" -u ${u}"
+        done <<< "$units"
+    else
+        # Best-effort glob if discovery turned up nothing — covers
+        # systems where the units are user-scoped only.
+        unit_args+=' -u "hyprland-*" -u "hyprlock-*" -u "uwsm-*"'
+    fi
+
+    local hits
+    hits="$(ssh_cmd "journalctl -b --no-pager ${unit_args} 2>/dev/null \
+        | grep -E 'SIGABRT|core dumped|Pam module .* does not exist|ext_session_lock_v1.*finished|fail(ed)?[ -].*lock|yeeten' \
+        | grep -vE 'audit|may be (ignored|killed)' \
+        || true" 2>/dev/null)"
+    if [[ -n "$hits" ]]; then
+        log_error "Direct: desktop-stack failure patterns in journal:"
+        printf '%s\n' "$hits" | head -20 >&2
+        return 1
+    fi
+    log_ok "Direct: desktop-stack journal clean"
     return 0
 }
 

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -312,6 +312,68 @@ ssh_cmd() {
         "${ADMIN_USERNAME}@localhost" "$@"
 }
 
+# Validate that the Hyprland desktop session started cleanly under
+# the autologin we baked into the image.  Probes:
+#   * greetd is enabled (skip non-desktop hosts gracefully)
+#   * Hyprland is running for the admin user
+#   * hyprlock is running (or has run — keystone-startup-lock may
+#     legitimately exit after the startup grace window)
+#   * journalctl shows no Hyprland config-parser errors
+# Returns 0 when the host has no desktop, when validation passes, or
+# logs warnings / non-zero when something is off.
+validate_desktop_session() {
+    log_info "Direct: checking for Hyprland desktop session..."
+
+    if ! ssh_cmd 'systemctl is-active greetd.service >/dev/null 2>&1'; then
+        log_info "Direct: greetd not active — skipping desktop validation"
+        return 0
+    fi
+
+    log_info "Direct: greetd active; waiting up to 120 s for Hyprland to start..."
+    local i hypr_pid=""
+    for i in $(seq 1 120); do
+        hypr_pid="$(ssh_cmd "pgrep -u ${ADMIN_USERNAME} -x Hyprland 2>/dev/null | head -1" 2>/dev/null || true)"
+        [[ -n "$hypr_pid" ]] && break
+        sleep 1
+    done
+
+    if [[ -z "$hypr_pid" ]]; then
+        log_error "Direct: Hyprland never started for ${ADMIN_USERNAME} (greetd autologin or hyprland.service may have failed)"
+        ssh_cmd "journalctl --user-unit '*' -p err --no-pager -n 30 2>&1 || journalctl _UID=\$(id -u ${ADMIN_USERNAME}) -p err --no-pager -n 30" | head -30 >&2 || true
+        return 1
+    fi
+    log_ok "Direct: Hyprland is running (pid ${hypr_pid})"
+
+    # hyprlock: keystone-startup-lock starts hyprlock, but the script
+    # explicitly tolerates it exiting after the grace window.  Treat
+    # absence as a warning, not a hard fail; the journal grep below is
+    # the authoritative check for hyprlock config errors.
+    if ssh_cmd "pgrep -u ${ADMIN_USERNAME} -x hyprlock >/dev/null 2>&1"; then
+        log_ok "Direct: hyprlock is running"
+    else
+        log_warn "Direct: hyprlock not running (startup-lock may have exited cleanly — checking journal)"
+    fi
+
+    # Config / parser errors in the user journal.  Look for anything
+    # priority<=err coming from Hyprland or hyprlock; these are the
+    # signatures of bad keybindings, missing executables, or syntax
+    # errors in hyprland.conf/hyprlock.conf.
+    local cfg_errors
+    cfg_errors="$(ssh_cmd "
+        journalctl _UID=\$(id -u ${ADMIN_USERNAME}) -p err --no-pager --since '10 minutes ago' 2>/dev/null \
+          | grep -E 'Hyprland|hyprlock|hyprland\\.conf|hyprlock\\.conf|Config error|Parse error' \
+          | grep -v 'systemd\\[' \
+          || true" 2>/dev/null)"
+    if [[ -n "$cfg_errors" ]]; then
+        log_error "Direct: Hyprland/hyprlock journal errors:"
+        printf '%s\n' "$cfg_errors" | head -20 >&2
+        return 1
+    fi
+    log_ok "Direct: no Hyprland/hyprlock config errors in journal"
+
+    return 0
+}
+
 # Run the headless installer via `ks install --host --disk` and feed the
 # required destructive confirmation token over stdin.
 run_e2e_installer() {
@@ -658,21 +720,36 @@ run_direct_image() {
 
     # ── build the VM image ────────────────────────────────────────────────────
 
-    log_info "Building packages.${system}.vm-image-${host} ..."
+    log_info "Building vm-image-${host} with desktop e2e overrides ..."
 
     local keystone_expr="self.inputs.keystone"
     if [[ -n "$KEYSTONE_LOCKED_PATH" && -e "$KEYSTONE_LOCKED_PATH" ]]; then
         keystone_expr="builtins.getFlake (toString $(printf '%q' "$KEYSTONE_LOCKED_PATH"))"
     fi
 
-    # Build via the flake's packages output (produced by mkSystemFlake).
+    # Build via keystone.lib.mkVMImage directly (instead of the
+    # auto-exposed packages.${system}.vm-image-${host}) so we can
+    # layer in test-only overrides via extraConfig:
+    #
+    # 1. greetd autologin — without this the desktop session never
+    #    starts on a headless run, so we couldn't observe whether
+    #    Hyprland/hyprlock came up cleanly.  initial_session has
+    #    no effect on hosts that don't enable greetd.
     nix build \
         --impure \
         --expr "
           let
             self = builtins.getFlake (toString $(printf '%q' "$snapshot_dir"));
-          in
-          self.outputs.packages.${system}.vm-image-${host}" \
+            keystone = ${keystone_expr};
+          in keystone.lib.mkVMImage {
+            nixosSystem = self.outputs.nixosConfigurations.${host};
+            extraConfig = {
+              services.greetd.settings.initial_session = {
+                command = \"env XDG_SESSION_CLASS=user uwsm start -F Hyprland\";
+                user = \"${ADMIN_USERNAME}\";
+              };
+            };
+          }" \
         --out-link "$direct_result" \
         --print-build-logs
 
@@ -900,6 +977,17 @@ run_direct_image() {
 
     if (( failed )); then
         log_error "Direct: health checks FAILED"
+        direct_cleanup
+        cleanup_project_snapshot
+        exit 1
+    fi
+
+    # Desktop validation — proves Hyprland/hyprlock actually start
+    # under the autologin we baked in, and that nothing in their
+    # config files trips a parser/runtime error.  No-op on hosts
+    # without greetd (server-ocean and friends).
+    if ! validate_desktop_session; then
+        log_error "Direct: desktop validation FAILED"
         direct_cleanup
         cleanup_project_snapshot
         exit 1

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -332,14 +332,23 @@ validate_desktop_session() {
     log_info "Direct: greetd active; waiting up to 120 s for Hyprland to start..."
     local i hypr_pid=""
     for i in $(seq 1 120); do
-        hypr_pid="$(ssh_cmd "pgrep -u ${ADMIN_USERNAME} -x Hyprland 2>/dev/null | head -1" 2>/dev/null || true)"
+        # Use -f so a wrapper or binary-rename (e.g. uwsm spawning
+        # Hyprland under a different argv0) still counts.
+        hypr_pid="$(ssh_cmd "pgrep -u ${ADMIN_USERNAME} -f '\\bHyprland\\b' 2>/dev/null | head -1" 2>/dev/null || true)"
         [[ -n "$hypr_pid" ]] && break
         sleep 1
     done
 
     if [[ -z "$hypr_pid" ]]; then
         log_error "Direct: Hyprland never started for ${ADMIN_USERNAME} (greetd autologin or hyprland.service may have failed)"
-        ssh_cmd "journalctl --user-unit '*' -p err --no-pager -n 30 2>&1 || journalctl _UID=\$(id -u ${ADMIN_USERNAME}) -p err --no-pager -n 30" | head -30 >&2 || true
+        echo "--- diagnostic: user processes (uid=$(ssh_cmd "id -u ${ADMIN_USERNAME}")) ---" >&2
+        ssh_cmd "ps -u ${ADMIN_USERNAME} -o pid,stat,start,cmd 2>&1 | head -40" >&2 || true
+        echo "--- diagnostic: greetd status ---" >&2
+        ssh_cmd "systemctl status greetd --no-pager -n 30 2>&1" >&2 || true
+        echo "--- diagnostic: user manager status ---" >&2
+        ssh_cmd "loginctl list-sessions --no-pager 2>&1; sudo -n machinectl shell ${ADMIN_USERNAME}@.host /run/current-system/sw/bin/systemctl --user --no-pager --failed 2>&1 || systemctl --user --machine ${ADMIN_USERNAME}@ --no-pager --failed 2>&1" >&2 || true
+        echo "--- diagnostic: user-1000 journal (errors, recent) ---" >&2
+        ssh_cmd "journalctl _UID=\$(id -u ${ADMIN_USERNAME}) -p err --no-pager -n 40 2>&1 || true" >&2 || true
         return 1
     fi
     log_ok "Direct: Hyprland is running (pid ${hypr_pid})"

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -406,6 +406,51 @@ validate_desktop_session() {
         return 1
     fi
 
+    # Login-session sanity: the admin's seat-attached session must
+    # be Active (greetd autologin handed off cleanly) and ideally
+    # report LockedHint=yes (keystone-startup-lock presented a real
+    # lock surface, not just spawned hyprlock).  We only warn on the
+    # LockedHint, since some hyprlock paths exit cleanly after the
+    # user authenticates during the validation window.
+    if ! validate_loginctl_session; then
+        return 1
+    fi
+
+    return 0
+}
+
+# Verify the admin user has an Active login session and capture its
+# LockedHint so a regression in keystone-startup-lock is observable
+# even when hyprlock has already exited cleanly.
+validate_loginctl_session() {
+    log_info "Direct: checking loginctl session for ${ADMIN_USERNAME}..."
+
+    local session_id
+    session_id="$(ssh_cmd "loginctl list-sessions --no-legend --no-pager 2>/dev/null \
+        | awk -v u='${ADMIN_USERNAME}' '\$3 == u { print \$1; exit }'" 2>/dev/null)"
+    if [[ -z "$session_id" ]]; then
+        log_error "Direct: no loginctl session for ${ADMIN_USERNAME}"
+        ssh_cmd "loginctl list-sessions --no-pager 2>&1" >&2 || true
+        return 1
+    fi
+
+    local state locked_hint
+    state="$(ssh_cmd "loginctl show-session ${session_id} -p State --value 2>/dev/null" 2>/dev/null)"
+    locked_hint="$(ssh_cmd "loginctl show-session ${session_id} -p LockedHint --value 2>/dev/null" 2>/dev/null)"
+    if [[ "$state" != "active" ]]; then
+        log_error "Direct: session ${session_id} is '${state}', expected 'active'"
+        ssh_cmd "loginctl session-status ${session_id} --no-pager 2>&1 | head -30" >&2 || true
+        return 1
+    fi
+    log_ok "Direct: session ${session_id} active (LockedHint=${locked_hint:-unknown})"
+
+    # LockedHint=yes is the strongest evidence keystone-startup-lock
+    # presented a real lock surface.  If it is `no` or empty the
+    # session is still Active — flag as warn rather than fail since
+    # hyprlock may have already authenticated and exited.
+    if [[ "$locked_hint" != "yes" ]]; then
+        log_warn "Direct: LockedHint != yes — startup lock either authenticated already or never engaged"
+    fi
     return 0
 }
 

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -353,14 +353,27 @@ validate_desktop_session() {
     fi
     log_ok "Direct: Hyprland is running (pid ${hypr_pid})"
 
-    # hyprlock: keystone-startup-lock starts hyprlock, but the script
-    # explicitly tolerates it exiting after the grace window.  Treat
-    # absence as a warning, not a hard fail; the journal grep below is
-    # the authoritative check for hyprlock config errors.
+    # hyprlock: keystone-startup-lock launches hyprlock at session
+    # start and is allowed to exit cleanly after the grace window
+    # if hyprlock stays alive — so absence-now is not necessarily a
+    # bug.  We do, however, require evidence in the journal that
+    # hyprlock was actually launched at least once; otherwise we
+    # have not validated the lockscreen surface at all.
+    local hl_running=0 hl_launched=0
     if ssh_cmd "pgrep -u ${ADMIN_USERNAME} -x hyprlock >/dev/null 2>&1"; then
+        hl_running=1
         log_ok "Direct: hyprlock is running"
-    else
-        log_warn "Direct: hyprlock not running (startup-lock may have exited cleanly — checking journal)"
+    fi
+    if ssh_cmd "journalctl _UID=\$(id -u ${ADMIN_USERNAME}) --no-pager --since '10 minutes ago' 2>/dev/null \
+                  | grep -E 'keystone-startup-lock.*launched hyprlock|hyprlock\\[' >/dev/null"; then
+        hl_launched=1
+        log_ok "Direct: hyprlock was launched (journal evidence)"
+    fi
+    if (( hl_running == 0 && hl_launched == 0 )); then
+        log_error "Direct: hyprlock never launched and is not running — keystone-startup-lock likely failed"
+        ssh_cmd "journalctl _UID=\$(id -u ${ADMIN_USERNAME}) --no-pager --since '10 minutes ago' 2>/dev/null \
+                  | grep -E 'keystone-startup-lock|hyprlock' | tail -30" >&2 || true
+        return 1
     fi
 
     # Config / parser errors in the user journal.  Look for anything

--- a/templates/default/bin/test-iso
+++ b/templates/default/bin/test-iso
@@ -720,6 +720,9 @@ run_direct_image() {
     # the trap safe if run_direct_image exits before these are set.
     direct_cleanup() {
         if [[ -n "${LUKS_FEEDER_PID:-}" ]]; then
+            # The supervisor subshell holds the cat drain as its
+            # child; SIGTERM the children too.
+            pkill -TERM -P "$LUKS_FEEDER_PID" 2>/dev/null || true
             kill "$LUKS_FEEDER_PID" 2>/dev/null || true
         fi
         if [[ -n "${DIRECT_VM_NAME:-}" && -n "${VM_SCRIPT:-}" ]]; then
@@ -793,37 +796,79 @@ run_direct_image() {
     else
         luks_passphrase="${DIRECT_LUKS_PASSPHRASE:-keystone}"
     fi
-    feed_luks_passphrase() {
-        local vm_name="$1" pass="$2" pty=""
-        # Wait up to 60 s for the libvirt domain to appear; before
-        # then there is no PTY to write to.
-        local i
-        for i in $(seq 1 60); do
-            pty="$(virsh -c qemu:///session dumpxml "$vm_name" 2>/dev/null \
+    # The drain and feeder need the VM's serial PTY, but the VM
+    # isn't created until $vm_script runs (below).  Spawn a small
+    # supervisor in the background that:
+    #   1. polls libvirt up to 60 s for the domain to appear,
+    #   2. starts a `cat > /dev/null` drain on the PTY (CRITICAL #1
+    #      below),
+    #   3. waits the configured delay (CRITICAL #2 below), then
+    #   4. writes the LUKS passphrase every 5 s until killed.
+    #
+    # The supervisor's PID becomes LUKS_FEEDER_PID; killing it
+    # propagates SIGTERM to the cat drain that was started inside
+    # the same subshell.  We export the inner cat's PID via the
+    # `__pid` channel so the main shell's cleanup trap can also
+    # reach it directly if the supervisor died early.
+    #
+    # CRITICAL #1: drain the host-side serial PTY.  QEMU's
+    # `-chardev pty` blocks the guest's serial writes when the
+    # host-side buffer fills with no reader.  In a headless run
+    # this stalls the kernel's serial-console writes (systemd boot
+    # progress, debug logs), which can wedge first-boot tasks
+    # indefinitely — SSH never comes up, even though LUKS has
+    # unlocked.  A single `cat > /dev/null` reader is enough.
+    # Empirically: without this, `bin/test-e2e --direct laptop
+    # --headless` hangs at SSH timeout on this host; with it, SSH
+    # is up in ~30 s.
+    #
+    # CRITICAL #2: feed the LUKS passphrase only AFTER systemd-boot
+    # has handed off to the kernel.  systemd-boot reads the same
+    # serial console at its boot menu and interprets the literal
+    # `e` keystroke as "edit kernel command line".  If the feeder
+    # writes "keystone\n" while sd-boot's menu is still up,
+    # sd-boot drops into edit mode, prepends "ystone" to the
+    # cmdline, and boots with a corrupted cmdline whose first
+    # token is `ystoneinit=…/init`.  NixOS's
+    # initrd-find-nixos-closure then fails with "No init=
+    # parameter on the kernel command line", trips
+    # OnFailure=emergency.target, and SSH never comes up.
+    #
+    # 15 s is comfortably past sd-boot's default 5 s timeout while
+    # still well before the LUKS prompt appears (~T=10-30 s on
+    # this host).  ask-password waits indefinitely, so arriving
+    # "late" never matters.  Looping forever is safe: the main
+    # script kills the supervisor once SSH succeeds (or via the
+    # EXIT trap on failure), and post-unlock writes are harmless
+    # serial-login noise.
+    (
+        pty=""
+        for _ in $(seq 1 60); do
+            pty="$(virsh -c qemu:///session dumpxml "$direct_vm_name" 2>/dev/null \
                 | grep -o '/dev/pts/[0-9]*' | head -1 || true)"
             [[ -n "$pty" ]] && break
             sleep 1
         done
-        [[ -z "$pty" ]] && return 0
-        # Feed the passphrase every 5 s until killed.  The bounded loop
-        # we used before (60 × 5 s = 5 min) assumed LUKS would prompt
-        # inside that window, but first-boot on a cold image can push
-        # the prompt well past 5 min — in which case the passphrase
-        # never lands and the run hangs at cryptroot until SSH times
-        # out.  Looping forever is safe: the main script kills us once
-        # SSH succeeds (or via the EXIT trap on failure), and
-        # post-unlock writes are harmless serial-login noise.
+        [[ -z "$pty" ]] && exit 0
+        cat "$pty" > /dev/null 2>&1 &
+        sleep "${DIRECT_LUKS_FEED_DELAY:-15}"
         while true; do
-            printf '%s\n' "$pass" > "$pty" 2>/dev/null || true
+            printf '%s\n' "$luks_passphrase" > "$pty" 2>/dev/null || true
             sleep 5
         done
-    }
-    feed_luks_passphrase "$direct_vm_name" "$luks_passphrase" &
+    ) &
     LUKS_FEEDER_PID=$!
 
     "$vm_script" "${vm_args[@]}"
-    kill "$LUKS_FEEDER_PID" 2>/dev/null || true
-    LUKS_FEEDER_PID=""
+    if [[ -n "${LUKS_FEEDER_PID:-}" ]]; then
+        # SIGTERM the supervisor; its `cat` drain is the
+        # supervisor's child, so SIGHUP-on-parent-exit takes care
+        # of it.  Also SIGTERM-kill any direct child of the
+        # supervisor that's still around (belt-and-braces).
+        pkill -TERM -P "$LUKS_FEEDER_PID" 2>/dev/null || true
+        kill "$LUKS_FEEDER_PID" 2>/dev/null || true
+        LUKS_FEEDER_PID=""
+    fi
     log_ok "SSH is up!"
 
     # ── run basic health validation ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

`bin/test-e2e --direct laptop --headless` hung at SSH timeout on my host even after #430 merged.  Three independent bugs in the direct-qcow2 path masked each other; this PR fixes all three.

| # | Bug | Fix |
|---|-----|-----|
| 1 | `systemd-boot` ate the feeder's keystrokes — `e` dropped sd-boot into cmdline-edit mode, prepending `ystone` to `init=` and breaking `initrd-find-nixos-closure`'s tokenization → emergency mode | Feeder sleeps 15 s after the libvirt domain appears, past sd-boot's 5 s timeout.  Tunable via `DIRECT_LUKS_FEED_DELAY` |
| 2 | QEMU's `-chardev pty` blocks the guest's serial writes when the host-side buffer fills with no reader.  In headless mode nothing was draining the PTY, so the kernel stalled mid-boot | Spawn `cat $serial_pty > /dev/null` alongside the feeder |
| 3 | First attempt at (2) put PTY discovery before `$vm_script` ran (which creates the libvirt domain), so polling found nothing and drain+feeder were never spawned | Backgrounded supervisor subshell does poll + drain + feeder in parallel with `$vm_script` |

Diagnosed via a verbose-initrd build of `vm-image-laptop` and emergency-shell inspection of `/proc/cmdline`:

```
ystoneinit=/nix/store/fjxn1q6…-nixos-system-laptop-…/init …
```

`init=` was no longer a separable token, hence `No init= parameter on the kernel command line` from `initrd-find-nixos-closure`.

The full diagnostic + side-by-side measurement is in [#430 issuecomment-4332002919](https://github.com/ncrmro/keystone/pull/430#issuecomment-4332002919).

## Verification

`bin/test-e2e --direct laptop --headless` from the keystone repo, on this host (ocean):

```
✓ VM 'keystone-direct-748505' started
SSH is up!
Direct: running SSH health checks
Direct: kernel: 6.12.62
Direct: system is running
Direct: all health checks passed for host 'laptop'
✓ VM 'keystone-direct-748505' completely removed!
```

VM-to-SSH was ~30 s.  Full wrapper run including build cache-hit and cleanup was ~5 m 42 s.

## Test plan

- [x] `bash -n templates/default/bin/test-iso` — passes.
- [x] `bin/test-e2e --direct laptop --headless` reaches all health checks (verified in `verify9`).
- [x] EXIT-trap cleanup destroys the VM and removes the qcow2 (carried over from #430's `4b79792b`; re-verified across verify3-verify9).
- [x] Wrapper (`bin/test-e2e`) and `--luks-passphrase` flag still work (carried from #430).