### PR TITLE
fix(activate): tolerate switch-to-configuration exit 4

### DIFF
--- a/packages/ks/src/cmd/activate.rs
+++ b/packages/ks/src/cmd/activate.rs
@@ -145,21 +145,40 @@ fn mark_bootloader_safe() -> Result<()> {
 /// at `path` carries its own switch-to-configuration so we always invoke
 /// the version that matches the closure being activated — never a stale
 /// one from a previous generation.
+///
+/// Exit-code handling: 0 = clean success, 4 = success-with-warnings,
+/// anything else = real failure.
+///
+/// Exit 4 is NixOS' "warning: the following units failed: …" outcome.
+/// The system *is* on the new generation by then: `/run/current-system`
+/// and `/nix/var/nix/profiles/system` are bumped, agenix has run, `/etc`
+/// is current, and the configured units have been
+/// started/restarted/reloaded. The warning typically reflects a unit
+/// that happens to be in `activating (auto-restart)` state during the
+/// post-switch check window — common for daemons with `Restart=always`
+/// plus a long `RestartSec` (e.g., `systemd-journal-upload` exiting 1
+/// on malformed local journal entries between cycles). Treating exit 4
+/// as a hard failure aborts `ks update --approve`'s post-activation
+/// work (relock, commit, push, notify) even though the system is
+/// already on the new generation, so we surface a notice and proceed.
 fn switch_to_configuration(path: &Path, mode: &str) -> Result<()> {
     let switch_bin = path.join("bin/switch-to-configuration");
     let status = Command::new(&switch_bin)
         .arg(mode)
         .status()
         .with_context(|| format!("failed to invoke {}", switch_bin.display()))?;
-    if !status.success() {
-        anyhow::bail!(
-            "{} {} exited {:?}",
-            switch_bin.display(),
-            mode,
-            status.code()
-        );
+    match status.code() {
+        Some(0) => Ok(()),
+        Some(4) => {
+            eprintln!(
+                "{} {}: completed with warnings (exit 4) — system is on the new generation; some units flagged in the post-switch check. Continuing.",
+                switch_bin.display(),
+                mode
+            );
+            Ok(())
+        }
+        other => anyhow::bail!("{} {} exited {:?}", switch_bin.display(), mode, other),
     }
-    Ok(())
 }
 
 fn is_root() -> bool {


### PR DESCRIPTION
## Summary

\`cmd::activate::switch_to_configuration\` treats any non-zero exit from the bundled \`switch-to-configuration switch\` as failure. NixOS uses exit code 4 for "switch-succeeded-with-warnings" — the system *is* on the new generation by then. Match on \`status.code()\` instead of \`status.success()\` and treat 4 as success-with-notice.

## Why

Exit 4 fires whenever a daemon with \`Restart=always\` + long \`RestartSec\` is mid-cycle when switch-to-configuration's post-switch state check samples it. \`systemd-journal-upload\` is the canonical case: exits 1 on a malformed local journal entry, sits in \`activating (auto-restart)\` for \`RestartSec=5min\`, and during that window the post-switch check counts it as failed.

PR #498's \`restartIfChanged = false\` already stops switch-to-configuration from *deliberately* restarting the unit, but the post-switch check is a separate pass and still flags the auto-restart cycle. So #498 is necessary but not sufficient — confirmed live on \`ncrmro-laptop\`:

\`\`\`
switch-to-configuration[…]: NOT restarting the following changed units:
    systemd-journal-upload.service                       (← #498 working)
switch-to-configuration[…]: activating the configuration...
switch-to-configuration[…]: [agenix] decrypting secrets...
switch-to-configuration[…]: setting up /etc...
switch-to-configuration[…]: reloading user units for ncrmro...
switch-to-configuration[…]: restarting the following units: polkit.service
(8s later, journal-upload's own RestartSec fires)
switch-to-configuration[…]: warning: the following units failed:
    systemd-journal-upload.service                       (← post-check)
nixos[…]: switching to system configuration … failed (status 4)
\`\`\`

Without this PR the run aborts here, \`ks update --approve\` reports failure, and \`flake.lock\` drifts behind the running closure. Every subsequent \`ks update\` then rebuilds the same cached closure and warns again.

## Behaviour

| status | action |
|---|---|
| 0 | success — proceed |
| 4 | log a notice that the post-switch check flagged warnings, return Ok so post-activation work proceeds |
| anything else | bail with the original error envelope |

## Pairs with

- #498 — \`restartIfChanged = false\` (stops s-to-c from restarting; defensive)
- #500 — relock uses modern \`nix flake update\` form

Together with this PR, \`ks update --approve\` completes end-to-end even with the journal-upload buffer issue present.

## Scope

Only \`cmd::activate::switch_to_configuration\` is touched. \`cmd::switch\` has the same shape in two places (\`switch_local_system\`, \`switch_remote_system\`) but those are the fleet-wide \`ks switch\` path rather than the desktop update path; left as a follow-up unless we hit the same warning there.

## Test plan

- [ ] Run \`ks update --approve\` on a host where \`systemd-journal-upload\` is stuck in the auto-restart cycle
- [ ] Verify activation completes, notice is logged about exit 4
- [ ] Verify relock, commit, push, notify all run
- [ ] Verify \`flake.lock\` advances in the consumer flake