### PR TITLE
feat(templates): fleet-wide shared.agents injection in mkSystemFlake

### DIFF
--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -752,6 +752,11 @@ rec {
         "sshKeys"
       ];
       sharedUsers = shared.users or { };
+      # Agent identities applied to every host's keystone.os.agents.
+      # The module system merges this attrset with any per-host
+      # keystone.os.agents declarations, so hosts can add agents without
+      # losing the fleet-wide set.
+      sharedAgents = shared.agents or { };
       # NixOS modules applied OS-wide on every host.
       sharedSystemModules = shared.systemModules or [ ];
       # Home Manager modules applied per-user on every host.
@@ -898,6 +903,9 @@ rec {
                 # Bridge admin.sshKeys to installed hosts so the keys survive
                 # NixOS system activation (which overwrites ~/.ssh/authorized_keys).
                 users.users.${adminUsername}.openssh.authorizedKeys.keys = adminSshKeys;
+              }
+              ++ lib.optional (sharedAgents != { }) {
+                keystone.os.agents = sharedAgents;
               }
               ++ sharedSystemModules
               ++ modules;

--- a/modules/os/agents/default.nix
+++ b/modules/os/agents/default.nix
@@ -21,10 +21,17 @@
 #     # SSH public key declared in keystone.keys."agent-researcher"
 #   };
 #
+# Fleet-wide declaration:
+#   Consumer flakes using `mkSystemFlake` can declare agents once via
+#   `shared.agents`; the template injects them into every host's
+#   `keystone.os.agents`. Per-host `keystone.os.agents.<name>` entries merge
+#   with the fleet set (module-system attrset merge), so hosts can add
+#   host-only agents without losing the shared identities.
+#
 # Host filtering:
-#   Agent identities are shared across all hosts (via a common import like
-#   agent-identities.nix), but the `host` field controls WHERE feature-specific
-#   resources are created:
+#   Agent identities are shared across all hosts (via `shared.agents` in
+#   `mkSystemFlake`, or a common import like agent-identities.nix), but the
+#   `host` field controls WHERE feature-specific resources are created:
 #
 #   ALWAYS created on every importing host (uses `cfg`, the full agent set):
 #   - OS user/group accounts (agents need accounts for SSH access everywhere)

--- a/tests/module/template-evaluation.nix
+++ b/tests/module/template-evaluation.nix
@@ -228,6 +228,95 @@ let
         };
       }).nixosConfigurations.vps
     );
+
+    # Guard: shared.agents passed to mkSystemFlake must inject the same
+    # agent identities into every host's keystone.os.agents, while still
+    # allowing per-host additions to merge in.  Eval-only — agent users are
+    # defined OS-wide so they appear in users.users on every host.
+    inventory-fleet-agents-host-a =
+      let
+        fleet = self.lib.mkSystemFlake {
+          admin = {
+            username = "admin";
+            fullName = "Fleet Owner";
+            email = "fleet@example.com";
+            initialPassword = "changeme";
+          };
+          defaults.timeZone = "UTC";
+          keystoneServices = {
+            git.host = "host-a";
+          };
+          shared.agents = {
+            fleeter = {
+              fullName = "Fleet-Wide Agent";
+              host = "host-a";
+            };
+          };
+          hosts = {
+            host-a = {
+              kind = "server";
+              hostname = "host-a";
+              hardware = null;
+              configuration = null;
+              storage.devices = [ "/dev/disk/by-id/host-a-root-001" ];
+              modules = [
+                {
+                  networking.hostId = "aaaaaaaa";
+                  keystone.os.agents.local-a = {
+                    fullName = "Host-A Local Agent";
+                    host = "host-a";
+                  };
+                }
+              ];
+              services.openssh.enable = true;
+            };
+            host-b = {
+              kind = "server";
+              hostname = "host-b";
+              hardware = null;
+              configuration = null;
+              storage.devices = [ "/dev/disk/by-id/host-b-root-001" ];
+              modules = [
+                {
+                  networking.hostId = "bbbbbbbb";
+                }
+              ];
+              services.openssh.enable = true;
+            };
+          };
+        };
+        hostA = fleet.nixosConfigurations.host-a.config;
+        hostB = fleet.nixosConfigurations.host-b.config;
+        # Force evaluation of both hosts' agent sets.
+        agentsA = builtins.attrNames hostA.keystone.os.agents;
+        agentsB = builtins.attrNames hostB.keystone.os.agents;
+        expectFleetA = builtins.elem "fleeter" agentsA;
+        expectFleetB = builtins.elem "fleeter" agentsB;
+        expectLocalA = builtins.elem "local-a" agentsA;
+        expectLocalNotOnB = !(builtins.elem "local-a" agentsB);
+        ok = expectFleetA && expectFleetB && expectLocalA && expectLocalNotOnB;
+        agentsAJson = builtins.toJSON agentsA;
+        agentsBJson = builtins.toJSON agentsB;
+      in
+      if !ok then
+        throw ''
+          inventory-fleet-agents: shared.agents did not propagate as expected.
+            host-a agents: ${agentsAJson}
+            host-b agents: ${agentsBJson}
+            expected: 'fleeter' on both hosts; 'local-a' on host-a only.
+        ''
+      else
+        pkgs.runCommand "eval-template-inventory-fleet-agents" { } ''
+          mkdir -p $out
+          cat > $out/inventory-fleet-agents-host-a.json <<'ENDJSON'
+          {
+            "name": "inventory-fleet-agents-host-a",
+            "kind": "fleet-agents",
+            "hostAAgents": ${agentsAJson},
+            "hostBAgents": ${agentsBJson}
+          }
+          ENDJSON
+        '';
   };
 
   homeTests = lib.optionalAttrs (home-manager != null) {


### PR DESCRIPTION
## Summary

- Adds `shared.agents` parameter to `mkSystemFlake` (lib/templates.nix). The template injects `{ keystone.os.agents = sharedAgents; }` as a module into every host, so fleet-wide agent identities can be declared once and merge with any per-host `keystone.os.agents` additions.
- Updates the agent module's doc comment (modules/os/agents/default.nix) to point at the new fleet path.
- Adds a `template-evaluation` guard (`inventory-fleet-agents-host-a`) that builds a 2-host fleet, declares one fleet agent + one per-host agent, and asserts the fleet agent lands on both hosts while the host-only agent stays on its declaring host.

## Motivation

Investigating why Keystone-shipped Claude agents were missing on host `ocean` revealed that `keystone.os.agents` is per-host only. There is no fleet injection point, so consumer flakes have to either copy-paste agent declarations across hosts or build their own shared import. This adds the natural shared injection point alongside the existing `shared.users`, `shared.userModules`, `shared.systemModules`, and `shared.desktopUserModules`.

## Consumer usage

```nix
keystone.lib.mkSystemFlake {
  # ...
  shared.agents = {
    researcher = { fullName = "Research Agent"; email = "researcher@ks.systems"; host = "workstation"; };
  };
  hosts = {
    workstation = { ... };
    ocean       = { ... };  # also gets the researcher agent identity
  };
}
```

Per-host `keystone.os.agents.<name>` declarations continue to work and merge with the fleet set.

## Test plan

- [x] `nix build .#checks.x86_64-linux.template-evaluation` — passes; new guard `inventory-fleet-agents-host-a` evaluates and asserts the merge semantics
- [ ] Land in consumer flake (`ncrmro/nixos-config`), move agent declarations to `shared.agents`, run `ks update --lock` on `ocean` and confirm `~/.config/keystone/agent-assets.json` is populated and Claude agents appear in the picker
- [ ] Confirm workstation `keystone.os.agents` set is unchanged (no agents lost or duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)