### PR TITLE
fix(terminal): surface keystone.os.agents in Claude manifest + fleet-wide shared.agents

### DIFF
--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -752,6 +752,11 @@ rec {
         "sshKeys"
       ];
       sharedUsers = shared.users or { };
+      # Agent identities applied to every host's keystone.os.agents.
+      # The module system merges this attrset with any per-host
+      # keystone.os.agents declarations, so hosts can add agents without
+      # losing the fleet-wide set.
+      sharedAgents = shared.agents or { };
       # NixOS modules applied OS-wide on every host.
       sharedSystemModules = shared.systemModules or [ ];
       # Home Manager modules applied per-user on every host.
@@ -898,6 +903,9 @@ rec {
                 # Bridge admin.sshKeys to installed hosts so the keys survive
                 # NixOS system activation (which overwrites ~/.ssh/authorized_keys).
                 users.users.${adminUsername}.openssh.authorizedKeys.keys = adminSshKeys;
+              }
+              ++ lib.optional (sharedAgents != { }) {
+                keystone.os.agents = sharedAgents;
               }
               ++ sharedSystemModules
               ++ modules;

--- a/modules/os/agents/default.nix
+++ b/modules/os/agents/default.nix
@@ -21,10 +21,17 @@
 #     # SSH public key declared in keystone.keys."agent-researcher"
 #   };
 #
+# Fleet-wide declaration:
+#   Consumer flakes using `mkSystemFlake` can declare agents once via
+#   `shared.agents`; the template injects them into every host's
+#   `keystone.os.agents`. Per-host `keystone.os.agents.<name>` entries merge
+#   with the fleet set (module-system attrset merge), so hosts can add
+#   host-only agents without losing the shared identities.
+#
 # Host filtering:
-#   Agent identities are shared across all hosts (via a common import like
-#   agent-identities.nix), but the `host` field controls WHERE feature-specific
-#   resources are created:
+#   Agent identities are shared across all hosts (via `shared.agents` in
+#   `mkSystemFlake`, or a common import like agent-identities.nix), but the
+#   `host` field controls WHERE feature-specific resources are created:
 #
 #   ALWAYS created on every importing host (uses `cfg`, the full agent set):
 #   - OS user/group accounts (agents need accounts for SSH access everywhere)

--- a/modules/terminal/generated-agent-assets.nix
+++ b/modules/terminal/generated-agent-assets.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  osConfig ? null,
   ...
 }:
 with lib;
@@ -11,9 +12,26 @@ let
   isAgent = lib.hasPrefix "agent-" config.home.username;
   devScripts = import ../shared/dev-script-link.nix { inherit lib; };
   repoCheckout = if isAgent then null else devScripts.resolveRepoCheckout config "keystone";
-  agentsLib = import ../os/agents/lib.nix { inherit lib config pkgs; };
+  # agentsLib reads `config.keystone.os.*`, so it must be constructed with the
+  # NixOS config (osConfig), not the home-manager config tree.
+  agentsLib =
+    if osConfig != null then
+      import ../os/agents/lib.nix {
+        inherit lib pkgs;
+        config = osConfig;
+      }
+    else
+      null;
+  # `keystone.os.agents` is a NixOS-level option, not a home-manager option,
+  # so reading it from `config` always returned { } here and the manifest
+  # never reflected the host's agent set. Bridge via `osConfig` (the standard
+  # home-manager pattern, used elsewhere in keystone for keystone.development
+  # and keystone.repos) so the generated agent-assets.json matches reality.
   osAgents =
-    if config.keystone ? os && config.keystone.os ? agents then config.keystone.os.agents else { };
+    if osConfig != null && osConfig.keystone ? os && osConfig.keystone.os ? agents then
+      osConfig.keystone.os.agents
+    else
+      { };
   manifestRelPath = ".config/keystone/agent-assets.json";
   scriptRelPath = "modules/terminal/scripts/keystone-sync-agent-assets.sh";
   scriptPackage = pkgs.writeShellScriptBin "keystone-sync-agent-assets" (

--- a/tests/module/template-evaluation.nix
+++ b/tests/module/template-evaluation.nix
@@ -228,6 +228,95 @@ let
         };
       }).nixosConfigurations.vps
     );
+
+    # Guard: shared.agents passed to mkSystemFlake must inject the same
+    # agent identities into every host's keystone.os.agents, while still
+    # allowing per-host additions to merge in.  Eval-only — agent users are
+    # defined OS-wide so they appear in users.users on every host.
+    inventory-fleet-agents-host-a =
+      let
+        fleet = self.lib.mkSystemFlake {
+          admin = {
+            username = "admin";
+            fullName = "Fleet Owner";
+            email = "fleet@example.com";
+            initialPassword = "changeme";
+          };
+          defaults.timeZone = "UTC";
+          keystoneServices = {
+            git.host = "host-a";
+          };
+          shared.agents = {
+            fleeter = {
+              fullName = "Fleet-Wide Agent";
+              host = "host-a";
+            };
+          };
+          hosts = {
+            host-a = {
+              kind = "server";
+              hostname = "host-a";
+              hardware = null;
+              configuration = null;
+              storage.devices = [ "/dev/disk/by-id/host-a-root-001" ];
+              modules = [
+                {
+                  networking.hostId = "aaaaaaaa";
+                  keystone.os.agents.local-a = {
+                    fullName = "Host-A Local Agent";
+                    host = "host-a";
+                  };
+                }
+              ];
+              services.openssh.enable = true;
+            };
+            host-b = {
+              kind = "server";
+              hostname = "host-b";
+              hardware = null;
+              configuration = null;
+              storage.devices = [ "/dev/disk/by-id/host-b-root-001" ];
+              modules = [
+                {
+                  networking.hostId = "bbbbbbbb";
+                }
+              ];
+              services.openssh.enable = true;
+            };
+          };
+        };
+        hostA = fleet.nixosConfigurations.host-a.config;
+        hostB = fleet.nixosConfigurations.host-b.config;
+        # Force evaluation of both hosts' agent sets.
+        agentsA = builtins.attrNames hostA.keystone.os.agents;
+        agentsB = builtins.attrNames hostB.keystone.os.agents;
+        expectFleetA = builtins.elem "fleeter" agentsA;
+        expectFleetB = builtins.elem "fleeter" agentsB;
+        expectLocalA = builtins.elem "local-a" agentsA;
+        expectLocalNotOnB = !(builtins.elem "local-a" agentsB);
+        ok = expectFleetA && expectFleetB && expectLocalA && expectLocalNotOnB;
+        agentsAJson = builtins.toJSON agentsA;
+        agentsBJson = builtins.toJSON agentsB;
+      in
+      if !ok then
+        throw ''
+          inventory-fleet-agents: shared.agents did not propagate as expected.
+            host-a agents: ${agentsAJson}
+            host-b agents: ${agentsBJson}
+            expected: 'fleeter' on both hosts; 'local-a' on host-a only.
+        ''
+      else
+        pkgs.runCommand "eval-template-inventory-fleet-agents" { } ''
+          mkdir -p $out
+          cat > $out/inventory-fleet-agents-host-a.json <<'ENDJSON'
+          {
+            "name": "inventory-fleet-agents-host-a",
+            "kind": "fleet-agents",
+            "hostAAgents": ${agentsAJson},
+            "hostBAgents": ${agentsBJson}
+          }
+          ENDJSON
+        '';
   };
 
   homeTests = lib.optionalAttrs (home-manager != null) {


### PR DESCRIPTION
## Summary

Two related commits — landing together because the bug fix is the reason this work started, and the new fleet-wide option is the natural ergonomics improvement uncovered along the way.

### 1. fix(terminal): bridge `keystone.os.agents` via `osConfig`

`modules/terminal/generated-agent-assets.nix` was reading `config.keystone.os.agents` from the home-manager evaluator, but `keystone.os.agents` is a NixOS-level option (defined in `modules/os/agents/default.nix`). The attribute is not declared on the home-manager side, so the conditional always fell through and `~/.config/keystone/agent-assets.json` was always `{ "agents": {} }` — on every host, even when agents were declared correctly.

Fix: read via `osConfig` (the standard home-manager → NixOS bridge, already used in `modules/terminal/default.nix:134-135` and `modules/shared/repos.nix:133` for `keystone.development` and `keystone.repos`). Also pass `osConfig` to `import ../os/agents/lib.nix`, since `lib.nix` reads `config.keystone.os.*` and would otherwise throw `attribute 'os' missing`.

**Verified** by overriding the keystone input in `ncrmro/nixos-config` and re-evaluating `ocean`'s manifest:

- Before: `"agents":{}`
- After: `"agents":{"drago":{...},"luce":{...}}` with full MCP server entries (deepwork + chrome-devtools).

### 2. feat(templates): fleet-wide `shared.agents` injection in `mkSystemFlake`

Adds `shared.agents` parameter to `mkSystemFlake` (lib/templates.nix). The template injects `{ keystone.os.agents = sharedAgents; }` as a module into every host, so fleet-wide agent identities can be declared once and merge with any per-host `keystone.os.agents` additions. Sits alongside the existing `shared.users`, `shared.userModules`, `shared.systemModules`, and `shared.desktopUserModules`.

Adds a `template-evaluation` guard (`inventory-fleet-agents-host-a`) that builds a 2-host fleet, declares one fleet agent + one per-host agent, and asserts the fleet agent lands on both hosts while the host-only agent stays on its declaring host. (This fleet-wide option does NOT apply to consumer flakes that use `nixpkgs.lib.nixosSystem` directly, like `ncrmro/nixos-config` — they should keep using a shared common-import.)

## Test plan

- [x] `nix build .#checks.x86_64-linux.template-evaluation` (covers both the fix and the new fleet test)
- [x] `nix build .#checks.x86_64-linux.os-evaluation`
- [ ] After merge: `ks update --lock` on ocean and workstation; confirm `cat ~/.config/keystone/agent-assets.json | jq '.agents | keys'` returns `["drago","luce"]`
- [ ] Confirm `ls ~/.claude/agents/` is populated and Claude Code's `/agents` picker shows the keystone agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)