### PR TITLE
feat(os/containers): enable podman dockerCompat by default

### DIFF
--- a/modules/os/containers.nix
+++ b/modules/os/containers.nix
@@ -38,6 +38,11 @@ in
     virtualisation.docker.enable = lib.mkForce false;
     virtualisation.podman = {
       enable = true;
+      # Provides the `docker` CLI shim so existing docker-based tooling
+      # (scripts, compose files, IDE integrations) works transparently
+      # against podman. Safe because `virtualisation.docker.enable` is
+      # forced off above, so the shim never collides with real Docker.
+      dockerCompat = true;
       dockerSocket.enable = true;
       defaultNetwork.settings.dns_enabled = true;
     };


### PR DESCRIPTION
## Summary
- Sets `virtualisation.podman.dockerCompat = true` in `modules/os/containers.nix` so the `docker` CLI shim is available on all keystone hosts.
- Pairs with the already-enabled `dockerSocket.enable = true` for a complete drop-in: existing docker-based tooling (compose, scripts, IDE integrations) works transparently against podman with no per-host opt-in.
- Safe by construction: `virtualisation.docker.enable = lib.mkForce false` is set in the same module, so the shim cannot collide with a real Docker install.

## Test plan
- [ ] `ks build` on workstation
- [ ] `ks build` on laptop
- [ ] After deploy: `docker --version` resolves to podman, `docker run --rm hello-world` succeeds as the admin user

🤖 Generated with [Claude Code](https://claude.com/claude-code)