### PR TITLE
fix(overlays): wire buildNpmPackage into synthetic llmAgentsPerSystem

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -68,10 +68,22 @@ let
   llmAgentsVersionCheckHomeHook =
     llmAgentsPkgs.callPackage "${llm-agents-src}/packages/versionCheckHomeHook/default.nix"
       { };
+  # Required since llm-agents.nix commit 4049025 (2026-04-26): packages like
+  # gemini-cli `inherit (perSystem.self) buildNpmPackage`. Upstream wraps
+  # nixpkgs' buildNpmPackage with an eval-time guard that requires
+  # fetchNpmDeps to support `fetcherVersion = 2`. The guard's failure message
+  # tells you to bump nixpkgs (>= 203662a570c4, 2026-02-15) or switch to
+  # overlays.default / the flake packages directly. Without this attr, the
+  # inherit fails with "attribute 'buildNpmPackage' missing" and blocks every
+  # host build.
+  llmAgentsBuildNpmPackage =
+    llmAgentsPkgs.callPackage "${llm-agents-src}/packages/buildNpmPackage/default.nix"
+      { };
   llmAgentsPerSystem = {
     self = {
       wrapBuddy = llmAgentsWrapBuddy;
       versionCheckHomeHook = llmAgentsVersionCheckHomeHook;
+      buildNpmPackage = llmAgentsBuildNpmPackage;
     };
   };
 in


### PR DESCRIPTION
## Summary

- llm-agents.nix commit `4049025` (2026-04-26) changed `packages/gemini-cli/default.nix` to `inherit (perSystem.self) buildNpmPackage versionCheckHomeHook`. Keystone's overlay hand-rolls a synthetic `perSystem.self` containing only `wrapBuddy + versionCheckHomeHook` (to avoid pulling all 100+ upstream packages), so the inherit fails with `attribute 'buildNpmPackage' missing` and blocks every host at module evaluation time.
- Fix: wire upstream's `packages/buildNpmPackage/default.nix` (a wrapper around `nixpkgs.buildNpmPackage` with an eval-time `fetcherVersion=2` guard, see [llm-agents.nix#4320](https://github.com/numtide/llm-agents.nix/issues/4320)) into `llmAgentsPerSystem.self`.

## Failure surfaced

\`ks update --lock\` on host \`ocean\` after pulling keystone main \`1dbc9803\`:

\`\`\`
error: attribute 'buildNpmPackage' missing
at /nix/store/.../packages/gemini-cli/default.nix:4:28
\`\`\`

Triggered via \`home-manager.users.agent-luce.home.packages\` → \`keystone/modules/terminal/ai.nix\` → \`pkgs.keystone.gemini-cli\`.

## Verification

\`\`\`bash
nix eval --raw \\
  --override-input keystone path:/path/to/this/branch \\
  .#nixosConfigurations.ocean.config.system.build.toplevel.drvPath
# → /nix/store/wp7n0a00kczcrwaf9yrbmhip2cbyx332-nixos-system-ocean-...drv
\`\`\`

Pre-fix the eval threw \`attribute 'buildNpmPackage' missing\`; post-fix it produces a valid derivation path.

## Urgency

**Same-day blocker.** Affects every host where \`keystone.terminal.ai.enable\` evaluates \`gemini-cli\` (ncrmro on workstation/laptop/ocean, every agent). Fails at module evaluation, so any \`ks update --lock\` / \`ks switch\` on any host with the new lock fails until merged.

## Test plan

- [x] \`nix eval\` of ocean's \`system.build.toplevel\` succeeds with the patched overlay
- [ ] After merge: \`ks update --lock\` on ocean succeeds end-to-end
- [ ] Confirm \`gemini-cli\` actually builds (the eval guard might fire if the host's nixpkgs lacks \`fetchNpmDeps fetcherVersion\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)