### PR TITLE
fix(hyprland): float and center the polkit auth dialog

### DIFF
--- a/modules/desktop/home/hyprland/layout.nix
+++ b/modules/desktop/home/hyprland/layout.nix
@@ -67,13 +67,17 @@ in
         # whichever tile slot it lands in, and the QML theming looks
         # broken because the layout assumes the natural size. The Qt app
         # doesn't set a Wayland app_id (class is empty in `hyprctl
-        # clients`), so match on title — `Authentication required` is the
-        # standard polkit prompt title across actions. `pin` keeps it
-        # above tiled windows so an active terminal can't focus-steal it.
-        "float on, match:title ^(Authentication required)$"
-        "center on, match:title ^(Authentication required)$"
-        "size 486 246, match:title ^(Authentication required)$"
-        "pin on, match:title ^(Authentication required)$"
+        # clients`), so match on the empty class AND the title together.
+        # AND-matching on class ^$ scopes the rule to classless windows
+        # so localized prompt titles in other apps (matching English
+        # `Authentication required`) don't get accidentally floated;
+        # hyprpolkitagent itself is the only window we've seen ship with
+        # no class. `pin` keeps it above tiled windows so an active
+        # terminal can't focus-steal it.
+        "float on, match:class ^$, match:title ^(Authentication required)$"
+        "center on, match:class ^$, match:title ^(Authentication required)$"
+        "size 486 246, match:class ^$, match:title ^(Authentication required)$"
+        "pin on, match:class ^$, match:title ^(Authentication required)$"
       ];
 
       # layerrule disabled until Hyprland 0.52+ syntax is confirmed

--- a/modules/desktop/home/hyprland/layout.nix
+++ b/modules/desktop/home/hyprland/layout.nix
@@ -60,6 +60,20 @@ in
         "float on, match:class ^(com.mitchellh.ghostty)$, match:title ^(keystone-notes-inbox)$"
         "center on, match:class ^(com.mitchellh.ghostty)$, match:title ^(keystone-notes-inbox)$"
         "size 1000 700, match:class ^(com.mitchellh.ghostty)$, match:title ^(keystone-notes-inbox)$"
+
+        # hyprpolkitagent's password dialog is a 486×246 modal but Hyprland
+        # tiles it by default — `xdg_toplevel.configure` arrives with
+        # WindowMaximized state, the input field gets stretched into
+        # whichever tile slot it lands in, and the QML theming looks
+        # broken because the layout assumes the natural size. The Qt app
+        # doesn't set a Wayland app_id (class is empty in `hyprctl
+        # clients`), so match on title — `Authentication required` is the
+        # standard polkit prompt title across actions. `pin` keeps it
+        # above tiled windows so an active terminal can't focus-steal it.
+        "float on, match:title ^(Authentication required)$"
+        "center on, match:title ^(Authentication required)$"
+        "size 486 246, match:title ^(Authentication required)$"
+        "pin on, match:title ^(Authentication required)$"
       ];
 
       # layerrule disabled until Hyprland 0.52+ syntax is confirmed


### PR DESCRIPTION
## Summary

- Add Hyprland windowrules to float/center/size/pin hyprpolkitagent's password dialog
- Match on title \`Authentication required\` because the agent doesn't set a Wayland app_id (class is empty)

## Why

Confirmed live on \`ncrmro-laptop\` while debugging the Walker → Update flow:

\`\`\`
xdg_toplevel.configure with QSize(486, 246) and QFlags<Qt::WindowState>(WindowMaximized)
\`\`\`

The dialog is a 486×246 modal but Hyprland tiles it (WindowMaximized state). Result: the input field is stretched/misplaced into a tile slot, the QML theme is laid out against an unexpected size, and what should be a tight prompt feels broken — both visually and ergonomically (long time to find/type into the password field).

Class match isn't possible — captured via Hyprland's \`.socket2.sock\` event stream:

\`\`\`
openwindow>>561a919d8800,4,,Authentication required
                          ^^ class field empty
\`\`\`

The Qt app doesn't call \`setDesktopFileName()\` / \`setApplicationName()\` early enough for the Wayland surface, so the title is the only stable matchable field. \`Authentication required\` is polkit's standard prompt title.

## Test plan

- [ ] Activate on a desktop host
- [ ] Trigger any pkexec/polkit auth (\`pkexec true\` is enough — or Walker → Update)
- [ ] Verify dialog floats at 486×246, centered, pinned above tiled windows
- [ ] Verify QML theming renders correctly (no stretched input field)

## Independent of #496

#496 fixes *how the prompt is triggered* (Walker → Update via uwsm session app instead of \`ks-update.service\`). This PR fixes *how the prompt is laid out* once it shows up. They land in any order.