### PR TITLE
feat(os): default-on systemd-oomd module

### DIFF
--- a/modules/os/AGENTS.md
+++ b/modules/os/AGENTS.md
@@ -24,6 +24,23 @@ keystone.os.storage = {
 
 **ext4 alternative**: LUKS-encrypted ext4 with optional hibernate. No snapshots/compression.
 
+## systemd-oomd (`oomd.nix`)
+
+Default-on cgroup-aware OOM killer that reacts to PSI memory pressure before
+the kernel oom-killer fires. Kills the offending cgroup after 20 seconds of
+sustained pressure.
+
+```nix
+# Default — no opt-in needed
+keystone.os.oomd.enable = true;
+
+# Disable on hosts where you only want the in-kernel oom-killer
+keystone.os.oomd.enable = false;
+```
+
+This module is a focused carve-out: zram, vm.* sysctls, and the ZFS ARC cap
+are tracked separately in #484 / #485.
+
 ## Users (`users.nix`)
 
 ```nix

--- a/modules/os/default.nix
+++ b/modules/os/default.nix
@@ -246,6 +246,7 @@ in
     ../shared/system-flake.nix
     ./notifications.nix
     ./storage.nix
+    ./oomd.nix
     ./secure-boot.nix
     ./tpm.nix
     ./hardware-key.nix

--- a/modules/os/oomd.nix
+++ b/modules/os/oomd.nix
@@ -1,0 +1,58 @@
+# systemd-oomd — modern userspace OOM killer
+#
+# Wires systemd-oomd to act on user, root, and system cgroup slices using PSI
+# (Pressure Stall Information) signals. systemd-oomd is the modern complement
+# to the in-kernel oom-killer: it kills cgroups based on sustained memory
+# pressure, before the kernel oom-killer fires too late and the system has
+# already wedged.
+#
+# Default-on per process.enable-by-default. This module deliberately covers
+# only systemd-oomd — zram, vm.* sysctls, and the ZFS ARC cap are tracked
+# separately (see issue #484 / PR #485). It is the lowest-risk, no-dependency
+# slice of that work and can land independently.
+#
+# Behavior when enabled:
+#   - systemd.oomd.enable = true (explicit, not relying on NixOS default)
+#   - Monitors user, root, and system slices
+#   - Kills the offending cgroup after 20 s of sustained memory pressure
+#
+{
+  lib,
+  config,
+  ...
+}:
+with lib;
+let
+  cfg = config.keystone.os.oomd;
+in
+{
+  options.keystone.os.oomd = {
+    enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Enable systemd-oomd cgroup-aware OOM killing on user, root, and
+        system slices.
+
+        When true (the default), systemd-oomd reacts to PSI memory-pressure
+        signals and kills the offending cgroup before the kernel oom-killer
+        fires. The reaction window is 20 seconds of sustained pressure.
+
+        Set to false on hosts where you want only the in-kernel oom-killer
+        (e.g., minimal containers or when debugging cgroup hierarchies).
+      '';
+    };
+  };
+
+  config = mkIf (config.keystone.os.enable && cfg.enable) {
+    systemd.oomd = {
+      enable = true;
+      enableUserSlices = true;
+      enableRootSlice = true;
+      enableSystemSlice = true;
+      extraConfig = {
+        DefaultMemoryPressureDurationSec = "20s";
+      };
+    };
+  };
+}

--- a/modules/os/oomd.nix
+++ b/modules/os/oomd.nix
@@ -46,12 +46,12 @@ in
 
   config = mkIf (config.keystone.os.enable && cfg.enable) {
     systemd.oomd = {
-      enable = true;
-      enableUserSlices = true;
-      enableRootSlice = true;
-      enableSystemSlice = true;
+      enable = mkDefault true;
+      enableUserSlices = mkDefault true;
+      enableRootSlice = mkDefault true;
+      enableSystemSlice = mkDefault true;
       extraConfig = {
-        DefaultMemoryPressureDurationSec = "20s";
+        DefaultMemoryPressureDurationSec = mkDefault "20s";
       };
     };
   };

--- a/tests/module/os-evaluation.nix
+++ b/tests/module/os-evaluation.nix
@@ -624,6 +624,77 @@ let
     # is disentangled or once we can emit warnings via a narrower
     # option.
 
+    # systemd-oomd is wired up by default and applies the keystone-specific
+    # 20-second pressure window. The DefaultMemoryPressureDurationSec value is
+    # the keystone-unique signature — the slice-enable flags overlap with
+    # NixOS defaults, so asserting the extraConfig is the cleanest pin.
+    oomd-default-on =
+      let
+        result = (import "${pkgs.path}/nixos/lib/eval-config.nix") {
+          system = "x86_64-linux";
+          modules = [
+            self.nixosModules.operating-system
+            {
+              system.stateVersion = "25.05";
+              boot.loader.systemd-boot.enable = true;
+            }
+            adminBase
+            {
+              keystone.os.users.testuser = {
+                fullName = "Test User";
+                initialPassword = "testpass";
+                admin = true;
+              };
+            }
+          ];
+        };
+        actual = result.config.systemd.oomd.extraConfig.DefaultMemoryPressureDurationSec or "<unset>";
+      in
+      pkgs.runCommand "oomd-default-on" { } ''
+        if [ "${actual}" != "20s" ]; then
+          echo "FAIL: oomd-default-on: expected DefaultMemoryPressureDurationSec=20s, got '${actual}'" >&2
+          exit 1
+        fi
+        echo "OK: oomd-default-on: DefaultMemoryPressureDurationSec=${actual}"
+        touch $out
+      '';
+
+    # When keystone.os.oomd.enable = false, the keystone module MUST NOT set
+    # the 20 s pressure window. NixOS may still leave systemd-oomd enabled at
+    # its own defaults; this test only verifies the keystone contribution
+    # disappears.
+    oomd-disabled =
+      let
+        result = (import "${pkgs.path}/nixos/lib/eval-config.nix") {
+          system = "x86_64-linux";
+          modules = [
+            self.nixosModules.operating-system
+            {
+              system.stateVersion = "25.05";
+              boot.loader.systemd-boot.enable = true;
+            }
+            adminBase
+            {
+              keystone.os.oomd.enable = false;
+              keystone.os.users.testuser = {
+                fullName = "Test User";
+                initialPassword = "testpass";
+                admin = true;
+              };
+            }
+          ];
+        };
+        actual = result.config.systemd.oomd.extraConfig.DefaultMemoryPressureDurationSec or "<unset>";
+      in
+      pkgs.runCommand "oomd-disabled" { } ''
+        if [ "${actual}" = "20s" ]; then
+          echo "FAIL: oomd-disabled: keystone still applied DefaultMemoryPressureDurationSec=20s" >&2
+          exit 1
+        fi
+        echo "OK: oomd-disabled: keystone did not apply pressure window (got '${actual}')"
+        touch $out
+      '';
+
     # Containers disabled → admin does NOT get podman, but still gets
     # the unconditional admin groups (dialout, media).
     auto-groups-admin-no-containers =
@@ -667,6 +738,8 @@ pkgs.runCommand "test-os-evaluation"
     echo "  - journal-remote-server: Journal collection server (HTTPS via nginx)"
     echo "  - journal-remote-client: Journal upload client (HTTPS via nginx)"
     echo "  - journal-remote-client-no-domain: Journal upload client (HTTP fallback)"
+    echo "  - oomd-default-on: keystone.os.oomd.enable defaults to true and applies 20 s pressure window"
+    echo "  - oomd-disabled: keystone.os.oomd.enable = false drops the keystone-specific oomd contribution"
     echo ""
     echo "All configurations evaluated successfully!"
     touch $out

--- a/tests/module/os-evaluation.nix
+++ b/tests/module/os-evaluation.nix
@@ -625,9 +625,11 @@ let
     # option.
 
     # systemd-oomd is wired up by default and applies the keystone-specific
-    # 20-second pressure window. The DefaultMemoryPressureDurationSec value is
-    # the keystone-unique signature — the slice-enable flags overlap with
-    # NixOS defaults, so asserting the extraConfig is the cleanest pin.
+    # 20-second pressure window.  Two independent keystone signatures are
+    # checked so the test cannot pass vacuously if nixpkgs ever happens to
+    # adopt the same value as its own default:
+    #   1. DefaultMemoryPressureDurationSec is present in extraConfig and = "20s"
+    #   2. enableRootSlice = true  (NixOS upstream default is false)
     oomd-default-on =
       let
         result = (import "${pkgs.path}/nixos/lib/eval-config.nix") {
@@ -648,21 +650,37 @@ let
             }
           ];
         };
-        actual = result.config.systemd.oomd.extraConfig.DefaultMemoryPressureDurationSec or "<unset>";
+        oomdCfg = result.config.systemd.oomd;
+        hasDuration = builtins.hasAttr "DefaultMemoryPressureDurationSec" oomdCfg.extraConfig;
+        actualDuration = oomdCfg.extraConfig.DefaultMemoryPressureDurationSec or "<unset>";
+        actualRootSlice = oomdCfg.enableRootSlice;
       in
       pkgs.runCommand "oomd-default-on" { } ''
-        if [ "${actual}" != "20s" ]; then
-          echo "FAIL: oomd-default-on: expected DefaultMemoryPressureDurationSec=20s, got '${actual}'" >&2
-          exit 1
+        ok=1
+        if [ "${builtins.toJSON hasDuration}" != "true" ]; then
+          echo "FAIL: oomd-default-on: DefaultMemoryPressureDurationSec absent from extraConfig" >&2
+          ok=0
         fi
-        echo "OK: oomd-default-on: DefaultMemoryPressureDurationSec=${actual}"
+        if [ "${actualDuration}" != "20s" ]; then
+          echo "FAIL: oomd-default-on: expected DefaultMemoryPressureDurationSec=20s, got '${actualDuration}'" >&2
+          ok=0
+        fi
+        if [ "${builtins.toJSON actualRootSlice}" != "true" ]; then
+          echo "FAIL: oomd-default-on: expected enableRootSlice=true (keystone default), got '${builtins.toJSON actualRootSlice}'" >&2
+          ok=0
+        fi
+        [ "$ok" = "1" ] || exit 1
+        echo "OK: oomd-default-on: duration=${actualDuration} enableRootSlice=${builtins.toJSON actualRootSlice}"
         touch $out
       '';
 
-    # When keystone.os.oomd.enable = false, the keystone module MUST NOT set
-    # the 20 s pressure window. NixOS may still leave systemd-oomd enabled at
-    # its own defaults; this test only verifies the keystone contribution
-    # disappears.
+    # When keystone.os.oomd.enable = false, the keystone module MUST NOT inject
+    # its settings.  Two independent keystone-absence checks are made so the
+    # test cannot produce a false negative if nixpkgs ever also defaults one of
+    # these to the same value:
+    #   1. DefaultMemoryPressureDurationSec must be ABSENT from extraConfig
+    #      (key presence, not value comparison — robust against upstream adopting "20s")
+    #   2. enableRootSlice must be false  (the NixOS upstream default)
     oomd-disabled =
       let
         result = (import "${pkgs.path}/nixos/lib/eval-config.nix") {
@@ -684,14 +702,22 @@ let
             }
           ];
         };
-        actual = result.config.systemd.oomd.extraConfig.DefaultMemoryPressureDurationSec or "<unset>";
+        oomdCfg = result.config.systemd.oomd;
+        hasDuration = builtins.hasAttr "DefaultMemoryPressureDurationSec" oomdCfg.extraConfig;
+        actualRootSlice = oomdCfg.enableRootSlice;
       in
       pkgs.runCommand "oomd-disabled" { } ''
-        if [ "${actual}" = "20s" ]; then
-          echo "FAIL: oomd-disabled: keystone still applied DefaultMemoryPressureDurationSec=20s" >&2
-          exit 1
+        ok=1
+        if [ "${builtins.toJSON hasDuration}" = "true" ]; then
+          echo "FAIL: oomd-disabled: keystone still injected DefaultMemoryPressureDurationSec into extraConfig" >&2
+          ok=0
         fi
-        echo "OK: oomd-disabled: keystone did not apply pressure window (got '${actual}')"
+        if [ "${builtins.toJSON actualRootSlice}" = "true" ]; then
+          echo "FAIL: oomd-disabled: keystone still set enableRootSlice=true" >&2
+          ok=0
+        fi
+        [ "$ok" = "1" ] || exit 1
+        echo "OK: oomd-disabled: keystone contribution absent (hasDuration=${builtins.toJSON hasDuration} enableRootSlice=${builtins.toJSON actualRootSlice})"
         touch $out
       '';
 


### PR DESCRIPTION
## Summary

Carves out the systemd-oomd portion of #484 / #485 into a self-contained, no-dependency module so it can land independently of the zram, `vm.*` sysctls, and ZFS ARC cap work still in review on #485.

systemd-oomd is the modern userspace OOM killer: it watches PSI (Pressure Stall Information) on cgroups and kills the offending cgroup before the in-kernel oom-killer fires too late and the system has already wedged. On hosts that have hit OOM-induced freezes (workstation, 2026-04-08 and 2026-04-15), this is the single change most likely to convert a "freeze + hard reboot" into a clean cgroup kill.

## Why split it out

| Piece | Risk | Dependencies | In this PR |
|---|---|---|---|
| systemd-oomd | low — single NixOS option block | none | ✅ |
| zram swap | medium — interacts with hibernation, swap priority | none | ❌ (in #485) |
| `vm.*` sysctls | medium — system-wide reclaim behavior | tuned for zram | ❌ (in #485) |
| ZFS ARC cap | medium — kernel param, requires reboot | host registry change | ❌ (in #485) |

systemd-oomd has the smallest blast radius, no interaction with storage type or hibernation, and produces an immediately observable improvement (`journalctl -u systemd-oomd` will start logging cgroup kills under pressure).

## Changes

- New `modules/os/oomd.nix`: `keystone.os.oomd.enable` (default `true`), gated on `keystone.os.enable`. Sets `systemd.oomd.{enable,enableUserSlices,enableRootSlice,enableSystemSlice} = true` and `extraConfig.DefaultMemoryPressureDurationSec = "20s"`.
- `modules/os/default.nix`: imports `./oomd.nix`.
- `tests/module/os-evaluation.nix`: two new eval-time tests pinning the keystone-specific 20 s pressure window when enabled, and confirming it drops out when `keystone.os.oomd.enable = false`.
- `modules/os/AGENTS.md`: brief reference for contributors.

## Compatibility with #485

#485's `modules/os/memory-pressure.nix` currently bundles oomd with zram and sysctls. If this PR lands first, #485 will need a small rebase to drop the `systemd.oomd = { … }` block from its `memory-pressure.nix` (it can either consume `keystone.os.oomd.enable` directly or just leave oomd to this module). Either order works; this PR does not block #485, and merging this first reduces #485's diff.

## Test plan

- [x] `nix build .#checks.x86_64-linux.os-evaluation` passes (verified locally)
- [ ] CI green
- [ ] On a host running this change, `systemctl status systemd-oomd` shows it active, and `oomctl` lists user/root/system slices being monitored
- [ ] Under synthetic memory pressure (`stress-ng --vm 4 --vm-bytes 80% --timeout 30s`), `journalctl -u systemd-oomd` logs a cgroup kill before the kernel oom-killer fires

## Related

- Refs #484 (parent issue)
- Carves out from #485 (which retains the zram + sysctl + ARC-cap work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)