### PR TITLE
feat(lib): mkSystemFlake forwards specialArgs to per-host nixosSystem

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -436,6 +436,10 @@
             inherit pkgs lib;
             self = self;
           };
+          templateSpecialArgs = import ./tests/module/template-special-args.nix {
+            inherit pkgs lib;
+            self = self;
+          };
           serverEvaluation = import ./tests/module/server-evaluation.nix {
             inherit pkgs lib nixpkgs;
             self = self;
@@ -515,6 +519,7 @@
           agent-evaluation = agentEvaluation;
           template-evaluation = templateEvaluation;
           template-update-channel = templateUpdateChannel;
+          template-special-args = templateSpecialArgs;
           server-evaluation = serverEvaluation;
           ks-help = ksHelp;
           ks-lock-sync = ksLockSync;
@@ -552,6 +557,7 @@
             ln -s ${agentEvaluation} "$out/agent-evaluation"
             ln -s ${templateEvaluation} "$out/template-evaluation"
             ln -s ${templateUpdateChannel} "$out/template-update-channel"
+            ln -s ${templateSpecialArgs} "$out/template-special-args"
             ln -s ${serverEvaluation} "$out/server-evaluation"
           '';
 

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -107,9 +107,15 @@ let
       config ? { },
       nixosModules ? [ ],
       modules ? [ ],
+      # specialArgs are forwarded directly to nixpkgs.lib.nixosSystem so
+      # consumer modules using `{ inputs, outputs, ... }:` can be evaluated
+      # without triggering `_module.args`-based infinite recursion. Defining
+      # `inputs` via `_module.args` works for runtime config but breaks when
+      # a module uses `inputs` inside its own `imports = [ ... ];` list.
+      specialArgs ? { },
     }:
     nixpkgs.lib.nixosSystem {
-      inherit system;
+      inherit system specialArgs;
       modules = [
         self.nixosModules.operating-system
       ]
@@ -758,6 +764,14 @@ rec {
       sharedUserModules = shared.userModules or [ ];
       # Home Manager modules applied per-user on desktop hosts (laptop, workstation) only.
       sharedDesktopUserModules = shared.desktopUserModules or [ ];
+      # specialArgs forwarded to every Linux host's nixosSystem call.
+      # Use this to provide module function args like `inputs`, `self`,
+      # `outputs` that consumer modules consume via the
+      # `{ inputs, ... }: { imports = [ inputs.X ]; ... }` pattern. These
+      # args must be visible at module-import time, which `_module.args`
+      # cannot satisfy without infinite recursion. Per-host
+      # `hosts.<name>.specialArgs` are merged on top of `shared.specialArgs`.
+      sharedSpecialArgs = shared.specialArgs or { };
       sharedTimeZone = defaults.timeZone or "UTC";
       sharedUpdateChannel = defaults.updateChannel or "stable";
       effectiveRepoRoot =
@@ -862,6 +876,7 @@ rec {
               "config"
               "modules"
               "updateChannel"
+              "specialArgs"
             ])
             // {
               hostname = hostCfg.hostname or name;
@@ -871,6 +886,7 @@ rec {
               inherit adminUsername;
               users = sharedUsers // (hostCfg.users or { });
               nixosModules = kindDefaults.nixosModules ++ (hostCfg.nixosModules or [ ]);
+              specialArgs = sharedSpecialArgs // (hostCfg.specialArgs or { });
               config = lib.recursiveUpdate mergedConfig {
                 keystone.services = keystoneServices;
                 keystone.update.channel = lib.mkDefault hostUpdateChannel;

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -770,7 +770,9 @@ rec {
       # `{ inputs, ... }: { imports = [ inputs.X ]; ... }` pattern. These
       # args must be visible at module-import time, which `_module.args`
       # cannot satisfy without infinite recursion. Per-host
-      # `hosts.<name>.specialArgs` are merged on top of `shared.specialArgs`.
+      # `hosts.<name>.specialArgs` are merged on top of `shared.specialArgs`
+      # via shallow last-write-wins (`sharedSpecialArgs // hostSpecialArgs`),
+      # so a host entry replaces the fleet value for any key it sets.
       sharedSpecialArgs = shared.specialArgs or { };
       sharedTimeZone = defaults.timeZone or "UTC";
       sharedUpdateChannel = defaults.updateChannel or "stable";
@@ -886,6 +888,10 @@ rec {
               inherit adminUsername;
               users = sharedUsers // (hostCfg.users or { });
               nixosModules = kindDefaults.nixosModules ++ (hostCfg.nixosModules or [ ]);
+              # Shallow last-write-wins merge: per-host `specialArgs` keys
+              # replace identical keys from `shared.specialArgs`. Nested
+              # values are not merged — set the full nested structure on
+              # the host if you need to override a sub-key.
               specialArgs = sharedSpecialArgs // (hostCfg.specialArgs or { });
               config = lib.recursiveUpdate mergedConfig {
                 keystone.services = keystoneServices;

--- a/tests/module/template-special-args.nix
+++ b/tests/module/template-special-args.nix
@@ -1,0 +1,172 @@
+# template-special-args — verify fleet/host composition of `shared.specialArgs`
+# and per-host `hosts.<name>.specialArgs` through `mkSystemFlake`.
+#
+# Covers three scenarios:
+#
+#   1. `shared.specialArgs = { injected = "fleet-value"; }` propagates to every
+#      Linux host's nixosSystem call, where the probe module reads `injected`
+#      both as a module function arg and inside its `imports = [ ... ]` list.
+#   2. A per-host `specialArgs = { injected = "host-value"; }` overrides the
+#      fleet default for that host only, leaving siblings on the fleet value
+#      (shallow last-write-wins merge: `sharedSpecialArgs // hostCfg.specialArgs`).
+#   3. With neither `shared.specialArgs` nor a per-host override, the fleet
+#      still evaluates without crashing.
+#
+# The whole point of `specialArgs` over `_module.args` is that values are
+# available at *module-import time*, not just *config-eval time*. So the probe
+# module references `injected` inside its `imports = [ ... ]` list. If a future
+# refactor regresses `lib/templates.nix` to use `_module.args` (or drops the
+# `inherit system specialArgs;` line), this test fails with "infinite recursion"
+# or "missing argument 'injected'", not a silent false positive.
+{
+  pkgs,
+  lib ? pkgs.lib,
+  self,
+}:
+let
+  mkFleet =
+    { shared, hosts }:
+    self.lib.mkSystemFlake {
+      admin = {
+        username = "admin";
+        fullName = "Fleet Owner";
+        email = "fleet@example.com";
+        initialPassword = "changeme";
+      };
+      defaults = {
+        timeZone = "UTC";
+      };
+      inherit shared hosts;
+    };
+
+  # Probe module that requires `injected` to be a specialArg, not a
+  # _module.args value. The `imports = lib.optionals (injected != null) [ ]`
+  # line forces module-import-time evaluation of `injected`; with
+  # `_module.args` plumbing this triggers infinite recursion because
+  # `_module.args` resolution itself depends on `config`, which depends on
+  # imports being resolved.
+  probeModule =
+    { injected, lib, ... }:
+    {
+      imports = lib.optionals (injected != null) [ ];
+      config.environment.etc."ks-special-arg-probe".text = injected;
+    };
+
+  probeOf = system: system.config.environment.etc."ks-special-arg-probe".text;
+
+  # Minimal host configs that are accepted by mkLaptop / mkServer without a
+  # hardware.nix file. networking.hostId satisfies the ZFS server check.
+  minimalLaptop =
+    extra:
+    {
+      kind = "laptop";
+      hardware = null;
+      configuration = null;
+      storage.devices = [ "/dev/disk/by-id/nvme-laptop-root-001" ];
+      modules = [
+        { networking.hostId = "11111111"; }
+        probeModule
+      ];
+    }
+    // extra;
+
+  minimalServer =
+    extra:
+    {
+      kind = "server";
+      hardware = null;
+      configuration = null;
+      storage.devices = [ "/dev/disk/by-id/nvme-server-root-001" ];
+      modules = [
+        { networking.hostId = "22222222"; }
+        probeModule
+      ];
+    }
+    // extra;
+
+  # Variant for scenario 3 — no probeModule, since neither shared nor host
+  # provides `injected`. Used only to confirm a fleet without specialArgs
+  # still evaluates.
+  bareLaptop = {
+    kind = "laptop";
+    hardware = null;
+    configuration = null;
+    storage.devices = [ "/dev/disk/by-id/nvme-laptop-root-001" ];
+    modules = [
+      { networking.hostId = "11111111"; }
+    ];
+  };
+
+  # Scenario 1: shared specialArgs propagates to every host.
+  fleetShared = mkFleet {
+    shared = {
+      specialArgs = {
+        injected = "fleet-value";
+      };
+    };
+    hosts = {
+      laptop = minimalLaptop { };
+      server = minimalServer { };
+    };
+  };
+
+  # Scenario 2: per-host specialArgs overrides shared for that host only.
+  fleetMixed = mkFleet {
+    shared = {
+      specialArgs = {
+        injected = "fleet-value";
+      };
+    };
+    hosts = {
+      laptop = minimalLaptop { };
+      server = minimalServer {
+        specialArgs = {
+          injected = "host-value";
+        };
+      };
+    };
+  };
+
+  # Scenario 3: no specialArgs anywhere — fleet still evaluates.
+  fleetBare = mkFleet {
+    shared = { };
+    hosts = {
+      laptop = bareLaptop;
+    };
+  };
+
+  expect =
+    label: actual: expected:
+    if actual == expected then
+      "ok: ${label} = ${actual}"
+    else
+      throw "FAIL: ${label} expected '${expected}', got '${actual}'";
+
+  # Forcing evaluation of a NixOS configuration's drvPath proves the module
+  # tree resolves end-to-end without infinite recursion.
+  evalsOk =
+    label: system:
+    let
+      _ = system.config.system.build.toplevel.drvPath;
+    in
+    "ok: ${label} evaluated";
+
+  assertions = [
+    # Scenario 1 — shared propagates to every host's probe module.
+    (expect "fleetShared.laptop.probe" (probeOf fleetShared.nixosConfigurations.laptop) "fleet-value")
+    (expect "fleetShared.server.probe" (probeOf fleetShared.nixosConfigurations.server) "fleet-value")
+
+    # Scenario 2 — per-host override wins for that host only.
+    (expect "fleetMixed.laptop.probe" (probeOf fleetMixed.nixosConfigurations.laptop) "fleet-value")
+    (expect "fleetMixed.server.probe" (probeOf fleetMixed.nixosConfigurations.server) "host-value")
+
+    # Scenario 3 — fleet without specialArgs still evaluates.
+    (evalsOk "fleetBare.laptop" fleetBare.nixosConfigurations.laptop)
+  ];
+in
+pkgs.runCommand "test-template-special-args" { } ''
+  mkdir -p "$out"
+  cat > "$out/report.txt" <<'REPORT'
+  ${lib.concatStringsSep "\n" assertions}
+  REPORT
+''


### PR DESCRIPTION
## Summary

- `mkLinuxHost` (and therefore `mkSystemFlake`) now accepts and forwards `specialArgs` to `nixpkgs.lib.nixosSystem`.
- `mkSystemFlake` exposes `shared.specialArgs` (fleet-wide) and `hosts.<name>.specialArgs` (per-host); per-host args are merged on top of shared args.

## Why

Consumer-flake modules using the `{ inputs, outputs, ... }:` pattern need those names in scope at module-import time. Prior to this change `mkLinuxHost` did not pass `specialArgs`, so the only way to provide `inputs` was via `_module.args` — which causes infinite recursion when a module references `inputs.<flake>.nixosModules.X` inside its own `imports = [ ... ]` list. NixOS reports:

> argument `inputs` is not externally provided, so querying `_module.args` instead, requiring `config`. ... infinite recursion encountered

This blocks any non-template adopter that imports keystone via `inputs.keystone.nixosModules.*` from migrating to `mkSystemFlake`.

## Discovered by

Surfaced while migrating `ncrmro/nixos-config` to `keystone.lib.mkSystemFlake` (see ncrmro/nixos-config#23). Every host in that fleet imports keystone modules via `inputs.keystone.nixosModules.*` inside its host modules, so the migration cannot land without `specialArgs` support.

## Test plan

- [x] Existing `tests/module/template-update-channel.nix` passes unchanged (no consumer of `specialArgs` is required).
- [x] `nixos-config` migration evaluates and builds 4/6 hosts (the remaining two have a pre-existing zfs-backup conflict that is independent of this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)