### PR TITLE
fix(journal-remote): skip systemd-journal-upload during system switches

### DIFF
--- a/modules/os/journal-remote.nix
+++ b/modules/os/journal-remote.nix
@@ -171,12 +171,28 @@ in
         };
       };
 
-      systemd.services.systemd-journal-upload.serviceConfig = {
-        # systemd-journal-upload exits 1 for malformed or oversized local
-        # journal entries. Treat that as retryable so observability cannot
-        # make switch-to-configuration fail an otherwise valid system update.
-        SuccessExitStatus = [ 1 ];
-        RestartSec = mkForce "5min";
+      systemd.services.systemd-journal-upload = {
+        serviceConfig = {
+          # systemd-journal-upload exits 1 for malformed or oversized local
+          # journal entries. Treat that as retryable so observability cannot
+          # make switch-to-configuration fail an otherwise valid system update.
+          SuccessExitStatus = [ 1 ];
+          RestartSec = mkForce "5min";
+        };
+
+        # Don't let switch-to-configuration restart this unit during a system
+        # switch. With SuccessExitStatus=1 and RestartSec=5min, the unit sits
+        # in `activating` between auto-restart cycles whenever the local
+        # journal hits a malformed entry; switch-to-configuration's
+        # post-restart health check sees that transient state and exits 4
+        # ("warning: units failed"), which `ks update --approve` then treats
+        # as a hard failure and refuses to advance flake.lock. The currently
+        # running daemon keeps uploading regardless of switches; config
+        # changes here (URL, certs, drop-ins) take effect on the next reboot
+        # or manual `systemctl restart systemd-journal-upload`. That trade
+        # is acceptable for an observability uploader — losing a flake.lock
+        # advance every time the daemon is mid-cycle is not.
+        restartIfChanged = false;
       };
     })
   ]);

--- a/modules/os/journal-remote.nix
+++ b/modules/os/journal-remote.nix
@@ -192,7 +192,11 @@ in
         # or manual `systemctl restart systemd-journal-upload`. That trade
         # is acceptable for an observability uploader — losing a flake.lock
         # advance every time the daemon is mid-cycle is not.
-        restartIfChanged = false;
+        #
+        # mkDefault so a host that needs different behavior (e.g., wants
+        # immediate config rollout via stop/start during switch) can
+        # override without an option-redefinition conflict.
+        restartIfChanged = mkDefault false;
       };
     })
   ]);


### PR DESCRIPTION
## Summary

- Set \`restartIfChanged = false\` on \`systemd-journal-upload.service\` so switch-to-configuration leaves the running daemon alone during system switches
- Pairs with the existing \`SuccessExitStatus=[1]\` + \`RestartSec=5min\` from #496

## Why

#496 stopped switch-to-configuration from *aborting* on the malformed-entry exit-1 cascade, but didn't stop it from *warning*. Between auto-restart cycles the unit sits in \`activating\` for up to 5 min, switch-to-configuration's health check sees that and returns exit status 4, and \`ks update --approve\` treats non-zero as a hard failure — refuses to advance \`flake.lock\` even though the system did switch correctly.

Observed live on \`ncrmro-laptop\` immediately after #496 merged:

\`\`\`
ks-update.service:
  /run/current-system → /nix/store/dbxfdjsc…  (post-merge closure)  ✓
  /run/current-system/keystone-update-channel → unstable           ✓
  ks-update*.service unit files → 0                                 ✓
  flake.lock advance                                                 ✗
  
nixos[…]: switching to system configuration … failed (status 4)
Error: …/switch-to-configuration switch exited Some(4)
\`\`\`

Required a manual \`nix flake update keystone\` in nixos-config to recover.

## Trade-off

With \`restartIfChanged = false\`, config changes to the unit (URL, certs, the drop-in itself) only take effect on next reboot or manual \`systemctl restart systemd-journal-upload\`. That's acceptable for an observability uploader. Losing a flake.lock advance every time the daemon is mid-cycle is not.

## Test plan

- [ ] Run \`ks update --approve\` on a host that already has #496 active
- [ ] Verify switch-to-configuration completes without status 4
- [ ] Verify \`flake.lock\` advances on the consumer flake
- [ ] Verify the still-running journal-upload daemon keeps shipping (config changes won't take effect until reboot, which is the trade)