### PR TITLE
fix(update-approve): use modern `nix flake update` form for relock

### DIFF
--- a/packages/ks/src/cmd/update_approve.rs
+++ b/packages/ks/src/cmd/update_approve.rs
@@ -13,7 +13,7 @@
 //!             ├─ ks approve … -- ks activate <store-path>        ← polkit
 //!             │     └─ keystone-approve-exec → ks activate       [root]
 //!             ├─ on activation success:                          [user]
-//!             │     nix flake lock --update-input keystone
+//!             │     nix flake update keystone
 //!             │       --override-input keystone github:.../<rev>
 //!             ├─ git commit -m "chore: bump keystone to <ref>"   [user]
 //!             ├─ git push origin <branch>                        [user]
@@ -47,7 +47,7 @@
 //!    control returns here to gate the next step on the exit status.
 //! 4. **Only** on activation success: relock the consumer flake's
 //!    `keystone` input, pinned to the exact rev we just built and
-//!    activated (`--update-input keystone --override-input
+//!    activated (`nix flake update keystone --override-input
 //!    keystone github:ncrmro/keystone/<rev>`). Without the override,
 //!    `nix flake update keystone` would re-resolve `github:ncrmro/keystone`
 //!    to the default-branch tip — which can disagree with the activated
@@ -170,29 +170,35 @@ async fn build_with_override(repo_root: &Path, host: &str, rev: &str) -> Result<
 //   2. Unstable channel: between `resolve_target_ref` and this call,
 //      a new commit may land on `main`; `update keystone` would pick
 //      it up, locking to a rev we never built.
-// `--update-input keystone` forces the lockfile entry to refresh, and
-// `--override-input keystone github:.../<rev>` pins it to exactly the
-// rev we built — making the lock match the realized closure.
+// `nix flake update keystone` forces the lockfile entry to refresh,
+// and `--override-input keystone github:.../<rev>` pins it to exactly
+// the rev we built — making the lock match the realized closure.
+//
+// Use the modern `nix flake update <input>` form rather than the
+// deprecated `nix flake lock --update-input <input>` alias: nix 2.20+
+// rejects `--flake <path>` after the deprecated alias (the alias
+// rewrites to `flake update`, and `flake update` doesn't accept
+// `--flake` as a flag) and prints `error: unrecognised flag '--flake'`.
+// Set the flake via `current_dir` instead — same pattern as the build
+// command in `build_system_closure`.
 async fn relock_keystone_input(repo_root: &Path, rev: &str) -> Result<()> {
     let pinned = format!("github:ncrmro/keystone/{rev}");
     let status = tokio::process::Command::new("nix")
         .args([
             "flake",
-            "lock",
-            "--update-input",
+            "update",
             "keystone",
             "--override-input",
             "keystone",
             &pinned,
         ])
-        .arg("--flake")
-        .arg(repo_root)
+        .current_dir(repo_root)
         .status()
         .await
-        .context("failed to invoke nix flake lock for keystone input")?;
+        .context("failed to invoke nix flake update for keystone input")?;
     if !status.success() {
         anyhow::bail!(
-            "nix flake lock --update-input keystone --override-input keystone {pinned} exited {:?}",
+            "nix flake update keystone --override-input keystone {pinned} exited {:?}",
             status.code()
         );
     }


### PR DESCRIPTION
## Summary

Switch \`relock_keystone_input\` from the deprecated \`nix flake lock --update-input <name>\` form to the modern \`nix flake update <name>\` form, and drop \`--flake <path>\` (Nix doesn't accept it on this subcommand) in favor of \`current_dir(repo_root)\`.

## Why

Nix 2.20+ rejects the existing call with:

\`\`\`
warning: '--update-input' is a deprecated alias for 'flake update' and will be removed in a future version.
error: unrecognised flag '--flake'
Error: nix flake lock --update-input keystone … exited Some(1)
\`\`\`

\`--update-input\` rewrites internally to \`nix flake update\`, and \`flake update\` doesn't accept \`--flake\` as a flag — the flake URL is implicit from cwd or the positional arg. The relock step therefore explodes after every successful activation, leaving \`flake.lock\` unadvanced even when \`ks activate\` succeeded.

## Pre-existing, not a regression from #496

This bug was masked by the earlier journal-upload-exit-1 failure mode that aborted \`ks update\` before reaching the relock step. PR #496 unblocked the path *to* this code; the bug surfaced on the first end-to-end success against post-#496 main.

## Observed live on \`ncrmro-laptop\`

\`\`\`
ks-update[…]: ks activate: /run/current-system already points at
              /nix/store/dbxfdjsc… — nothing to do.
ks-update[…]: warning: '--update-input' is a deprecated alias …
ks-update[…]: error: unrecognised flag '--flake'
Error: nix flake lock --update-input keystone … exited Some(1)
\`\`\`

\`ks activate\` short-circuited correctly (system was already on the right closure from a prior partial activation), but the relock step crashed.

## Test plan

- [ ] Run \`ks update --approve\` on a host with this branch active
- [ ] Verify no deprecation warning, no \`--flake\` rejection
- [ ] Verify \`flake.lock\` advances on the consumer flake
- [ ] Verify the commit + push flow at the end of \`run_supervised_update\` proceeds

## Dependencies

Independent of #497 (windowrule) and #498 (restartIfChanged), but pairs with #498 — together they let \`ks update --approve\` complete end-to-end without manual intervention.