### PR TITLE
refactor(desktop): launch update via uwsm session app

### DIFF
--- a/modules/desktop/home/scripts/keystone-main-menu.sh
+++ b/modules/desktop/home/scripts/keystone-main-menu.sh
@@ -434,12 +434,9 @@ dispatch() {
       ;;
     run-update)
       # CRITICAL: delegate to the dedicated update submenu's dispatch path
-      # so the top-level Walker entry uses the supervised ks-update.service
-      # flow (polkit prompt via hyprpolkitagent, silent success path,
-      # journaled failure) instead of spawning a terminal. The legacy
-      # `ghostty -e ks update` ceremony was retired by #404 in the dedicated
-      # submenu but survived here until #414. Any change to the unit-firing
-      # contract belongs in update_menu.rs::dispatch, not duplicated here.
+      # so the top-level Walker entry stays aligned with the authoritative
+      # update launcher. Approval needs a real terminal on this desktop
+      # stack, so the submenu owns the Ghostty launch logic.
       ks menu update dispatch run-update
       ;;
     screenshot-smart)

--- a/modules/desktop/home/scripts/keystone-main-menu.sh
+++ b/modules/desktop/home/scripts/keystone-main-menu.sh
@@ -435,8 +435,12 @@ dispatch() {
     run-update)
       # CRITICAL: delegate to the dedicated update submenu's dispatch path
       # so the top-level Walker entry stays aligned with the authoritative
-      # update launcher. Approval needs a real terminal on this desktop
-      # stack, so the submenu owns the Ghostty launch logic.
+      # update launcher. The submenu spawns `ks update --approve` via
+      # `uwsm app -- systemd-inhibit … systemd-cat -t ks-update …` (no
+      # terminal); polkit prompt + notify-send make the run silent on
+      # success and journaled under tag `ks-update` on failure. Any
+      # change to the launch contract belongs in
+      # update_menu.rs::dispatch, not duplicated here.
       ks menu update dispatch run-update
       ;;
     screenshot-smart)

--- a/modules/desktop/home/services.nix
+++ b/modules/desktop/home/services.nix
@@ -1,130 +1,16 @@
-# Systemd user services for desktop-triggered background work.
-#
-# ks-update.service runs `ks update --approve` in the background so Walker
-# (and future triggers like keybinds or cron) can kick off a host update
-# without opening a terminal. Approval uses pkexec via the already-running
-# hyprpolkitagent; output goes to the journal; completion fires a
-# notification via the ks-update-notify@.service template.
-#
-# Principal parity (process.keystone-principal-parity): these units are
-# deliberately gated on `keystone.desktop.enable` — they're only useful on
-# principals that run a graphical session. Agents declared with desktop
-# access inherit the units automatically; headless principals don't get
-# them. Do not move this module to a desktop-neutral location.
-#
-# Rationale: see issue #414 and the accompanying PR. Prior to this module
-# the Walker update entry launched Ghostty and ran `ks approve -- ks update`
-# inline — this moves that work to a supervised background unit so the
-# success path is silent (polkit prompt + desktop notification) and the
-# failure path preserves logs in the journal for on-demand review.
-#
-# Update channel: `keystone.update.channel` (stable | unstable) selects which
-# GitHub source `ks menu update` tracks. The channel is passed in via
-# the KS_UPDATE_CHANNEL environment variable on both the worker unit
-# (ks-update.service) and the notifier template (ks-update-notify@.service)
-# so the Walker preview, release fetch, and notification copy all agree on
-# which source the host is tracking. Stable (default) uses `/releases/latest`
-# and only accepts `v<M>.<m>.<p>` tags; unstable uses
-# `/repos/OWNER/REPO/branches/main` and tracks the tip commit of `main` — a
-# moving SHA, not a tagged release. Changing the option requires a rebuild
-# because the channel is embedded into the unit Environment at activation
-# time, not read from a runtime file.
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 with lib;
 let
   cfg = config.keystone.desktop;
-  updateChannel = config.keystone.update.channel;
-  ksBin = "${pkgs.keystone.ks}/bin/ks";
-  systemdBin = "${pkgs.systemd}/bin/systemd-inhibit";
-
-  # `ks update` (invoked by ks-update.service) shells out to git, nix,
-  # pkexec, and keystone-approve-exec. Systemd user units start with a
-  # minimal PATH that does not include these, so spawn-by-name would fail
-  # inside the unit even though it works in an interactive shell.
-  #
-  # `/run/current-system/sw/bin` is the NixOS system-wide toolchain and
-  # contains git, nix, and keystone-approve-exec. `/run/wrappers/bin`
-  # holds setuid wrappers like pkexec. Together they cover everything
-  # `ks update --approve` needs for a supervised background run.
-  updatePath = "/run/wrappers/bin:/run/current-system/sw/bin";
-
-  # `ks notify` only shells out to journalctl (systemd) and notify-send
-  # (libnotify). Pin those explicitly rather than relying on the system
-  # path so the notifier keeps working even if the system profile
-  # excludes libnotify for any reason.
-  notifyPath = "${pkgs.systemd}/bin:${pkgs.libnotify}/bin";
 in
 {
   config = mkIf cfg.enable {
-    systemd.user.services.ks-update = {
-      Unit = {
-        Description = "Keystone OS update (background)";
-        After = [
-          "graphical-session.target"
-          "network-online.target"
-        ];
-        Wants = [ "network-online.target" ];
-        OnSuccess = [ "ks-update-notify@success.service" ];
-        OnFailure = [ "ks-update-notify@failure.service" ];
-      };
-      Service = {
-        Type = "oneshot";
-        # CRITICAL: import the graphical-session env from the user manager.
-        # `ks update --approve` calls `cmd::approve::has_graphical_session()`
-        # which checks DISPLAY / WAYLAND_DISPLAY / XDG_SESSION_TYPE to decide
-        # between pkexec (graphical, polkit prompt) and sudo (terminal).
-        # systemd user units start with a near-empty environment, so without
-        # PassEnvironment the function returns false, ks falls back to sudo,
-        # sudo finds no tty, and the unit silently exits 1 in milliseconds.
-        # XDG_RUNTIME_DIR + DBUS_SESSION_BUS_ADDRESS are required for pkexec
-        # to reach hyprpolkitagent on the user bus — without them the polkit
-        # prompt never renders and authentication fails silently.
-        PassEnvironment = "DISPLAY WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS";
-        Environment = [
-          "PATH=${updatePath}"
-          "KS_UPDATE_CHANNEL=${updateChannel}"
-        ];
-        # systemd-inhibit blocks suspend/shutdown for the duration of the
-        # update so a laptop lid close mid-rebuild doesn't wedge the unit.
-        # Single-line form (concatStringsSep) matches the keystone unit
-        # idiom and avoids relying on systemd's line-continuation parsing.
-        ExecStart = concatStringsSep " " [
-          systemdBin
-          "--what=sleep:shutdown:idle"
-          "--why=\"Keystone OS update in progress\""
-          "--mode=block"
-          ksBin
-          "update"
-          "--approve"
-        ];
-        # Polkit prompts may sit for a while if the user steps away. 30 min
-        # is enough to cover the largest real updates plus approval latency;
-        # beyond that we surface a timeout failure via OnFailure.
-        TimeoutStartSec = "30min";
-      };
-    };
-
-    # Template unit invoked via OnSuccess/OnFailure on ks-update.service.
-    # The instance name (%i) is either "success" or "failure" and is passed
-    # through to `ks notify`, which reads the ks-update.service journal and
-    # fires an appropriate desktop notification.
-    systemd.user.services."ks-update-notify@" = {
-      Unit = {
-        Description = "Keystone update notification (%i)";
-      };
-      Service = {
-        Type = "oneshot";
-        Environment = [
-          "PATH=${notifyPath}"
-          "KS_UPDATE_CHANNEL=${updateChannel}"
-        ];
-        ExecStart = "${ksBin} notify ks-update.service %i";
-      };
-    };
+    # Walker update now launches `ks update --approve` as a graphical session
+    # app via `uwsm app -- systemd-cat ...`, so there is no dedicated
+    # ks-update.service / notifier template to install here anymore.
   };
 }

--- a/modules/os/journal-remote.nix
+++ b/modules/os/journal-remote.nix
@@ -170,6 +170,14 @@ in
           TrustedCertificateFile = "/etc/ssl/certs/ca-bundle.crt";
         };
       };
+
+      systemd.services.systemd-journal-upload.serviceConfig = {
+        # systemd-journal-upload exits 1 for malformed or oversized local
+        # journal entries. Treat that as retryable so observability cannot
+        # make switch-to-configuration fail an otherwise valid system update.
+        SuccessExitStatus = [ 1 ];
+        RestartSec = mkForce "5min";
+      };
     })
   ]);
 }

--- a/modules/shared/system-flake.nix
+++ b/modules/shared/system-flake.nix
@@ -18,6 +18,8 @@ let
   cfg = config.keystone.systemFlake;
 in
 {
+  imports = [ ./update.nix ];
+
   options.keystone.systemFlake = {
     path = mkOption {
       type = types.path;
@@ -39,9 +41,11 @@ in
   config = {
     # Write the resolved path into the system derivation so that it is
     # available at /run/current-system/keystone-system-flake after every
-    # nixos-rebuild switch / boot.
-    system.extraSystemBuilderCmds = ''
+    # nixos-rebuild switch / boot. The effective update channel is written
+    # alongside it so runtime tools do not depend on session env freshness.
+    system.systemBuilderCommands = ''
       printf '%s\n' "${cfg.path}" > $out/keystone-system-flake
+      printf '%s\n' "${config.keystone.update.channel}" > $out/keystone-update-channel
     '';
   };
 }

--- a/modules/shared/update.nix
+++ b/modules/shared/update.nix
@@ -5,8 +5,9 @@
 # selection is available everywhere. Nix deduplicates identical imports.
 #
 # The channel selects which GitHub source the Walker update menu
-# (ks menu update) tracks. It is surfaced to `ks` at runtime via the
-# KS_UPDATE_CHANNEL environment variable.
+# (ks menu update) tracks. It is surfaced to `ks` at runtime via
+# /run/current-system/keystone-update-channel, with KS_UPDATE_CHANNEL as
+# an optional override for interactive shells and tests.
 { lib, ... }:
 {
   options.keystone.update = {
@@ -26,8 +27,8 @@
           `/repos/OWNER/REPO/branches/main` endpoint and tracks the tip
           commit directly.
 
-        Changing the channel requires a flake rebuild so the new value is
-        threaded into the ks-update.service environment and the user shell.
+        Changing the channel requires a flake rebuild so the running system's
+        `/run/current-system/keystone-update-channel` file is regenerated.
       '';
     };
   };

--- a/modules/terminal/default.nix
+++ b/modules/terminal/default.nix
@@ -240,10 +240,8 @@ in
       CODE_DIR = codeRoot;
       WORKTREE_DIR = worktreeRoot;
       NOTES_DIR = notesPath;
-      # Keep interactive `ks menu update status` and the background
-      # ks-update.service agreeing on which release feed they poll.
-      # services.nix threads the same value into the worker and notifier
-      # unit Environment blocks.
+      # Interactive shells can override the system runtime channel pointer;
+      # correctness no longer depends on this being present in detached apps.
       KS_UPDATE_CHANNEL = config.keystone.update.channel;
     };
 

--- a/packages/hyprpolkitagent/default.nix
+++ b/packages/hyprpolkitagent/default.nix
@@ -13,7 +13,8 @@ hyprpolkitagent.overrideAttrs (old: {
     mv "$out/libexec/hyprpolkitagent" "$out/libexec/.hyprpolkitagent-keystone"
     cat > "$out/libexec/hyprpolkitagent" <<EOF
     #!${stdenv.shell}
-    export KEYSTONE_POLKIT_THEME="''${KEYSTONE_POLKIT_THEME:-$HOME/.config/keystone/current/polkit.json}"
+    export KEYSTONE_POLKIT_THEME="''${KEYSTONE_POLKIT_THEME:-\$HOME/.config/keystone/current/polkit.json}"
+    export QML_XHR_ALLOW_FILE_READ="''${QML_XHR_ALLOW_FILE_READ:-1}"
     exec "$out/libexec/.hyprpolkitagent-keystone" "\$@"
     EOF
     chmod +x "$out/libexec/hyprpolkitagent"

--- a/packages/ks/src/cli.rs
+++ b/packages/ks/src/cli.rs
@@ -114,8 +114,9 @@ pub enum Command {
         json: bool,
 
         /// Route this invocation through the approval broker before running
-        /// the update body. Used by `ks-update.service` so the Walker-
-        /// triggered flow gets a polkit prompt instead of assuming root.
+        /// the update body. Used by the Walker-triggered graphical-session
+        /// launch so the update flow gets a polkit prompt instead of
+        /// assuming root.
         ///
         /// When `KS_APPROVE_EXECUTING` is set (i.e., we are already the
         /// approved child), this flag is a no-op and the body runs directly.

--- a/packages/ks/src/cmd/doctor.rs
+++ b/packages/ks/src/cmd/doctor.rs
@@ -467,16 +467,14 @@ fn pkexec_is_setuid() -> bool {
 }
 
 /// Verify the runtime prereqs for the Walker-triggered update flow
-/// introduced alongside `ks-update.service`:
+/// launched from the graphical session:
 ///
 /// 1. A polkit authentication agent is active on the user bus (so the
 ///    approval popup can render).
 /// 2. A notification daemon is registered on the session D-Bus (so
-///    `ks notify` actually surfaces to the user).
+///    completion/failure notifications surface to the user).
 /// 3. `/run/wrappers/bin/pkexec` is setuid (so `ks approve` can
 ///    escalate).
-/// 4. `ks-update.service` and `ks-update-notify@.service` are loaded on
-///    the user bus (so the dispatch -> unit -> notifier chain works).
 ///
 /// Only runs on hosts that look like desktops (detected by the presence
 /// of the `hyprpolkitagent.service` user unit). On headless hosts the
@@ -526,9 +524,6 @@ async fn gather_desktop_triggers() -> (String, Vec<DiagnosticCheck>) {
     let polkit_ok = systemctl_user_is_active("hyprpolkitagent.service").await;
     let notify_ok = notification_daemon_active().await;
     let pkexec_ok = pkexec_is_setuid();
-    let update_loaded = systemctl_user_unit_exists("ks-update.service").await;
-    let notifier_loaded = systemctl_user_unit_exists("ks-update-notify@.service").await;
-
     let results = [
         DesktopCheck {
             name: "desktop-triggers.polkit-agent",
@@ -557,27 +552,9 @@ async fn gather_desktop_triggers() -> (String, Vec<DiagnosticCheck>) {
             ok_detail: "/run/wrappers/bin/pkexec setuid",
             err_detail: "/run/wrappers/bin/pkexec not setuid",
         },
-        DesktopCheck {
-            name: "desktop-triggers.ks-update-service",
-            label: "ks-update.service",
-            ok: update_loaded,
-            ok_md: "loaded",
-            err_md: "**not loaded** — this host is missing the keystone.desktop services module or `ks update --dev` hasn't applied yet",
-            ok_detail: "ks-update.service loaded on user bus",
-            err_detail: "ks-update.service not loaded",
-        },
-        DesktopCheck {
-            name: "desktop-triggers.ks-update-notify-template",
-            label: "ks-update-notify@.service template",
-            ok: notifier_loaded,
-            ok_md: "loaded",
-            err_md: "**not loaded** — completion notifications won't fire",
-            ok_detail: "ks-update-notify@.service template loaded",
-            err_detail: "ks-update-notify@.service template not loaded",
-        },
     ];
 
-    let mut md = String::from("### Desktop-triggered background flow\n\n");
+    let mut md = String::from("### Desktop-triggered update flow\n\n");
     let mut checks = Vec::with_capacity(results.len());
     for r in &results {
         r.render_markdown(&mut md);

--- a/packages/ks/src/cmd/notify.rs
+++ b/packages/ks/src/cmd/notify.rs
@@ -14,6 +14,8 @@
 use anyhow::{Context, Result};
 use std::process::Command;
 
+use super::util::notify_send;
+
 /// Result tag passed by the template unit instance (`@success` / `@failure`).
 #[derive(Debug, Clone, Copy)]
 enum NotifyResult {
@@ -101,25 +103,5 @@ pub fn execute(unit: &str, result: &str) -> Result<()> {
     let title = unit_title(unit, parsed);
     let body = notification_body(unit, parsed);
 
-    // `--` stops notify-send's option parsing so a unit name / rendered
-    // title beginning with `-` isn't misread as a flag.
-    let status = Command::new("notify-send")
-        .args([
-            "--app-name=Keystone",
-            &format!("--urgency={}", parsed.urgency()),
-            "--",
-            &title,
-            &body,
-        ])
-        .status()
-        .context("failed to invoke notify-send (is libnotify installed?)")?;
-
-    if !status.success() {
-        anyhow::bail!(
-            "notify-send exited with status {}",
-            status.code().unwrap_or(-1)
-        );
-    }
-
-    Ok(())
+    notify_send(&title, &body, parsed.urgency())
 }

--- a/packages/ks/src/cmd/update_approve.rs
+++ b/packages/ks/src/cmd/update_approve.rs
@@ -4,8 +4,8 @@
 //! Privilege boundary (issue #487):
 //!
 //! ```text
-//! walker → systemctl --user start ks-update.service
-//!        → ks update --approve                                  [user]
+//! walker → uwsm app -- systemd-cat -t ks-update ks update --approve
+//!                                                          [user session]
 //!             ├─ pre-flight: refuse if local != origin           [user]
 //!             ├─ resolve channel target ref via GitHub API       [user]
 //!             ├─ nix build --override-input keystone <ref>       [user]
@@ -545,21 +545,18 @@ pub(crate) async fn run_supervised_update(
 
     // Step 3: activate via the privileged broker. We *wait* for the
     // child to exit so we can decide whether to mutate the lock based
-    // on whether activation actually succeeded. If it failed, return
-    // an outcome that records what we built but leave the lock alone.
+    // on whether activation actually succeeded. If it failed, abort the
+    // flow and leave the lock alone.
     let host_label = util::hostname_label();
     let reason = approval_reason(&host_label);
     eprintln!("Requesting approval to activate {store_path}…");
     let activated = activate_via_broker(&reason, &store_path)?;
     if !activated {
-        return Ok(ApproveUpdateOutcome {
-            host: host.clone(),
-            channel: channel.as_str(),
-            target_ref: target_label,
-            store_path: store_path.clone(),
-            lock_advanced: false,
-            pushed: false,
-        });
+        anyhow::bail!(
+            "activation was not approved or failed for {} on host {}; flake.lock was left unchanged",
+            target_label,
+            host
+        );
     }
 
     // Step 4: relock pinned to the rev we just built and activated.

--- a/packages/ks/src/cmd/update_approve.rs
+++ b/packages/ks/src/cmd/update_approve.rs
@@ -4,7 +4,8 @@
 //! Privilege boundary (issue #487):
 //!
 //! ```text
-//! walker → uwsm app -- systemd-cat -t ks-update ks update --approve
+//! walker → uwsm app -- systemd-inhibit … systemd-cat
+//!                          --identifier=ks-update ks update --approve
 //!                                                          [user session]
 //!             ├─ pre-flight: refuse if local != origin           [user]
 //!             ├─ resolve channel target ref via GitHub API       [user]

--- a/packages/ks/src/cmd/update_menu.rs
+++ b/packages/ks/src/cmd/update_menu.rs
@@ -1185,19 +1185,8 @@ fn xdg_open_detached(url: &str) -> Result<()> {
     Ok(())
 }
 
-fn find_executable(name: &str) -> Option<PathBuf> {
-    let path = env::var_os("PATH")?;
-    for entry in env::split_paths(&path) {
-        let candidate = entry.join(name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
-
 fn command_or_name(name: &str) -> PathBuf {
-    find_executable(name).unwrap_or_else(|| PathBuf::from(name))
+    super::util::find_executable(name).unwrap_or_else(|| PathBuf::from(name))
 }
 
 fn update_session_command_with_paths(
@@ -1255,7 +1244,7 @@ fn update_session_command(
 /// `/dev/tty` path.
 fn start_update_session(flake: Option<&Path>) -> Result<()> {
     let ks_bin = env::current_exe().context("failed to resolve current ks executable")?;
-    let (program, args) = update_session_command(&ks_bin, flake, find_executable("uwsm"));
+    let (program, args) = update_session_command(&ks_bin, flake, super::util::find_executable("uwsm"));
 
     Command::new(&program)
         .args(&args)

--- a/packages/ks/src/cmd/update_menu.rs
+++ b/packages/ks/src/cmd/update_menu.rs
@@ -20,8 +20,10 @@
 //! Replaces the previous bash implementation at
 //! `modules/desktop/home/scripts/keystone-update-menu.sh`.
 
+use std::env;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -37,9 +39,10 @@ pub(crate) const RELEASE_REPO: &str = "keystone";
 // -----------------------------------------------------------------------------
 
 /// Release source the menu tracks. Selected by `keystone.update.channel` in
-/// the Nix module, threaded in via the KS_UPDATE_CHANNEL environment
-/// variable. Fail-closed default is `Stable` so an unset, empty, or unknown
-/// env value never flips a host onto the moving-main source implicitly.
+/// the Nix module, surfaced at runtime via `KS_UPDATE_CHANNEL` and
+/// `/run/current-system/keystone-update-channel`. Fail-closed default is
+/// `Stable` so an unset, empty, or unknown source never flips a host onto the
+/// moving-main source implicitly.
 ///
 /// Visible at crate scope so the Walker → Update orchestrator
 /// (`cmd::update`) can resolve the same target the menu surfaces.
@@ -53,15 +56,29 @@ pub(crate) enum Channel {
 }
 
 impl Channel {
-    /// Resolve the active channel from KS_UPDATE_CHANNEL. Any value other
-    /// than exactly `"unstable"` maps to `Stable` — including empty strings,
-    /// mixed case, and typos like `"beta"` — so a misconfigured environment
-    /// never quietly flips a host onto the moving-main source.
-    pub(crate) fn current() -> Self {
-        match std::env::var("KS_UPDATE_CHANNEL").as_deref() {
-            Ok("unstable") => Self::Unstable,
-            _ => Self::Stable,
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "stable" => Some(Self::Stable),
+            "unstable" => Some(Self::Unstable),
+            _ => None,
         }
+    }
+
+    /// Resolve the active channel from KS_UPDATE_CHANNEL first, then the
+    /// runtime pointer file written into `/run/current-system`. Any other
+    /// value maps to `Stable` so a misconfigured runtime never quietly flips a
+    /// host onto the moving-main source.
+    pub(crate) fn current() -> Self {
+        std::env::var("KS_UPDATE_CHANNEL")
+            .ok()
+            .as_deref()
+            .and_then(Self::parse)
+            .or_else(|| {
+                repo::read_system_update_channel()
+                    .as_deref()
+                    .and_then(Self::parse)
+            })
+            .unwrap_or(Self::Stable)
     }
 
     pub(crate) fn as_str(&self) -> &'static str {
@@ -1168,17 +1185,87 @@ fn xdg_open_detached(url: &str) -> Result<()> {
     Ok(())
 }
 
-/// Start the background update unit via systemd --user. Delegates to
-/// `ks run-background` so the systemctl spawn plus error-surface
-/// translation lives in one place — the next Walker provider that needs
-/// a background-unit trigger can call the same verb instead of
-/// re-implementing this function.
-///
-/// The unit handles approval (pkexec via hyprpolkitagent), logging
-/// (journal), and completion notification (OnSuccess/OnFailure ->
-/// ks-update-notify@.service).
-fn start_update_unit() -> Result<()> {
-    crate::cmd::run_background::execute("ks-update.service")
+fn find_executable(name: &str) -> Option<PathBuf> {
+    let path = env::var_os("PATH")?;
+    for entry in env::split_paths(&path) {
+        let candidate = entry.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn command_or_name(name: &str) -> PathBuf {
+    find_executable(name).unwrap_or_else(|| PathBuf::from(name))
+}
+
+fn update_session_command_with_paths(
+    ks_bin: &Path,
+    flake: Option<&Path>,
+    uwsm: Option<PathBuf>,
+    systemd_inhibit: PathBuf,
+    systemd_cat: PathBuf,
+) -> (PathBuf, Vec<OsString>) {
+    let mut inner_args = vec![
+        OsString::from("--what=sleep:shutdown:idle"),
+        OsString::from("--why=Keystone OS update in progress"),
+        OsString::from("--mode=block"),
+        systemd_cat.into_os_string(),
+        OsString::from("--identifier=ks-update"),
+        ks_bin.as_os_str().to_os_string(),
+        OsString::from("update"),
+        OsString::from("--approve"),
+    ];
+    if let Some(flake_path) = flake {
+        inner_args.push(OsString::from("--flake"));
+        inner_args.push(flake_path.as_os_str().to_os_string());
+    }
+
+    match uwsm {
+        Some(uwsm_bin) => {
+            let mut args = vec![
+                OsString::from("app"),
+                OsString::from("--"),
+                systemd_inhibit.into_os_string(),
+            ];
+            args.extend(inner_args);
+            (uwsm_bin, args)
+        }
+        None => (systemd_inhibit, inner_args),
+    }
+}
+
+fn update_session_command(
+    ks_bin: &Path,
+    flake: Option<&Path>,
+    uwsm: Option<PathBuf>,
+) -> (PathBuf, Vec<OsString>) {
+    update_session_command_with_paths(
+        ks_bin,
+        flake,
+        uwsm,
+        command_or_name("systemd-inhibit"),
+        command_or_name("systemd-cat"),
+    )
+}
+
+/// Launch the update flow as a graphical-session app so `pkexec` can talk to
+/// the desktop polkit agent instead of falling back to the broken user-service
+/// `/dev/tty` path.
+fn start_update_session(flake: Option<&Path>) -> Result<()> {
+    let ks_bin = env::current_exe().context("failed to resolve current ks executable")?;
+    let (program, args) = update_session_command(&ks_bin, flake, find_executable("uwsm"));
+
+    Command::new(&program)
+        .args(&args)
+        .env("KS_UPDATE_NOTIFY", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("failed to spawn session update via {}", program.display()))?;
+    Ok(())
 }
 
 /// Look up the current blocker text from fresh state. Called when the user
@@ -1243,27 +1330,13 @@ async fn dispatch(value: &str, flake: Option<&Path>) -> Result<()> {
         ACT_RUN_UPDATE => {
             // Close the TOCTOU window between entries-render and click: if
             // the user dirtied the tree after opening the menu, refuse
-            // before firing the polkit popup (otherwise the approval
+            // before launching the session update (otherwise the approval
             // round-trip ends with `ks update` failing — strictly worse
             // UX than refusing up front with the same reason).
             match evaluate_local_gate(flake) {
-                Ok(()) => {
-                    // If `systemctl --user start` itself fails (unit not
-                    // loaded, user bus unavailable, systemctl not on PATH),
-                    // the error propagates out of `dispatch` → Walker. But
-                    // Walker doesn't surface stderr to the user, so this
-                    // would be a silent failure. Catch and surface via
-                    // notify-send with a pointer at the journal so the user
-                    // has something actionable.
-                    if let Err(err) = start_update_unit() {
-                        run_notify_send(
-                            "Keystone update failed to start",
-                            &format!("{err}\n\nSee journalctl --user -u ks-update.service -b"),
-                        )
-                    } else {
-                        Ok(())
-                    }
-                }
+                Ok(()) => start_update_session(flake).or_else(|err| {
+                    run_notify_send("Keystone update failed to start", &err.to_string())
+                }),
                 Err(reason) => run_notify_send("Keystone update unavailable", &reason),
             }
         }
@@ -1402,6 +1475,52 @@ mod tests {
         assert_eq!(short(""), "");
     }
 
+    #[test]
+    fn update_session_command_uses_uwsm_and_journald_when_available() {
+        let (program, args) = update_session_command_with_paths(
+            Path::new("/run/current-system/sw/bin/ks"),
+            Some(Path::new("/tmp/test flake")),
+            Some(PathBuf::from("/run/current-system/sw/bin/uwsm")),
+            PathBuf::from("/run/current-system/sw/bin/systemd-inhibit"),
+            PathBuf::from("/run/current-system/sw/bin/systemd-cat"),
+        );
+        let rendered: Vec<String> = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(program, PathBuf::from("/run/current-system/sw/bin/uwsm"));
+        assert_eq!(
+            rendered[0..3],
+            ["app", "--", "/run/current-system/sw/bin/systemd-inhibit"]
+        );
+        assert!(rendered.contains(&"--identifier=ks-update".to_string()));
+        assert!(rendered.contains(&"/run/current-system/sw/bin/ks".to_string()));
+        assert!(rendered.contains(&"--approve".to_string()));
+        assert!(rendered.contains(&"--flake".to_string()));
+        assert!(rendered.contains(&"/tmp/test flake".to_string()));
+    }
+
+    #[test]
+    fn update_session_command_falls_back_without_uwsm() {
+        let (program, args) = update_session_command_with_paths(
+            Path::new("/run/current-system/sw/bin/ks"),
+            None,
+            None,
+            PathBuf::from("/run/current-system/sw/bin/systemd-inhibit"),
+            PathBuf::from("/run/current-system/sw/bin/systemd-cat"),
+        );
+        let rendered: Vec<String> = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            program,
+            PathBuf::from("/run/current-system/sw/bin/systemd-inhibit")
+        );
+        assert!(rendered.contains(&"--identifier=ks-update".to_string()));
+        assert!(rendered.contains(&"/run/current-system/sw/bin/ks".to_string()));
+    }
+
     // CRITICAL: env mutation is process-global; serialise KS_UPDATE_CHANNEL
     // guard usage with a mutex so parallel tests don't observe each other's
     // env state. Same pattern as SKIP_NIX_EVAL_LOCK in repo.rs.
@@ -1409,16 +1528,27 @@ mod tests {
     struct ChannelEnvGuard {
         _lock: std::sync::MutexGuard<'static, ()>,
         prior: Option<String>,
+        prior_file: Option<std::ffi::OsString>,
+        _tempdir: tempfile::TempDir,
     }
     impl ChannelEnvGuard {
         fn new(value: Option<&str>) -> Self {
             let lock = CHANNEL_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
             let prior = std::env::var("KS_UPDATE_CHANNEL").ok();
+            let prior_file = std::env::var_os("KEYSTONE_UPDATE_CHANNEL_FILE");
+            let tempdir = tempfile::tempdir().expect("temp runtime dir");
+            let runtime_file = tempdir.path().join("keystone-update-channel");
+            std::env::set_var("KEYSTONE_UPDATE_CHANNEL_FILE", &runtime_file);
             match value {
                 Some(v) => std::env::set_var("KS_UPDATE_CHANNEL", v),
                 None => std::env::remove_var("KS_UPDATE_CHANNEL"),
             }
-            Self { _lock: lock, prior }
+            Self {
+                _lock: lock,
+                prior,
+                prior_file,
+                _tempdir: tempdir,
+            }
         }
     }
     impl Drop for ChannelEnvGuard {
@@ -1426,6 +1556,10 @@ mod tests {
             match self.prior.as_deref() {
                 Some(v) => std::env::set_var("KS_UPDATE_CHANNEL", v),
                 None => std::env::remove_var("KS_UPDATE_CHANNEL"),
+            }
+            match self.prior_file.as_deref() {
+                Some(v) => std::env::set_var("KEYSTONE_UPDATE_CHANNEL_FILE", v),
+                None => std::env::remove_var("KEYSTONE_UPDATE_CHANNEL_FILE"),
             }
         }
     }
@@ -1440,6 +1574,15 @@ mod tests {
     #[test]
     fn channel_current_reads_unstable_env() {
         let _guard = ChannelEnvGuard::new(Some("unstable"));
+        assert_eq!(Channel::current(), Channel::Unstable);
+        assert_eq!(Channel::current().as_str(), "unstable");
+    }
+
+    #[test]
+    fn channel_current_reads_runtime_file_when_env_missing() {
+        let _guard = ChannelEnvGuard::new(None);
+        let path = std::env::var("KEYSTONE_UPDATE_CHANNEL_FILE").unwrap();
+        std::fs::write(path, "unstable\n").unwrap();
         assert_eq!(Channel::current(), Channel::Unstable);
         assert_eq!(Channel::current().as_str(), "unstable");
     }
@@ -1467,6 +1610,14 @@ mod tests {
                 "value {val:?} must fail-closed to Stable"
             );
         }
+    }
+
+    #[test]
+    fn channel_current_env_overrides_runtime_file() {
+        let _guard = ChannelEnvGuard::new(Some("unstable"));
+        let path = std::env::var("KEYSTONE_UPDATE_CHANNEL_FILE").unwrap();
+        std::fs::write(path, "stable\n").unwrap();
+        assert_eq!(Channel::current(), Channel::Unstable);
     }
 
     #[test]

--- a/packages/ks/src/cmd/update_menu.rs
+++ b/packages/ks/src/cmd/update_menu.rs
@@ -1244,7 +1244,8 @@ fn update_session_command(
 /// `/dev/tty` path.
 fn start_update_session(flake: Option<&Path>) -> Result<()> {
     let ks_bin = env::current_exe().context("failed to resolve current ks executable")?;
-    let (program, args) = update_session_command(&ks_bin, flake, super::util::find_executable("uwsm"));
+    let (program, args) =
+        update_session_command(&ks_bin, flake, super::util::find_executable("uwsm"));
 
     Command::new(&program)
         .args(&args)

--- a/packages/ks/src/cmd/util.rs
+++ b/packages/ks/src/cmd/util.rs
@@ -22,6 +22,31 @@ pub fn require_executable(name: &str, guidance: &str) -> Result<PathBuf> {
     find_executable(name).ok_or_else(|| anyhow!(guidance.to_string()))
 }
 
+/// Fire a desktop notification via `notify-send` under the Keystone app
+/// name. `--` separates the args from the literal title/body so a unit name
+/// or rendered title beginning with `-` isn't misread as a flag.
+pub fn notify_send(summary: &str, body: &str, urgency: &str) -> Result<()> {
+    let status = Command::new("notify-send")
+        .args([
+            "--app-name=Keystone",
+            &format!("--urgency={urgency}"),
+            "--",
+            summary,
+            body,
+        ])
+        .status()
+        .context("failed to invoke notify-send (is libnotify installed?)")?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "notify-send exited with status {}",
+            status.code().unwrap_or(-1)
+        );
+    }
+
+    Ok(())
+}
+
 pub fn run_inherited(command: &mut Command, context: &str) -> Result<ExitStatus> {
     command
         .stdin(Stdio::inherit())

--- a/packages/ks/src/main.rs
+++ b/packages/ks/src/main.rs
@@ -13,7 +13,6 @@
 #![warn(clippy::cognitive_complexity)]
 
 use std::io;
-use std::process::Command as StdCommand;
 
 use anyhow::Result;
 use clap::Parser;
@@ -483,7 +482,7 @@ async fn run_supervised_update_command(json: bool, flake: Option<&std::path::Pat
                         "Activated {} on {} (channel {}).",
                         outcome.target_ref, outcome.host, outcome.channel
                     );
-                    let _ = desktop_notify("Keystone update complete", &body, "normal");
+                    let _ = cmd::util::notify_send("Keystone update complete", &body, "normal");
                 }
                 Ok(())
             }
@@ -494,7 +493,7 @@ async fn run_supervised_update_command(json: bool, flake: Option<&std::path::Pat
                     "{:#}\n\nSee journalctl --user -t ks-update -b for details.",
                     e
                 );
-                let _ = desktop_notify("Keystone update failed", &body, "critical");
+                let _ = cmd::util::notify_send("Keystone update failed", &body, "critical");
             }
             if json {
                 print_json_error(&e)
@@ -503,24 +502,6 @@ async fn run_supervised_update_command(json: bool, flake: Option<&std::path::Pat
             }
         }
     }
-}
-
-fn desktop_notify(summary: &str, body: &str, urgency: &str) -> Result<()> {
-    let status = StdCommand::new("notify-send")
-        .args([
-            "--app-name=Keystone",
-            &format!("--urgency={urgency}"),
-            "--",
-            summary,
-            body,
-        ])
-        .status()?;
-
-    if !status.success() {
-        anyhow::bail!("notify-send exited with status {:?}", status.code());
-    }
-
-    Ok(())
 }
 
 async fn run_docs_command(topic_or_path: Option<String>) -> Result<()> {

--- a/packages/ks/src/main.rs
+++ b/packages/ks/src/main.rs
@@ -13,6 +13,7 @@
 #![warn(clippy::cognitive_complexity)]
 
 use std::io;
+use std::process::Command as StdCommand;
 
 use anyhow::Result;
 use clap::Parser;
@@ -392,9 +393,9 @@ async fn run_switch_command(
 /// `--approve` and `--lock` (or `--dev`) are mutually exclusive code
 /// paths with different privilege contracts:
 ///
-/// - `--approve` (Walker → ks-update.service) → `update_approve`:
+/// - `--approve` (Walker → graphical session app) → `update_approve`:
 ///   user-side channel-aware build, narrow polkit-elevated activation.
-///   Single host only — the host the unit runs on.
+///   Single host only — the host the session app runs on.
 /// - `--lock` / default → `cmd::update::execute`: terminal-only
 ///   full-fleet update, sudo-cached activation. Multiple hosts allowed.
 ///
@@ -456,6 +457,7 @@ async fn run_update_command(
 /// (so it can gate post-activation lock work on actual activation
 /// success), so control returns here on both happy and sad paths.
 async fn run_supervised_update_command(json: bool, flake: Option<&std::path::Path>) -> Result<()> {
+    let notify = std::env::var_os("KS_UPDATE_NOTIFY").is_some();
     match cmd::update_approve::run_supervised_update(flake).await {
         Ok(outcome) => {
             if json {
@@ -476,10 +478,24 @@ async fn run_supervised_update_command(json: bool, flake: Option<&std::path::Pat
                     outcome.lock_advanced,
                     outcome.pushed,
                 );
+                if notify {
+                    let body = format!(
+                        "Activated {} on {} (channel {}).",
+                        outcome.target_ref, outcome.host, outcome.channel
+                    );
+                    let _ = desktop_notify("Keystone update complete", &body, "normal");
+                }
                 Ok(())
             }
         }
         Err(e) => {
+            if notify && !json {
+                let body = format!(
+                    "{:#}\n\nSee journalctl --user -t ks-update -b for details.",
+                    e
+                );
+                let _ = desktop_notify("Keystone update failed", &body, "critical");
+            }
             if json {
                 print_json_error(&e)
             } else {
@@ -487,6 +503,24 @@ async fn run_supervised_update_command(json: bool, flake: Option<&std::path::Pat
             }
         }
     }
+}
+
+fn desktop_notify(summary: &str, body: &str, urgency: &str) -> Result<()> {
+    let status = StdCommand::new("notify-send")
+        .args([
+            "--app-name=Keystone",
+            &format!("--urgency={urgency}"),
+            "--",
+            summary,
+            body,
+        ])
+        .status()?;
+
+    if !status.success() {
+        anyhow::bail!("notify-send exited with status {:?}", status.code());
+    }
+
+    Ok(())
 }
 
 async fn run_docs_command(topic_or_path: Option<String>) -> Result<()> {

--- a/packages/ks/src/repo.rs
+++ b/packages/ks/src/repo.rs
@@ -119,6 +119,9 @@ fn validate_repo_path(path: &Path) -> Option<PathBuf> {
 
 /// The default path of the system flake pointer file.
 const SYSTEM_FLAKE_POINTER_FILE: &str = "/run/current-system/keystone-system-flake";
+/// The default path of the system update-channel pointer file.
+const SYSTEM_UPDATE_CHANNEL_FILE: &str = "/run/current-system/keystone-update-channel";
+const SYSTEM_UPDATE_CHANNEL_FILE_ENV: &str = "KEYSTONE_UPDATE_CHANNEL_FILE";
 
 /// Read the system flake pointer from the given file path.
 ///
@@ -137,6 +140,24 @@ fn read_system_flake_pointer_from(pointer_file: &Path) -> Option<PathBuf> {
 /// Read the system flake pointer from `/run/current-system/keystone-system-flake`.
 fn read_system_flake_pointer() -> Option<PathBuf> {
     read_system_flake_pointer_from(Path::new(SYSTEM_FLAKE_POINTER_FILE))
+}
+
+fn read_system_update_channel_from(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let value = content.trim();
+    match value {
+        "stable" | "unstable" => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+/// Read the current system update channel from
+/// `/run/current-system/keystone-update-channel`.
+pub fn read_system_update_channel() -> Option<String> {
+    let path = std::env::var_os(SYSTEM_UPDATE_CHANNEL_FILE_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(SYSTEM_UPDATE_CHANNEL_FILE));
+    read_system_update_channel_from(&path)
 }
 
 /// Locate the active Keystone config repository.
@@ -1275,6 +1296,30 @@ mod tests {
         // Error should mention the pointer file location and --flake.
         let msg = err.to_string();
         assert!(msg.contains("--flake") || msg.contains("keystone.systemFlake"));
+    }
+
+    #[test]
+    fn read_system_update_channel_accepts_valid_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("keystone-update-channel");
+        std::fs::write(&path, "unstable\n").unwrap();
+        assert_eq!(
+            read_system_update_channel_from(&path).as_deref(),
+            Some("unstable")
+        );
+        std::fs::write(&path, "stable\n").unwrap();
+        assert_eq!(
+            read_system_update_channel_from(&path).as_deref(),
+            Some("stable")
+        );
+    }
+
+    #[test]
+    fn read_system_update_channel_rejects_invalid_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("keystone-update-channel");
+        std::fs::write(&path, "beta\n").unwrap();
+        assert!(read_system_update_channel_from(&path).is_none());
     }
 
     #[test]

--- a/specs/REQ-019-ks-cli.md
+++ b/specs/REQ-019-ks-cli.md
@@ -41,8 +41,12 @@ the following priority chain:
 3. Hard error with guidance
 
 **REQ-019.1a** The pointer file MUST contain the absolute path to the consumer
-flake followed by a newline. It is written by `system.extraSystemBuilderCmds`
+flake followed by a newline. It is written by `system.systemBuilderCommands`
 in `modules/shared/system-flake.nix` using the value of `keystone.systemFlake.path`.
+The same `systemBuilderCommands` block writes
+`/run/current-system/keystone-update-channel` from
+`config.keystone.update.channel` so detached graphical-session apps have a
+stable channel source without depending on shell env propagation.
 
 **REQ-019.1b** A valid consumer flake MUST contain `flake.nix` AND either
 `hosts/` (mkSystemFlake layout) or `hosts.nix` (legacy layout). A bare

--- a/tests/module/keystone-update-menu-wiring.nix
+++ b/tests/module/keystone-update-menu-wiring.nix
@@ -8,13 +8,19 @@
 # What those unit tests can't see is the *wiring* between files:
 #
 #   - keystone-update.lua must call `ks menu update …`.
-#   - services.nix must declare both ks-update.service and the
-#     ks-update-notify@.service template.
+#   - update_menu.rs::start_update_session must spawn the update via the
+#     graphical-session app launcher (`uwsm app -- systemd-inhibit …
+#     systemd-cat -t ks-update ks update --approve`), not via a user
+#     systemd unit. The unit-based path was retired because it lost the
+#     graphical session env that pkexec needs to reach hyprpolkitagent.
+#   - system-flake.nix must write `/run/current-system/keystone-update-channel`
+#     from `keystone.update.channel` so detached session apps have a stable
+#     channel source without depending on session env freshness.
 #   - The activation tokens emitted by entries_json (in Rust) must be the
 #     same tokens dispatch matches on (in Rust) and the same tokens the
 #     Lua provider feeds into the Action.
 #
-# If anyone renames the subcommand, drops a unit, or edits activation
+# If anyone renames the subcommand, drops the launcher, or edits activation
 # tokens without the corresponding other-file update, this test fails
 # loudly instead of silently breaking the desktop flow.
 {
@@ -23,10 +29,10 @@
 }:
 let
   luaFile = ../../modules/desktop/home/components/keystone-update.lua;
-  servicesFile = ../../modules/desktop/home/services.nix;
   updateMenuRs = ../../packages/ks/src/cmd/update_menu.rs;
-  runBackgroundRs = ../../packages/ks/src/cmd/run_background.rs;
+  repoRs = ../../packages/ks/src/repo.rs;
   updateChannelOption = ../../modules/shared/update.nix;
+  systemFlakeFile = ../../modules/shared/system-flake.nix;
   terminalDefault = ../../modules/terminal/default.nix;
   mainMenuShell = ../../modules/desktop/home/scripts/keystone-main-menu.sh;
 in
@@ -58,37 +64,39 @@ pkgs.runCommand "test-keystone-update-menu-wiring"
       fail "keystone-update.lua still references the legacy 'update-menu' command"
     fi
 
-    # -- services.nix declares the worker and notifier units --------------
-
-    if ! grep -F 'ks-update.service' ${servicesFile} >/dev/null; then
-      fail "services.nix must reference ks-update.service"
-    fi
-    if ! grep -F 'ks-update-notify@' ${servicesFile} >/dev/null; then
-      fail "services.nix must declare the ks-update-notify@ template"
-    fi
-    if ! grep -F 'OnSuccess' ${servicesFile} >/dev/null; then
-      fail "services.nix must wire OnSuccess= on ks-update.service"
-    fi
-    if ! grep -F 'OnFailure' ${servicesFile} >/dev/null; then
-      fail "services.nix must wire OnFailure= on ks-update.service"
-    fi
-
-    # -- ks-update.service imports graphical-session env -------------------
+    # -- update_menu.rs spawns the update as a session app, not a unit ----
     #
-    # `ks update --approve` (the unit's ExecStart) checks DISPLAY /
-    # WAYLAND_DISPLAY / XDG_SESSION_TYPE to decide pkexec vs sudo. Without
-    # PassEnvironment the user manager doesn't propagate those into the
-    # unit's env, ks falls through to sudo, sudo has no tty, and the unit
-    # silently exits 1. XDG_RUNTIME_DIR + DBUS_SESSION_BUS_ADDRESS are
-    # needed for pkexec to find hyprpolkitagent on the user bus.
-    if ! grep -F 'PassEnvironment' ${servicesFile} >/dev/null; then
-      fail "services.nix must declare PassEnvironment on ks-update.service so the graphical-session env reaches ks --approve"
+    # The retired `ks-update.service` path lost the graphical session env
+    # pkexec needs to talk to hyprpolkitagent. start_update_session must
+    # build a `uwsm app -- systemd-inhibit … systemd-cat -t ks-update
+    # ks update --approve` argv so the update inherits DISPLAY /
+    # WAYLAND_DISPLAY / DBUS_SESSION_BUS_ADDRESS from the session.
+
+    if ! grep -F 'start_update_session' ${updateMenuRs} >/dev/null; then
+      fail "update_menu.rs must define start_update_session for the graphical-session app launch"
     fi
-    for var in DISPLAY WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS; do
-      if ! grep -F "$var" ${servicesFile} >/dev/null; then
-        fail "ks-update.service PassEnvironment must include $var"
-      fi
-    done
+    if ! grep -F 'uwsm' ${updateMenuRs} >/dev/null; then
+      fail "update_menu.rs must launch the update via uwsm app -- … so it inherits the graphical session env"
+    fi
+    if ! grep -F '--identifier=ks-update' ${updateMenuRs} >/dev/null; then
+      fail "update_menu.rs must tag the session app with systemd-cat --identifier=ks-update for journal lookup"
+    fi
+    if ! grep -F 'systemd-inhibit' ${updateMenuRs} >/dev/null; then
+      fail "update_menu.rs must wrap the update in systemd-inhibit so suspend/shutdown can't wedge a switch"
+    fi
+    if ! grep -F '"--approve"' ${updateMenuRs} >/dev/null; then
+      fail "update_menu.rs session-app argv must invoke ks update --approve"
+    fi
+    if ! grep -F 'KS_UPDATE_NOTIFY' ${updateMenuRs} >/dev/null; then
+      fail "update_menu.rs must set KS_UPDATE_NOTIFY=1 so ks main fires notify-send (replaces the retired ks-update-notify@ template)"
+    fi
+
+    # Guard against regression: the unit-based launcher is gone. If anyone
+    # reintroduces `systemctl --user start ks-update.service` without first
+    # solving the session-env problem, fail loudly.
+    if grep -F 'ks-update.service' ${updateMenuRs} >/dev/null; then
+      fail "update_menu.rs must not reference ks-update.service — the unit was retired in favor of the uwsm session-app launcher"
+    fi
 
     # -- Activation tokens defined in Rust match dispatch handling ---------
     #
@@ -108,40 +116,44 @@ pkgs.runCommand "test-keystone-update-menu-wiring"
       fi
     done
 
-    # -- run-background unit validation references ks-update.service ------
-
-    if ! grep -F 'ks-update.service' ${runBackgroundRs} >/dev/null 2>&1; then
-      : # currently run_background.rs doesn't hard-code the name — that's fine
-    fi
-
-    # -- Channel wiring: KS_UPDATE_CHANNEL reaches ks at runtime ----------
+    # -- Channel wiring ---------------------------------------------------
     #
-    # The Rust backend reads KS_UPDATE_CHANNEL from the env. The desktop
-    # services and terminal home-manager module must thread the declared
-    # keystone.update.channel value in, otherwise Walker / interactive
-    # shells will silently fall back to the default "stable" even after
-    # a consumer flake sets channel = "unstable". This is the class of bug
-    # unit tests can't catch because the coupling spans three files.
+    # The Rust backend resolves the channel from KS_UPDATE_CHANNEL first
+    # (interactive shells / tests) and falls back to
+    # /run/current-system/keystone-update-channel (detached session apps).
+    # Three files have to agree:
     #
-    # Match the *assignment* shape rather than the bare token so comments
-    # referencing the option (which happen throughout both files) don't
-    # satisfy the check if the actual wiring is removed.
+    #   - system-flake.nix writes the runtime pointer from
+    #     config.keystone.update.channel so it is regenerated on every
+    #     nixos-rebuild switch / boot.
+    #   - terminal/default.nix exports KS_UPDATE_CHANNEL for interactive
+    #     shells so `ks menu update status` from a terminal also tracks
+    #     the declared channel.
+    #   - update_menu.rs reads both paths via repo::read_system_update_channel
+    #     plus an env lookup. Match the function so it can't be silently
+    #     deleted.
 
-    # services.nix binds `updateChannel = config.keystone.update.channel;`
-    # and then interpolates it into Environment = [ "KS_UPDATE_CHANNEL=..." ].
-    if ! grep -E '=[[:space:]]*config\.keystone\.update\.channel' ${servicesFile} >/dev/null; then
-      fail "services.nix must bind updateChannel = config.keystone.update.channel to thread into unit env"
+    if ! grep -F 'keystone-update-channel' ${systemFlakeFile} >/dev/null; then
+      fail "system-flake.nix must write /run/current-system/keystone-update-channel for runtime channel discovery"
     fi
-    # Match the Nix interpolation literally: KS_UPDATE_CHANNEL=''${updateChannel}
-    # (escaped here so Nix passes the raw ''${...} through to grep).
-    if ! grep -F 'KS_UPDATE_CHANNEL=''${updateChannel}' ${servicesFile} >/dev/null; then
-      fail "services.nix must set KS_UPDATE_CHANNEL=\''${updateChannel} in ks-update.service / ks-update-notify@.service Environment"
+    if ! grep -E 'config\.keystone\.update\.channel' ${systemFlakeFile} >/dev/null; then
+      fail "system-flake.nix must source the runtime channel pointer from config.keystone.update.channel"
     fi
 
     # terminal/default.nix sets it as a home.sessionVariables attribute
     # whose value is `config.keystone.update.channel` (no string literal).
     if ! grep -E 'KS_UPDATE_CHANNEL[[:space:]]*=[[:space:]]*config\.keystone\.update\.channel' ${terminalDefault} >/dev/null; then
       fail "terminal/default.nix must set KS_UPDATE_CHANNEL = config.keystone.update.channel in home.sessionVariables"
+    fi
+
+    if ! grep -F 'KS_UPDATE_CHANNEL' ${updateMenuRs} >/dev/null; then
+      fail "update_menu.rs must read KS_UPDATE_CHANNEL for channel dispatch"
+    fi
+    if ! grep -F 'read_system_update_channel' ${updateMenuRs} >/dev/null; then
+      fail "update_menu.rs must fall back to repo::read_system_update_channel when KS_UPDATE_CHANNEL is unset"
+    fi
+    if ! grep -F 'keystone-update-channel' ${repoRs} >/dev/null; then
+      fail "repo.rs must read /run/current-system/keystone-update-channel as the runtime channel pointer"
     fi
 
     # -- Option exists somewhere under modules/ ---------------------------
@@ -159,20 +171,14 @@ pkgs.runCommand "test-keystone-update-menu-wiring"
       fi
     done
 
-    # -- Rust entrypoint reads the env var --------------------------------
-
-    if ! grep -F 'KS_UPDATE_CHANNEL' ${updateMenuRs} >/dev/null; then
-      fail "update_menu.rs must read KS_UPDATE_CHANNEL for channel dispatch"
-    fi
-
-    # -- Top-level Walker menu delegates update to ks-update.service ------
+    # -- Top-level Walker menu delegates update to the dedicated submenu --
     #
     # CRITICAL: keystone-main-menu.sh emits a top-level "Update" entry that
     # parallels the dedicated keystone-update submenu's "Run update" action.
     # PR #404 retired the legacy `ghostty -e ks update` terminal ceremony in
-    # the dedicated submenu (Lua → Rust dispatch → ks-update.service unit),
-    # but the top-level entry was missed and silently regressed back to the
-    # terminal path on every host until #414 caught it.
+    # the dedicated submenu (Lua → Rust dispatch), but the top-level entry
+    # was missed and silently regressed back to the terminal path on every
+    # host until #414 caught it.
     #
     # The fix is for keystone-main-menu.sh's dispatch to delegate to
     # `ks menu update dispatch`, NOT to spawn its own terminal. These greps

--- a/tests/module/keystone-update-menu-wiring.nix
+++ b/tests/module/keystone-update-menu-wiring.nix
@@ -78,7 +78,7 @@ pkgs.runCommand "test-keystone-update-menu-wiring"
     if ! grep -F 'uwsm' ${updateMenuRs} >/dev/null; then
       fail "update_menu.rs must launch the update via uwsm app -- … so it inherits the graphical session env"
     fi
-    if ! grep -F '--identifier=ks-update' ${updateMenuRs} >/dev/null; then
+    if ! grep -F -- '--identifier=ks-update' ${updateMenuRs} >/dev/null; then
       fail "update_menu.rs must tag the session app with systemd-cat --identifier=ks-update for journal lookup"
     fi
     if ! grep -F 'systemd-inhibit' ${updateMenuRs} >/dev/null; then


### PR DESCRIPTION
## Summary

- Retire `ks-update.service` / `ks-update-notify@.service` and launch the Walker-triggered update flow as a graphical-session app (`uwsm app -- systemd-inhibit … systemd-cat -t ks-update ks update --approve`) so pkexec keeps DISPLAY / WAYLAND_DISPLAY / DBUS context and hyprpolkitagent can render. notify-send replaces the retired notifier template, gated by `KS_UPDATE_NOTIFY=1`.
- Move the update channel pointer from a unit `Environment=` variable to the runtime file `/run/current-system/keystone-update-channel`, written via `system.systemBuilderCommands`. Detached session apps don't inherit `KS_UPDATE_CHANNEL` reliably; `ks` reads env first then the runtime file (with `KEYSTONE_UPDATE_CHANNEL_FILE` for tests).
- Bundle two prerequisite fixes that surfaced while debugging:
  - `fix(journal-remote)`: treat `systemd-journal-upload` exit 1 as success — observability must not be able to fail switch-to-configuration.
  - `fix(hyprpolkitagent)`: escape `\$HOME` in the wrapper heredoc (default theme path was empty) and export `QML_XHR_ALLOW_FILE_READ=1` so the polkit theme JSON loads.

## Why

Captured directly from `journalctl --user -t ks-update -b` on `ncrmro-laptop` today:

- Earlier failure mode (old user-service path):
  ```
  pkexec[…]: ncrmro: Error executing command as another user: Not authorized
  polkitd[…]: Operator of unix-session:3 FAILED to authenticate to gain authorization for action org.freedesktop.policykit.exec
  ks-update[…]: ks activate failed (exit Some(127)) — leaving flake.lock unchanged.
  ```
  The user-service launch lost graphical session context, the polkit prompt couldn't render against the right bus, and pkexec fell back to the broken `/dev/tty` path.
- After moving to `uwsm app -- …`, the prompt rendered, the user authenticated, and `ks activate` ran. The remaining failure was downstream:
  ```
  systemd-journal-upload[…]: Buffer space is too small to write entry.
  systemd-journal-upload.service: Main process exited, code=exited, status=1/FAILURE
  ks-update[…]: Error: activation was not approved or failed for main@408a81d on host ncrmro-laptop
  ```
  Hence the `SuccessExitStatus=[1]` hardening on `systemd-journal-upload` — a malformed local journal entry must not abort an otherwise valid system update.

## Test plan

- [ ] `ci` (nix flake check) passes
- [ ] `ks doctor` no longer reports the (now-removed) `ks-update.service` checks
- [ ] After `ks update --boot` on a desktop host, Walker `Update` triggers an `uwsm`-spawned app: polkit prompt renders against hyprpolkitagent, success path is silent + notify-send "Keystone update complete", failure path surfaces notify-send "Keystone update failed" with a journal pointer
- [ ] `journalctl --user -t ks-update -b` shows the full run; no `ks-update.service` unit referenced
- [ ] `cat /run/current-system/keystone-update-channel` reflects `keystone.update.channel` after rebuild
- [ ] Inject a deliberate `systemd-journal-upload` exit-1 condition and confirm `nixos-rebuild switch` no longer fails