### PR TITLE
refactor(update-approve): auth early, lock-first, rollback on failure

### DIFF
--- a/packages/ks/src/cli.rs
+++ b/packages/ks/src/cli.rs
@@ -122,6 +122,26 @@ pub enum Command {
         /// approved child), this flag is a no-op and the body runs directly.
         #[arg(long)]
         approve: bool,
+
+        /// Local-development override for the `--approve` supervised flow:
+        /// use this keystone ref instead of the channel-resolved target.
+        /// Accepts any value that `nix flake update keystone
+        /// --override-input keystone <value>` accepts — typically
+        /// `github:ncrmro/keystone/<branch-or-sha>` or
+        /// `path:/absolute/path/to/worktree`.
+        ///
+        /// In override mode the supervised flow modifies `flake.lock` in
+        /// the working tree only (no commit), runs build + activation
+        /// against that ref, and restores `flake.lock` on exit
+        /// regardless of outcome. Push is always skipped. The system is
+        /// activated against the override target while the consumer
+        /// flake stays clean — re-run `ks update --approve` without the
+        /// flag once you're done testing to bring the system back to the
+        /// channel rev.
+        ///
+        /// Only valid alongside `--approve`. Other update modes ignore it.
+        #[arg(long = "keystone")]
+        keystone_override: Option<String>,
     },
 
     /// Activate a pre-built NixOS system closure (privileged).

--- a/packages/ks/src/cmd/update_approve.rs
+++ b/packages/ks/src/cmd/update_approve.rs
@@ -10,9 +10,12 @@
 //!                                                          [user session]
 //!             ├─ pre-flight: refuse if local != origin           [user]
 //!             ├─ resolve channel target ref via GitHub API       [user]
-//!             ├─ ks approve … -- ks activate /run/current-system ← polkit (warm)
-//!             │     └─ no-op (current-system already matches);
-//!             │       polkit caches credential under auth_admin_keep
+//!             ├─ ks approve … -- ks activate <canonical(current)>  ← polkit (warm)
+//!             │     └─ canonicalize /run/current-system to its
+//!             │       /nix/store closure path (validate_store_path
+//!             │       rejects symlinks); ks activate short-circuits
+//!             │       because the closure already matches; polkit
+//!             │       caches credential under auth_admin_keep
 //!             ├─ notify-send "Building <target>…"                [user]
 //!             ├─ nix flake update keystone                       [user]
 //!             │     --override-input keystone github:.../<rev>
@@ -56,10 +59,13 @@
 //! 0. Pre-flight: ensure consumer flake is in sync with origin.
 //! 1. Resolve target ref (no filesystem mutation).
 //! 2. Warm the polkit credential via a no-op `ks activate
-//!    /run/current-system`. The activation short-circuits in
-//!    `cmd::activate::execute` because the closure already matches
-//!    current-system; only side effect is polkit caching the credential
-//!    under `auth_admin_keep` for ~5 min.
+//!    <canonical(current)>`. We canonicalize `/run/current-system`
+//!    first because `cmd::activate::validate_store_path` rejects
+//!    arguments outside `/nix/store/` (defense-in-depth). The
+//!    activation then short-circuits in `cmd::activate::execute`
+//!    because the closure already matches current-system; only side
+//!    effect is polkit caching the credential under `auth_admin_keep`
+//!    for ~5 min.
 //! 3. notify-send "Building <target>…" so the user has feedback during
 //!    the build phase.
 //! 4. Bump `flake.lock` (`nix flake update keystone --override-input
@@ -490,21 +496,25 @@ fn activate_via_broker(reason: &str, store_path: &str) -> Result<bool> {
     let argv = elevated_argv(store_path);
     let status = cmd::approve::run_and_wait(reason, &argv)?;
     if !should_advance_lock(&status) {
-        eprintln!(
-            "ks activate failed (exit {:?}) — rolling back the flake.lock bump.",
-            status.code()
-        );
+        // Only log the failure here. Whether a rollback is performed
+        // depends on caller state (was a bump committed or did the
+        // lock no-op?), so the rollback decision and its corresponding
+        // log line live in `run_supervised_update`'s error path.
+        eprintln!("ks activate failed (exit {:?}).", status.code());
         return Ok(false);
     }
     Ok(true)
 }
 
 /// Warm the polkit credential cache by firing a no-op activation. The
-/// allowlist matches `["ks", "activate", …]` (prefix), so the helper
-/// validates `["ks", "activate", "/run/current-system"]` and execs
-/// `ks activate /run/current-system` as root. `cmd::activate::execute`
-/// then short-circuits (the closure already matches `current-system`)
-/// and returns 0 with no side effects.
+/// allowlist matches `["ks", "activate", …]` (prefix). We canonicalize
+/// `/run/current-system` to its underlying `/nix/store/<closure>` first,
+/// because `cmd::activate::validate_store_path` rejects any argument
+/// that isn't under `/nix/store/` (defense in depth — the symlink
+/// itself isn't a store path). The helper then validates `["ks",
+/// "activate", "/nix/store/<closure>"]`, execs `ks activate <closure>`
+/// as root, and `cmd::activate::execute` short-circuits because the
+/// closure already matches `/run/current-system`.
 ///
 /// Net effect: the user sees the polkit dialog within seconds of
 /// Walker dispatch, authenticates once, and polkit caches the
@@ -518,7 +528,17 @@ fn activate_via_broker(reason: &str, store_path: &str) -> Result<bool> {
 /// no side effects on the consumer flake. We treat this as the user
 /// explicitly declining the update.
 fn warm_polkit_cache(host_label: &str) -> Result<bool> {
-    let argv = elevated_argv("/run/current-system");
+    let current = std::fs::canonicalize("/run/current-system").context(
+        "failed to canonicalize /run/current-system for the warm approval payload — \
+         the host has no current system generation?",
+    )?;
+    let current_str = current.to_str().ok_or_else(|| {
+        anyhow!(
+            "/run/current-system canonical path {} is not valid UTF-8",
+            current.display()
+        )
+    })?;
+    let argv = elevated_argv(current_str);
     let reason = approval_reason(host_label);
     eprintln!("Requesting approval for the upcoming activation (warming polkit cache)…");
     let status = cmd::approve::run_and_wait(&reason, &argv)?;
@@ -555,7 +575,36 @@ fn notify_build_phase(target_label: &str) {
 /// - `lock_advanced = false` and `bump_sha = None` when the lock was
 ///   already at `target_rev` (no relock changes, no commit). In that
 ///   case the caller has nothing to roll back.
+///
+/// Transactional contract: if any inner step (`relock_keystone_input`,
+/// `flake_lock_dirty`, `commit_lock`) fails partway, this function
+/// restores `flake.lock` to its `HEAD` state via
+/// `git checkout HEAD -- flake.lock` — both the working tree and the
+/// index are reset, so a subsequent `ensure_in_sync` pre-flight on
+/// the next run still sees a clean tree. Without this, a partial
+/// `nix flake update` (lock modified, commit not yet made) or a
+/// `commit` failure after `git add` would strand the consumer flake
+/// in a state the next run refuses to start from.
 async fn bump_lock_and_commit(
+    repo_root: &Path,
+    target_rev: &str,
+    target_label: &str,
+) -> Result<(bool, Option<String>)> {
+    match bump_lock_and_commit_inner(repo_root, target_rev, target_label).await {
+        Ok(result) => Ok(result),
+        Err(e) => {
+            if let Err(restore_err) = restore_flake_lock(repo_root).await {
+                eprintln!(
+                    "Warning: failed to restore flake.lock after bump failure: {restore_err:#}. \
+                     Working tree may be dirty; resolve manually before retrying.",
+                );
+            }
+            Err(e)
+        }
+    }
+}
+
+async fn bump_lock_and_commit_inner(
     repo_root: &Path,
     target_rev: &str,
     target_label: &str,
@@ -569,6 +618,25 @@ async fn bump_lock_and_commit(
     let sha = rev_parse(repo_root, "HEAD").await?;
     eprintln!("Committed flake.lock bump (HEAD={sha}).");
     Ok((true, Some(sha)))
+}
+
+/// Restore `flake.lock` from `HEAD` into both the index and the
+/// working tree. Used to roll back partial bump failures (mid-relock
+/// or mid-commit). After this call, `git status -- flake.lock`
+/// produces no output and the next supervised run's `ensure_in_sync`
+/// pre-flight passes again.
+async fn restore_flake_lock(repo_root: &Path) -> Result<()> {
+    let status = tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["checkout", "HEAD", "--", "flake.lock"])
+        .status()
+        .await
+        .context("failed to invoke git checkout HEAD -- flake.lock")?;
+    if !status.success() {
+        anyhow::bail!("git checkout HEAD -- flake.lock exited {:?}", status.code());
+    }
+    Ok(())
 }
 
 /// Rewind the bump commit if HEAD still equals `expected_sha`. Refuses

--- a/packages/ks/src/cmd/update_approve.rs
+++ b/packages/ks/src/cmd/update_approve.rs
@@ -174,34 +174,37 @@ async fn build_locked(repo_root: &Path, host: &str, target_label: &str) -> Resul
     Ok(path)
 }
 
-/// Lock the keystone input to the exact target rev we just built and
-/// activated. Run AFTER successful activation so a failed activation
-/// never mutates `flake.lock`.
-//
-// CRITICAL: pin the lock to `github:ncrmro/keystone/<rev>` rather than
-// running a bare `nix flake update keystone`. For consumer flakes that
-// declare `keystone.url = "github:ncrmro/keystone"`, the bare update
-// would re-resolve the input to the default-branch tip, which can drift
-// from the channel-resolved rev in two ways:
-//   1. Stable channel: the target is a tag commit (often older than
-//      `main`); `update keystone` would jump to `main` tip and the lock
-//      would diverge from the activated closure.
-//   2. Unstable channel: between `resolve_target_ref` and this call,
-//      a new commit may land on `main`; `update keystone` would pick
-//      it up, locking to a rev we never built.
-// `nix flake update keystone` forces the lockfile entry to refresh,
-// and `--override-input keystone github:.../<rev>` pins it to exactly
-// the rev we built — making the lock match the realized closure.
-//
-// Use the modern `nix flake update <input>` form rather than the
-// deprecated `nix flake lock --update-input <input>` alias: nix 2.20+
-// rejects `--flake <path>` after the deprecated alias (the alias
-// rewrites to `flake update`, and `flake update` doesn't accept
-// `--flake` as a flag) and prints `error: unrecognised flag '--flake'`.
-// Set the flake via `current_dir` instead — same pattern as the build
-// command in `build_system_closure`.
-async fn relock_keystone_input(repo_root: &Path, rev: &str) -> Result<()> {
-    let pinned = format!("github:ncrmro/keystone/{rev}");
+/// Lock the keystone input to a fully-formed `--override-input` value.
+/// Caller is responsible for shape: channel mode passes
+/// `github:ncrmro/keystone/<rev>`; override mode (REQ-019.31f) passes
+/// the user-supplied flag value (`github:.../<branch>`,
+/// `path:/...worktree`, etc.) directly. Pre-2025 versions of this
+/// helper took a bare `<rev>` and wrapped it internally — that broke
+/// the override path because the flag value already includes the
+/// `github:ncrmro/keystone/` prefix and double-wrapping produced
+/// `github:ncrmro/keystone/github:ncrmro/keystone/<branch>`.
+///
+/// CRITICAL: pin the lock via `--override-input` rather than running a
+/// bare `nix flake update keystone`. For consumer flakes that declare
+/// `keystone.url = "github:ncrmro/keystone"`, the bare update would
+/// re-resolve the input to the default-branch tip, which can drift
+/// from the channel-resolved rev in two ways:
+///   1. Stable channel: the target is a tag commit (often older than
+///      `main`); `update keystone` would jump to `main` tip and the lock
+///      would diverge from the activated closure.
+///   2. Unstable channel: between `resolve_target_ref` and this call,
+///      a new commit may land on `main`; `update keystone` would pick
+///      it up, locking to a rev we never built.
+///
+/// Use the modern `nix flake update <input>` form rather than the
+/// deprecated `nix flake lock --update-input <input>` alias: nix 2.20+
+/// rejects `--flake <path>` after the deprecated alias.
+///
+/// Self-cleaning on failure: `nix flake update` may write to
+/// `flake.lock` before returning non-zero. We restore the working tree
+/// to `HEAD` so a partial relock can't strand the consumer flake in a
+/// state the next run's `ensure_in_sync` pre-flight refuses.
+async fn relock_keystone_input(repo_root: &Path, pinned: &str) -> Result<()> {
     let status = tokio::process::Command::new("nix")
         .args([
             "flake",
@@ -209,13 +212,16 @@ async fn relock_keystone_input(repo_root: &Path, rev: &str) -> Result<()> {
             "keystone",
             "--override-input",
             "keystone",
-            &pinned,
+            pinned,
         ])
         .current_dir(repo_root)
         .status()
         .await
         .context("failed to invoke nix flake update for keystone input")?;
     if !status.success() {
+        if let Err(re) = restore_flake_lock(repo_root).await {
+            eprintln!("Warning: failed to restore flake.lock after relock failure: {re:#}",);
+        }
         anyhow::bail!(
             "nix flake update keystone --override-input keystone {pinned} exited {:?}",
             status.code()
@@ -609,7 +615,8 @@ async fn bump_lock_and_commit_inner(
     target_rev: &str,
     target_label: &str,
 ) -> Result<(bool, Option<String>)> {
-    relock_keystone_input(repo_root, target_rev).await?;
+    let pinned = format!("github:ncrmro/keystone/{target_rev}");
+    relock_keystone_input(repo_root, &pinned).await?;
     if !flake_lock_dirty(repo_root).await? {
         eprintln!("flake.lock already pinned at {target_rev} — no commit needed.");
         return Ok((false, None));

--- a/packages/ks/src/cmd/update_approve.rs
+++ b/packages/ks/src/cmd/update_approve.rs
@@ -1,7 +1,8 @@
 //! `ks update --approve` — Walker-triggered, channel-aware update flow
 //! with narrow polkit-elevated activation.
 //!
-//! Privilege boundary (issue #487):
+//! Spec: REQ-019.31 (specs/REQ-019-ks-cli.md). Privilege boundary
+//! initially defined in issue #487.
 //!
 //! ```text
 //! walker → uwsm app -- systemd-inhibit … systemd-cat
@@ -9,16 +10,31 @@
 //!                                                          [user session]
 //!             ├─ pre-flight: refuse if local != origin           [user]
 //!             ├─ resolve channel target ref via GitHub API       [user]
-//!             ├─ nix build --override-input keystone <ref>       [user]
-//!             ├─ ks approve … -- ks activate <store-path>        ← polkit
-//!             │     └─ keystone-approve-exec → ks activate       [root]
-//!             ├─ on activation success:                          [user]
-//!             │     nix flake update keystone
-//!             │       --override-input keystone github:.../<rev>
+//!             ├─ ks approve … -- ks activate /run/current-system ← polkit (warm)
+//!             │     └─ no-op (current-system already matches);
+//!             │       polkit caches credential under auth_admin_keep
+//!             ├─ notify-send "Building <target>…"                [user]
+//!             ├─ nix flake update keystone                       [user]
+//!             │     --override-input keystone github:.../<rev>
 //!             ├─ git commit -m "chore: bump keystone to <ref>"   [user]
-//!             ├─ git push origin <branch>                        [user]
+//!             │     CAPTURE bump_sha = HEAD
+//!             ├─ nix build                                       [user]
+//!             ├─ ks approve … -- ks activate <store-path>        ← polkit (cache hit)
+//!             │     └─ keystone-approve-exec → ks activate       [root]
+//!             ├─ git push origin <branch>                        [user, soft fail]
 //!             └─ notify success/failure                          [user]
 //! ```
+//!
+//! Why early-auth + lock-first?
+//!
+//! The previous order was build-then-prompt: the user clicked Walker →
+//! Update and waited 1–2 minutes (silent nix build) before the polkit
+//! dialog appeared. By that point the user had often context-switched
+//! away and the dialog timed out (exit 127, "Not authorized"), so an
+//! otherwise-clean run failed at the auth step. Today's order asks
+//! permission first, surfaces a "Building…" notification immediately
+//! after auth, and spends the cache window on actual work instead of
+//! dead build time.
 //!
 //! In-sync invariant:
 //!
@@ -26,58 +42,65 @@
 //! clean and the current branch MUST equal `origin/<branch>`. The
 //! supervised flow refuses to start otherwise. This buys us:
 //!
-//! - Atomicity at the user layer: a successful update appends exactly
-//!   one new commit (the lock bump), so the final `git push` is a
-//!   guaranteed fast-forward by exactly one commit. No mid-flow
-//!   non-fast-forward errors after the privileged step has already run.
+//! - Rollback is unambiguous: the bump commit is always HEAD, has
+//!   exactly one parent, and touches only `flake.lock`. A failure
+//!   between commit and successful activation rewinds with
+//!   `git reset --hard HEAD~1` after verifying HEAD == bump_sha.
 //! - Comprehensibility: when the dialog refuses up front, the user
 //!   sees one concrete reason ("ahead of origin", "behind origin",
 //!   "uncommitted changes") instead of a partially-applied update
 //!   that activated but couldn't push.
 //!
-//! Atomicity contract (activate-then-mutate):
+//! Atomicity contract (lock-first with rollback on failure):
 //!
 //! 0. Pre-flight: ensure consumer flake is in sync with origin.
 //! 1. Resolve target ref (no filesystem mutation).
-//! 2. `nix build --override-input keystone <ref>` — does NOT modify
-//!    `flake.lock`. Failure here is a no-op on the consumer flake.
-//! 3. polkit → `ks activate <store-path>` via
-//!    [`cmd::approve::run_and_wait`]. The orchestrator waits for the
-//!    privileged child to exit instead of `exec()`-replacing itself, so
-//!    control returns here to gate the next step on the exit status.
-//! 4. **Only** on activation success: relock the consumer flake's
-//!    `keystone` input, pinned to the exact rev we just built and
-//!    activated (`nix flake update keystone --override-input
-//!    keystone github:ncrmro/keystone/<rev>`). Without the override,
-//!    `nix flake update keystone` would re-resolve `github:ncrmro/keystone`
-//!    to the default-branch tip — which can disagree with the activated
-//!    closure on stable channels (where the target is a tag commit, not
-//!    branch tip) or on unstable when a new commit lands between resolve
-//!    and relock.
-//! 5. Commit the lock change, push (guaranteed fast-forward by exactly
-//!    one commit; see the in-sync invariant above), notify.
+//! 2. Warm the polkit credential via a no-op `ks activate
+//!    /run/current-system`. The activation short-circuits in
+//!    `cmd::activate::execute` because the closure already matches
+//!    current-system; only side effect is polkit caching the credential
+//!    under `auth_admin_keep` for ~5 min.
+//! 3. notify-send "Building <target>…" so the user has feedback during
+//!    the build phase.
+//! 4. Bump `flake.lock` (`nix flake update keystone --override-input
+//!    keystone github:.../<rev>`) and commit it. Capture HEAD as
+//!    `bump_sha`. NOT pushed yet.
+//! 5. `nix build` against the consumer flake's
+//!    `nixosConfigurations.<host>.config.system.build.toplevel`. The
+//!    lock is correct, so no per-build `--override-input keystone`
+//!    needed; local file-source overrides MAY still be layered.
+//! 6. `ks activate <store-path>` via [`cmd::approve::run_and_wait`].
+//!    The polkit cache from step 2 should cover this prompt; if it
+//!    has expired, the user may be prompted again (degraded UX, not
+//!    a failure).
+//! 7. On activation success: `git push origin <branch>` (best-effort,
+//!    soft fail), notify-send "complete".
+//! 8. On any failure between steps 4 and 6 success:
+//!    `rollback_lock_bump(bump_sha)` — verifies HEAD == bump_sha then
+//!    `git reset --hard HEAD~1`. Refuses if HEAD diverged. notify-send
+//!    "failed" with a journal pointer.
 //!
 //! Failure modes:
 //!
-//! - Step 0 fails → pre-flight refused to start. No side effects on
-//!   the host or the consumer flake. The error names the specific
-//!   reason (dirty / ahead / behind) so the user can resolve it
-//!   without inspecting logs.
-//! - Steps 1–3 fail → consumer flake's `flake.lock` and working tree
-//!   are untouched. The next Walker click retries from scratch.
-//! - Step 3 succeeds, step 4 fails → host is activated against the new
-//!   closure but the lock is stale. This is the same end state as
-//!   `--dev` activations and resolves on the next successful update.
-//! - Step 5 push fails → lock is committed locally; the user pushes by
-//!   hand or the next update sweeps it. With the pre-flight in place
-//!   the push is fast-forward by exactly one commit, so this failure
-//!   is now strictly a network/auth issue, not a divergence issue.
+//! - Step 0 fails → pre-flight refused to start. No side effects.
+//! - Step 2 fails (user cancelled or auth failed) → consumer flake
+//!   untouched. Next click retries from scratch.
+//! - Steps 4 fails (lock update or commit) → working tree may have a
+//!   modified `flake.lock` if the failure happened mid-step. The
+//!   rollback path runs `git reset --hard HEAD` then a final
+//!   `git checkout -- flake.lock` to restore clean state.
+//! - Steps 5–6 fail → bump commit exists; rollback resets `HEAD~1`,
+//!   leaving the consumer flake exactly as it was before the run.
+//! - Step 6 succeeds, step 7 push fails → KEEP the bump commit. System
+//!   is on the new closure, lock matches; only the remote is behind.
+//!   User pushes by hand. This matches the previous best-effort push
+//!   contract.
 //!
 //! Never confuse this code path with `cmd::update::update_locked`. That
 //! is the terminal-only `ks update --lock` flow with full-fleet semantics
 //! (pull all managed repos, deploy multiple hosts, sudo-cached
 //! activation). This module is consumer-OS-style: one host, one channel
-//! target, one polkit prompt.
+//! target, polkit-elevated activation.
 
 use anyhow::{anyhow, Context, Result};
 use std::path::Path;
@@ -101,19 +124,14 @@ pub(crate) struct ApproveUpdateOutcome {
     pub pushed: bool,
 }
 
-/// Build the system closure for `host` against an overridden keystone
-/// input pinned at `rev`. Uses `--override-input` so `flake.lock` is
-/// untouched — a build failure leaves the consumer flake clean. Returns
-/// the realized store path of the system toplevel.
-async fn build_with_override(repo_root: &Path, host: &str, rev: &str) -> Result<String> {
-    let mut override_args = repo::local_override_args(repo_root).await?;
-    // CRITICAL: this is the override that points the build at the
-    // channel-resolved target. It MUST coexist with any
-    // `local_override_args` (which redirect file-source inputs in
-    // development mode) — the new override layers on top.
-    override_args.push("--override-input".to_string());
-    override_args.push("keystone".to_string());
-    override_args.push(format!("github:ncrmro/keystone/{rev}"));
+/// Build the system closure for `host` using the current `flake.lock`.
+/// The lock-first flow bumps `flake.lock` to the target rev BEFORE this
+/// is called, so `nix build` resolves the keystone input from the lock
+/// — no per-build `--override-input keystone` needed. Local file-source
+/// overrides (dev-mode `repo::local_override_args`) are still layered.
+/// Returns the realized store path of the system toplevel.
+async fn build_locked(repo_root: &Path, host: &str, target_label: &str) -> Result<String> {
+    let override_args = repo::local_override_args(repo_root).await?;
 
     let target = format!(
         "{}#nixosConfigurations.{}.config.system.build.toplevel",
@@ -131,12 +149,7 @@ async fn build_with_override(repo_root: &Path, host: &str, rev: &str) -> Result<
     }
     cmd.current_dir(repo_root);
 
-    eprintln!(
-        "Building {host} system closure against keystone@{rev}…\n  target: {target}",
-        host = host,
-        rev = rev,
-        target = target
-    );
+    eprintln!("Building {host} system closure for keystone@{target_label}…\n  target: {target}",);
 
     let output = cmd
         .output()
@@ -468,17 +481,17 @@ fn should_advance_lock(status: &std::process::ExitStatus) -> bool {
 /// Drive the activation step through `cmd::approve::run_and_wait`. The
 /// orchestrator-callable variant of the broker spawns the helper and
 /// waits for it to exit, so we can inspect the [`std::process::ExitStatus`]
-/// and gate post-activation work (relock, commit, push) on actual
-/// activation success. The interactive `cmd::approve::execute` path
-/// would `exec()`-replace this process and force us to perform that
-/// follow-up work *before* the privileged step — which is exactly the
-/// atomicity bug this commit fixes.
+/// and gate post-activation work (push) on actual activation success.
+/// The interactive `cmd::approve::execute` path would `exec()`-replace
+/// this process and force us to perform that follow-up work *before*
+/// the privileged step — which is exactly the atomicity bug the
+/// orchestrator-callable variant exists to avoid.
 fn activate_via_broker(reason: &str, store_path: &str) -> Result<bool> {
     let argv = elevated_argv(store_path);
     let status = cmd::approve::run_and_wait(reason, &argv)?;
     if !should_advance_lock(&status) {
         eprintln!(
-            "ks activate failed (exit {:?}) — leaving flake.lock unchanged.",
+            "ks activate failed (exit {:?}) — rolling back the flake.lock bump.",
             status.code()
         );
         return Ok(false);
@@ -486,14 +499,120 @@ fn activate_via_broker(reason: &str, store_path: &str) -> Result<bool> {
     Ok(true)
 }
 
-/// Top-level entry. Resolves channel target → builds (no lock change)
-/// → activates (privileged, awaited) → on success, relocks pinned to
-/// the activated rev → commits → pushes.
+/// Warm the polkit credential cache by firing a no-op activation. The
+/// allowlist matches `["ks", "activate", …]` (prefix), so the helper
+/// validates `["ks", "activate", "/run/current-system"]` and execs
+/// `ks activate /run/current-system` as root. `cmd::activate::execute`
+/// then short-circuits (the closure already matches `current-system`)
+/// and returns 0 with no side effects.
 ///
-/// Sequencing invariant: `relock_keystone_input` and `commit_lock` MUST
-/// only run on the activation-success branch. A failed activation must
-/// leave `flake.lock` and the working tree untouched so the next Walker
-/// click retries cleanly.
+/// Net effect: the user sees the polkit dialog within seconds of
+/// Walker dispatch, authenticates once, and polkit caches the
+/// credential under `auth_admin_keep` (configured by
+/// `keystone.security.privilegedApproval` — see
+/// `modules/os/privileged-approval.nix:112`). The cache (~5 min default)
+/// covers the build and final activation prompt without re-asking.
+///
+/// On user cancellation / auth failure the helper returns non-zero;
+/// this function returns Ok(false) and the caller aborts the run with
+/// no side effects on the consumer flake. We treat this as the user
+/// explicitly declining the update.
+fn warm_polkit_cache(host_label: &str) -> Result<bool> {
+    let argv = elevated_argv("/run/current-system");
+    let reason = approval_reason(host_label);
+    eprintln!("Requesting approval for the upcoming activation (warming polkit cache)…");
+    let status = cmd::approve::run_and_wait(&reason, &argv)?;
+    if !status.success() {
+        eprintln!(
+            "Polkit approval cancelled or failed (exit {:?}) — aborting update.",
+            status.code()
+        );
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+/// Best-effort desktop notification surfaced after the early polkit
+/// approval, before the build phase begins. Bridges the silent
+/// build-phase wait with feedback so the user knows the update is
+/// progressing. Gated on `KS_UPDATE_NOTIFY=1` (set by the launcher in
+/// `cmd::update_menu::start_update_session`) so direct CLI invocations
+/// stay quiet on the desktop. Failures are swallowed — this is purely
+/// UX feedback.
+fn notify_build_phase(target_label: &str) {
+    if std::env::var_os("KS_UPDATE_NOTIFY").is_none() {
+        return;
+    }
+    let body = format!("Building keystone@{target_label}…");
+    let _ = util::notify_send("Keystone update", &body, "normal");
+}
+
+/// Bump the keystone input in `flake.lock` to `target_rev` and commit
+/// it on the current branch. Returns `(lock_advanced, bump_sha)`:
+///
+/// - `lock_advanced = true` and `bump_sha = Some(sha)` when the lock
+///   moved and a new commit landed.
+/// - `lock_advanced = false` and `bump_sha = None` when the lock was
+///   already at `target_rev` (no relock changes, no commit). In that
+///   case the caller has nothing to roll back.
+async fn bump_lock_and_commit(
+    repo_root: &Path,
+    target_rev: &str,
+    target_label: &str,
+) -> Result<(bool, Option<String>)> {
+    relock_keystone_input(repo_root, target_rev).await?;
+    if !flake_lock_dirty(repo_root).await? {
+        eprintln!("flake.lock already pinned at {target_rev} — no commit needed.");
+        return Ok((false, None));
+    }
+    commit_lock(repo_root, target_label).await?;
+    let sha = rev_parse(repo_root, "HEAD").await?;
+    eprintln!("Committed flake.lock bump (HEAD={sha}).");
+    Ok((true, Some(sha)))
+}
+
+/// Rewind the bump commit if HEAD still equals `expected_sha`. Refuses
+/// if HEAD diverged (someone committed in parallel between our commit
+/// and the failure point) — we surface a clear error instead of
+/// destroying the user's work via `git reset --hard`.
+///
+/// On success the working tree is at the pre-bump SHA and is clean.
+async fn rollback_lock_bump(repo_root: &Path, expected_sha: &str) -> Result<()> {
+    let head_now = rev_parse(repo_root, "HEAD").await?;
+    if head_now != expected_sha {
+        anyhow::bail!(
+            "rollback refused: HEAD ({head_now}) diverged from the bump commit ({expected_sha}). \
+             Resolve manually — your work is intact."
+        );
+    }
+    let status = tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["reset", "--hard", "HEAD~1"])
+        .status()
+        .await
+        .context("failed to invoke git reset for rollback")?;
+    if !status.success() {
+        anyhow::bail!("git reset --hard HEAD~1 exited {:?}", status.code());
+    }
+    eprintln!("Rolled back flake.lock bump.");
+    Ok(())
+}
+
+/// Top-level entry. Spec: REQ-019.31. Order:
+///
+/// 1. Pre-flight (in-sync) → refuse unless local == origin.
+/// 2. Resolve channel target.
+/// 3. **Early polkit warm.** Fires the dialog within ~2 s of Walker
+///    dispatch. User cancellation aborts cleanly.
+/// 4. notify-send "Building …" (gated on `KS_UPDATE_NOTIFY=1`).
+/// 5. Bump `flake.lock` and commit. Captured `bump_sha` is the rollback
+///    target for any subsequent failure.
+/// 6. `nix build` against the bumped lock.
+/// 7. `ks activate` via broker. Polkit cache from step 3 should hit.
+/// 8. On success: best-effort `git push`.
+/// 9. On any failure between 5 and 7 success: rollback the bump
+///    commit via `rollback_lock_bump`. Refuses if HEAD diverged.
 pub(crate) async fn run_supervised_update(
     flake_override: Option<&Path>,
 ) -> Result<ApproveUpdateOutcome> {
@@ -509,14 +628,10 @@ pub(crate) async fn run_supervised_update(
         channel.as_str()
     );
 
-    // Step 0: refuse to run unless the consumer flake is in sync with
-    // origin. See `ensure_in_sync` for the invariant — this is the
-    // only way to make the post-activation push a guaranteed
-    // fast-forward.
+    // Step 1: pre-flight in-sync check.
     ensure_in_sync(&repo_root).await?;
 
-    // Step 1: resolve the target ref via GitHub API. Runs in the
-    // user's session — token + DNS available.
+    // Step 2: resolve target ref via GitHub API.
     let info = fetch_latest_release(channel)
         .await
         .with_context(|| format!("failed to resolve {} channel target", channel.as_str()))?;
@@ -532,8 +647,7 @@ pub(crate) async fn run_supervised_update(
     // CRITICAL: use `latest_name` for the audit-trail commit message.
     // For unstable, `latest_tag` is the literal "main" — losing the
     // resolved SHA — while `latest_name` is `main@<shortsha>` and
-    // preserves traceability. For stable, both coincide on the tag,
-    // so this is a no-op there.
+    // preserves traceability. For stable, both coincide on the tag.
     let target_label = if info.latest_name.is_empty() {
         target_tag.clone()
     } else {
@@ -544,48 +658,51 @@ pub(crate) async fn run_supervised_update(
         channel.as_str()
     );
 
-    // Step 2: build the closure with the override. flake.lock untouched
-    // up to this point; a failure here is a no-op on the consumer
-    // flake's state.
-    let store_path = build_with_override(&repo_root, &host, &target_rev).await?;
-    eprintln!("Built closure: {store_path}");
-
-    // Step 3: activate via the privileged broker. We *wait* for the
-    // child to exit so we can decide whether to mutate the lock based
-    // on whether activation actually succeeded. If it failed, abort the
-    // flow and leave the lock alone.
     let host_label = util::hostname_label();
-    let reason = approval_reason(&host_label);
-    eprintln!("Requesting approval to activate {store_path}…");
-    let activated = activate_via_broker(&reason, &store_path)?;
-    if !activated {
+
+    // Step 3: warm the polkit cache. User cancellation aborts cleanly.
+    let warmed = warm_polkit_cache(&host_label)?;
+    if !warmed {
         anyhow::bail!(
-            "activation was not approved or failed for {} on host {}; flake.lock was left unchanged",
+            "approval cancelled or failed for {} on host {}; no changes made",
             target_label,
             host
         );
     }
 
-    // Step 4: relock pinned to the rev we just built and activated.
-    // See `relock_keystone_input` for why we use `--override-input`
-    // instead of a bare `nix flake update keystone`.
-    relock_keystone_input(&repo_root, &target_rev).await?;
+    // Step 4: surface "building" notification.
+    notify_build_phase(&target_label);
 
-    // Step 5: commit the lock change. If the relock didn't move the
-    // lock (consumer was already on this rev), there's nothing to
-    // commit and we skip straight to the push decision.
-    let lock_advanced = if flake_lock_dirty(&repo_root).await? {
-        commit_lock(&repo_root, &target_label).await?;
-        true
-    } else {
-        eprintln!("flake.lock already pinned at {target_rev} — no commit needed.");
-        false
+    // Step 5: bump lock + commit. `bump_sha` is None when the lock was
+    // already at the target rev (no commit, nothing to roll back).
+    let (lock_advanced, bump_sha) =
+        bump_lock_and_commit(&repo_root, &target_rev, &target_label).await?;
+
+    // Steps 6 + 7: build and activate. Wrap so any failure can roll
+    // back the bump commit before propagating the error.
+    let outcome = run_build_and_activate(&repo_root, &host, &target_label, &host_label).await;
+
+    let store_path = match outcome {
+        Ok(p) => p,
+        Err(e) => {
+            if let Some(sha) = bump_sha.as_deref() {
+                if let Err(rollback_err) = rollback_lock_bump(&repo_root, sha).await {
+                    eprintln!(
+                        "Warning: rollback failed: {rollback_err:#}. Manual cleanup required."
+                    );
+                }
+            }
+            return Err(e.context(format!(
+                "supervised update failed for {} on host {}",
+                target_label, host
+            )));
+        }
     };
 
-    // Step 6: push best-effort. A network blip post-activation
-    // shouldn't fail the whole flow — the local generation is already
-    // promoted to /run/current-system and the lock is committed
-    // locally, so the user can recover by pushing by hand.
+    // Step 8: push best-effort. A network blip post-activation does NOT
+    // trigger rollback — the system is on the new closure, the lock
+    // matches, and only the remote is behind. The user can recover by
+    // pushing by hand.
     let pushed = if lock_advanced {
         let branch = current_branch(&repo_root).await?;
         match push_lock(&repo_root, &branch).await {
@@ -609,6 +726,31 @@ pub(crate) async fn run_supervised_update(
         lock_advanced,
         pushed,
     })
+}
+
+/// Steps 6 + 7 of `run_supervised_update`, factored out so a single
+/// `?`-style early return covers both the build and activation paths
+/// from the orchestrator's perspective. Any failure here propagates up
+/// and triggers `rollback_lock_bump` in the caller.
+async fn run_build_and_activate(
+    repo_root: &Path,
+    host: &str,
+    target_label: &str,
+    host_label: &str,
+) -> Result<String> {
+    // Step 6: build against the bumped lock.
+    let store_path = build_locked(repo_root, host, target_label).await?;
+    eprintln!("Built closure: {store_path}");
+
+    // Step 7: activate via the privileged broker. Polkit cache from
+    // the warm step should hit; if not, the user re-prompts.
+    let reason = approval_reason(host_label);
+    eprintln!("Requesting activation of {store_path}…");
+    let activated = activate_via_broker(&reason, &store_path)?;
+    if !activated {
+        anyhow::bail!("activation was not approved or failed");
+    }
+    Ok(store_path)
 }
 
 #[cfg(test)]
@@ -817,6 +959,115 @@ mod tests {
         assert!(
             msg.contains("master"),
             "error should name the branch: {msg}"
+        );
+    }
+
+    /// Helper: write a `flake.lock` change, stage + commit it on top of
+    /// the in-sync fixture, return the resulting HEAD sha. Lets the
+    /// rollback tests exercise the same shape `bump_lock_and_commit`
+    /// produces (single-file, single-commit ahead of origin) without
+    /// relying on a real `nix flake update`.
+    async fn make_bump_commit(local: &Path, body: &str) -> String {
+        std::fs::write(local.join("flake.lock"), body).expect("rewrite flake.lock");
+        for args in [
+            vec!["add", "flake.lock"],
+            vec!["commit", "-m", "chore: bump keystone (test)"],
+        ] {
+            let s = std::process::Command::new("git")
+                .arg("-C")
+                .arg(local)
+                .args(&args)
+                .status()
+                .expect("git command");
+            assert!(s.success(), "git {args:?} failed");
+        }
+        rev_parse(local, "HEAD").await.expect("rev-parse HEAD")
+    }
+
+    #[tokio::test]
+    async fn rollback_lock_bump_resets_to_pre_bump_when_head_matches() {
+        // Happy path: bump_sha == HEAD → reset --hard HEAD~1 lands us
+        // back on the pre-bump SHA with a clean working tree. The
+        // rollback path is what makes lock-first safe under failures
+        // between the commit and a successful activation.
+        let (_tmp, local, _remote) = make_in_sync_fixture();
+        let pre_bump = rev_parse(&local, "HEAD").await.expect("rev-parse pre-bump");
+        let bump_sha = make_bump_commit(&local, "{ \"new\": true }\n").await;
+        assert_ne!(pre_bump, bump_sha, "fixture must produce a new commit");
+
+        rollback_lock_bump(&local, &bump_sha)
+            .await
+            .expect("rollback should succeed when HEAD matches");
+
+        let after = rev_parse(&local, "HEAD")
+            .await
+            .expect("rev-parse post-rollback");
+        assert_eq!(after, pre_bump, "rollback should restore pre-bump SHA");
+
+        // Working tree must be clean — the rollback restores the
+        // pre-bump flake.lock contents.
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&local)
+            .args(["status", "--porcelain"])
+            .output()
+            .expect("git status");
+        assert!(status.status.success(), "git status failed");
+        assert!(
+            status.stdout.is_empty(),
+            "working tree must be clean after rollback: {}",
+            String::from_utf8_lossy(&status.stdout)
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_lock_bump_refuses_when_head_diverged() {
+        // Defensive guard: if someone (or a parallel agent) committed
+        // between our bump and the rollback trigger, HEAD no longer
+        // matches `expected_sha`. `git reset --hard HEAD~1` would
+        // discard their work. Refuse and surface a clear error so the
+        // user can resolve manually.
+        let (_tmp, local, _remote) = make_in_sync_fixture();
+        let bump_sha = make_bump_commit(&local, "{ \"bumped\": true }\n").await;
+
+        // Drop another commit on top so HEAD != bump_sha.
+        std::fs::write(local.join("other.txt"), "parallel work\n").expect("write other.txt");
+        for args in [
+            vec!["add", "other.txt"],
+            vec!["commit", "-m", "parallel work"],
+        ] {
+            let s = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&local)
+                .args(&args)
+                .status()
+                .expect("git command");
+            assert!(s.success(), "git {args:?} failed");
+        }
+        let head_after_parallel = rev_parse(&local, "HEAD")
+            .await
+            .expect("rev-parse parallel head");
+        assert_ne!(
+            head_after_parallel, bump_sha,
+            "fixture must drift HEAD past the bump"
+        );
+
+        let err = rollback_lock_bump(&local, &bump_sha)
+            .await
+            .expect_err("rollback must refuse on diverged HEAD");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("diverged") || msg.contains("refused"),
+            "error must name the divergence: {msg}"
+        );
+
+        // Diverged commit must still be present — we did NOT reset.
+        let head_now = rev_parse(&local, "HEAD")
+            .await
+            .expect("rev-parse post-refusal");
+        assert_eq!(
+            head_now, head_after_parallel,
+            "refusing rollback must leave HEAD untouched"
         );
     }
 

--- a/packages/ks/src/cmd/update_approve.rs
+++ b/packages/ks/src/cmd/update_approve.rs
@@ -667,22 +667,102 @@ async fn rollback_lock_bump(repo_root: &Path, expected_sha: &str) -> Result<()> 
     Ok(())
 }
 
+/// Resolve the supervised flow's target rev/label. In override mode
+/// (REQ-019.31f) the flag value is used directly so callers can point
+/// at unpublished worktrees (`path:/…`) or feature branches
+/// (`github:…/<branch>`) without going through the channel API. In
+/// channel mode we hit the existing GitHub release / branch lookup.
+async fn resolve_target(
+    channel: Channel,
+    target_override: Option<&str>,
+) -> Result<(String, String)> {
+    match target_override {
+        Some(value) => Ok((value.to_string(), value.to_string())),
+        None => {
+            let info = fetch_latest_release(channel).await.with_context(|| {
+                format!("failed to resolve {} channel target", channel.as_str())
+            })?;
+            if info.latest_rev.trim().is_empty() {
+                anyhow::bail!(
+                    "{} channel returned no commit sha for target {}",
+                    channel.as_str(),
+                    info.latest_tag
+                );
+            }
+            // CRITICAL: prefer `latest_name` (e.g., `main@<shortsha>`)
+            // for the audit-trail label. `latest_tag` for unstable is
+            // the literal "main" — losing the resolved SHA. Stable
+            // channels coincide on the tag.
+            let target_label = if info.latest_name.is_empty() {
+                info.latest_tag.clone()
+            } else {
+                info.latest_name.clone()
+            };
+            eprintln!(
+                "Resolved {} channel target: {target_label} ({})",
+                channel.as_str(),
+                info.latest_rev,
+            );
+            Ok((info.latest_rev, target_label))
+        }
+    }
+}
+
+/// Cleanup the consumer flake at end-of-run.
+///
+/// - Override mode (REQ-019.31f) ALWAYS restores `flake.lock` from
+///   HEAD: success or failure both end with a clean working tree, no
+///   commits, nothing to push.
+/// - Channel mode rolls back the bump commit on failure (when one
+///   was created) so the consumer flake is back at the pre-update
+///   SHA.
+/// - Channel mode on success leaves the bump commit in place — the
+///   caller's push step picks it up.
+async fn cleanup_after_outcome(
+    repo_root: &Path,
+    target_override: Option<&str>,
+    bump_sha: Option<&str>,
+    failed: bool,
+) {
+    if target_override.is_some() {
+        if let Err(restore_err) = restore_flake_lock(repo_root).await {
+            eprintln!(
+                "Warning: failed to restore flake.lock after override-mode {}: \
+                 {restore_err:#}. Working tree may be dirty.",
+                if failed { "failure" } else { "success" }
+            );
+        }
+        return;
+    }
+    if failed {
+        if let Some(sha) = bump_sha {
+            if let Err(rollback_err) = rollback_lock_bump(repo_root, sha).await {
+                eprintln!("Warning: rollback failed: {rollback_err:#}. Manual cleanup required.");
+            }
+        }
+    }
+}
+
 /// Top-level entry. Spec: REQ-019.31. Order:
 ///
 /// 1. Pre-flight (in-sync) → refuse unless local == origin.
-/// 2. Resolve channel target.
+/// 2. Resolve target: channel API or `target_override` if Some.
 /// 3. **Early polkit warm.** Fires the dialog within ~2 s of Walker
 ///    dispatch. User cancellation aborts cleanly.
 /// 4. notify-send "Building …" (gated on `KS_UPDATE_NOTIFY=1`).
-/// 5. Bump `flake.lock` and commit. Captured `bump_sha` is the rollback
-///    target for any subsequent failure.
-/// 6. `nix build` against the bumped lock.
+/// 5. Lock change. Channel mode: bump + commit, capture `bump_sha`.
+///    Override mode (REQ-019.31f): working-tree-only relock, no commit.
+/// 6. `nix build` against the bumped/dirty lock.
 /// 7. `ks activate` via broker. Polkit cache from step 3 should hit.
-/// 8. On success: best-effort `git push`.
-/// 9. On any failure between 5 and 7 success: rollback the bump
-///    commit via `rollback_lock_bump`. Refuses if HEAD diverged.
+/// 8. On success in channel mode: best-effort `git push`. Override
+///    mode skips push.
+/// 9. Cleanup: channel mode rolls back the bump commit on failure
+///    (`rollback_lock_bump`). Override mode unconditionally restores
+///    the working-tree lock (`restore_flake_lock`) on success or
+///    failure so the consumer flake ends clean.
 pub(crate) async fn run_supervised_update(
     flake_override: Option<&Path>,
+    target_override: Option<&str>,
 ) -> Result<ApproveUpdateOutcome> {
     let repo_root = repo::find_repo(flake_override)?;
     let host = repo::resolve_current_host(&repo_root)
@@ -690,41 +770,27 @@ pub(crate) async fn run_supervised_update(
         .ok_or_else(|| anyhow!("could not resolve current host from repo registry"))?;
 
     let channel = Channel::current();
-    eprintln!(
-        "Running supervised update for host {} on channel {}",
-        host,
-        channel.as_str()
-    );
+    if let Some(value) = target_override {
+        eprintln!(
+            "Running supervised update for host {} with --keystone override {} \
+             (channel {} ignored; no commit, no push)",
+            host,
+            value,
+            channel.as_str()
+        );
+    } else {
+        eprintln!(
+            "Running supervised update for host {} on channel {}",
+            host,
+            channel.as_str()
+        );
+    }
 
     // Step 1: pre-flight in-sync check.
     ensure_in_sync(&repo_root).await?;
 
-    // Step 2: resolve target ref via GitHub API.
-    let info = fetch_latest_release(channel)
-        .await
-        .with_context(|| format!("failed to resolve {} channel target", channel.as_str()))?;
-    if info.latest_rev.trim().is_empty() {
-        anyhow::bail!(
-            "{} channel returned no commit sha for target {}",
-            channel.as_str(),
-            info.latest_tag
-        );
-    }
-    let target_rev = info.latest_rev.clone();
-    let target_tag = info.latest_tag.clone();
-    // CRITICAL: use `latest_name` for the audit-trail commit message.
-    // For unstable, `latest_tag` is the literal "main" — losing the
-    // resolved SHA — while `latest_name` is `main@<shortsha>` and
-    // preserves traceability. For stable, both coincide on the tag.
-    let target_label = if info.latest_name.is_empty() {
-        target_tag.clone()
-    } else {
-        info.latest_name.clone()
-    };
-    eprintln!(
-        "Resolved {} channel target: {target_label} ({target_rev})",
-        channel.as_str()
-    );
+    // Step 2: resolve target (channel API or override).
+    let (target_rev, target_label) = resolve_target(channel, target_override).await?;
 
     let host_label = util::hostname_label();
 
@@ -741,37 +807,42 @@ pub(crate) async fn run_supervised_update(
     // Step 4: surface "building" notification.
     notify_build_phase(&target_label);
 
-    // Step 5: bump lock + commit. `bump_sha` is None when the lock was
-    // already at the target rev (no commit, nothing to roll back).
-    let (lock_advanced, bump_sha) =
-        bump_lock_and_commit(&repo_root, &target_rev, &target_label).await?;
-
-    // Steps 6 + 7: build and activate. Wrap so any failure can roll
-    // back the bump commit before propagating the error.
-    let outcome = run_build_and_activate(&repo_root, &host, &target_label, &host_label).await;
-
-    let store_path = match outcome {
-        Ok(p) => p,
-        Err(e) => {
-            if let Some(sha) = bump_sha.as_deref() {
-                if let Err(rollback_err) = rollback_lock_bump(&repo_root, sha).await {
-                    eprintln!(
-                        "Warning: rollback failed: {rollback_err:#}. Manual cleanup required."
-                    );
-                }
-            }
-            return Err(e.context(format!(
-                "supervised update failed for {} on host {}",
-                target_label, host
-            )));
+    // Step 5: lock change.
+    //
+    // - Channel mode: relock + commit; `bump_sha` lets us roll back on
+    //   later failure.
+    // - Override mode: working-tree-only relock so the consumer flake
+    //   carries no commit a future `git push` could publish; the
+    //   matching `restore_flake_lock` runs unconditionally below.
+    let bump_sha = match target_override {
+        Some(_) => {
+            relock_keystone_input(&repo_root, &target_rev).await?;
+            None
+        }
+        None => {
+            bump_lock_and_commit(&repo_root, &target_rev, &target_label)
+                .await?
+                .1
         }
     };
+    let lock_advanced = bump_sha.is_some();
 
-    // Step 8: push best-effort. A network blip post-activation does NOT
-    // trigger rollback — the system is on the new closure, the lock
-    // matches, and only the remote is behind. The user can recover by
-    // pushing by hand.
-    let pushed = if lock_advanced {
+    // Steps 6 + 7: build and activate.
+    let outcome = run_build_and_activate(&repo_root, &host, &target_label, &host_label).await;
+    let failed = outcome.is_err();
+    cleanup_after_outcome(&repo_root, target_override, bump_sha.as_deref(), failed).await;
+    let store_path = outcome.map_err(|e| {
+        e.context(format!(
+            "supervised update failed for {} on host {}",
+            target_label, host
+        ))
+    })?;
+
+    // Step 8: push only in channel mode. Override mode never publishes.
+    // A network blip in channel mode does NOT trigger rollback — the
+    // system is on the new closure, the lock matches, and only the
+    // remote is behind.
+    let pushed = if target_override.is_none() && lock_advanced {
         let branch = current_branch(&repo_root).await?;
         match push_lock(&repo_root, &branch).await {
             Ok(p) => p,

--- a/packages/ks/src/main.rs
+++ b/packages/ks/src/main.rs
@@ -89,6 +89,7 @@ async fn main() -> Result<()> {
                 hosts,
                 json,
                 approve,
+                keystone_override,
             } => {
                 let dev_mode = dev && !lock;
                 let pull_only = pull && dev_mode;
@@ -100,6 +101,7 @@ async fn main() -> Result<()> {
                     approve,
                     json,
                     flake,
+                    keystone_override.as_deref(),
                 )
                 .await
             }
@@ -400,6 +402,7 @@ async fn run_switch_command(
 ///
 /// See issue #487 for the privilege-boundary rationale that drove the
 /// split.
+#[allow(clippy::too_many_arguments)]
 async fn run_update_command(
     hosts: Option<&str>,
     dev: bool,
@@ -408,6 +411,7 @@ async fn run_update_command(
     approve: bool,
     json: bool,
     flake: Option<&std::path::Path>,
+    keystone_override: Option<&str>,
 ) -> Result<()> {
     if approve {
         // `--approve` ignores --boot / --pull / --hosts / --dev: the
@@ -421,7 +425,13 @@ async fn run_update_command(
                  Use `ks update --lock` from a terminal for fleet-wide updates."
             );
         }
-        return run_supervised_update_command(json, flake).await;
+        return run_supervised_update_command(json, flake, keystone_override).await;
+    }
+    if keystone_override.is_some() {
+        anyhow::bail!(
+            "ks update --keystone <ref> is only valid with --approve. \
+             Other update modes use the locked keystone input."
+        );
     }
 
     match cmd::update::execute(hosts, dev, boot, pull_only, flake).await {
@@ -455,9 +465,13 @@ async fn run_update_command(
 /// `run_supervised_update` now spawns + waits on the privileged child
 /// (so it can gate post-activation lock work on actual activation
 /// success), so control returns here on both happy and sad paths.
-async fn run_supervised_update_command(json: bool, flake: Option<&std::path::Path>) -> Result<()> {
+async fn run_supervised_update_command(
+    json: bool,
+    flake: Option<&std::path::Path>,
+    keystone_override: Option<&str>,
+) -> Result<()> {
     let notify = std::env::var_os("KS_UPDATE_NOTIFY").is_some();
-    match cmd::update_approve::run_supervised_update(flake).await {
+    match cmd::update_approve::run_supervised_update(flake, keystone_override).await {
         Ok(outcome) => {
             if json {
                 print_json_success(&serde_json::json!({

--- a/specs/REQ-019-ks-cli.md
+++ b/specs/REQ-019-ks-cli.md
@@ -218,6 +218,91 @@ pause marker for one agent or all configured agents.
 target agent task loop is paused. It SHOULD include the pause timestamp,
 pause actor, and pause reason when present.
 
+### Supervised update flow (`ks update --approve`)
+
+The supervised update path is the desktop-triggered, single-host channel-update
+flow invoked by Walker → Update. Implementation: `packages/ks/src/cmd/update_approve.rs`.
+Privileged elevation goes through `cmd::approve` (REQ-016 family) and is
+narrow: only `ks activate <store-path>` runs as root. Channel resolution,
+`nix build`, `nix flake update`, `git commit`, and `git push` all run in
+the user's session.
+
+**REQ-019.31** `ks update --approve` MUST run the following steps in order
+on every invocation:
+
+1. **Pre-flight in-sync check.** Refuse to start unless the consumer flake's
+   working tree is clean AND the current branch resolves to the same SHA
+   as `origin/<branch>`. The error MUST name the specific reason
+   (uncommitted changes / ahead / behind) so the user can act without
+   inspecting logs.
+2. **Channel resolution.** Resolve the active channel
+   (`keystone.update.channel`, REQ-019.1a runtime pointer + env override)
+   to a concrete keystone rev via the GitHub API.
+3. **Early polkit prompt (cache warm).** Trigger the `com.ncrmro.keystone.approve`
+   action via `cmd::approve::run_and_wait` with a no-op activation payload
+   (`ks activate /run/current-system`, which short-circuits in
+   `cmd::activate::execute` because the closure is already current). The
+   prompt MUST appear within ~2 s of Walker dispatch so the user can
+   authenticate while still focused on the action. Polkit's
+   `auth_admin_keep` (configured by `keystone.security.privilegedApproval`)
+   then caches the credential for ~5 min, covering the build and
+   activation steps without a second prompt.
+4. **Build-phase notification.** Emit a `notify-send` "Keystone update:
+   building <target>…" via `cmd::util::notify_send`, gated by
+   `KS_UPDATE_NOTIFY=1` in the same way the launcher already sets the
+   completion / failure notifications. This bridges the silent
+   build-phase wait so the user has feedback after authenticating.
+5. **Lock-first bump.** Update `flake.lock`'s `keystone` input to
+   `github:ncrmro/keystone/<rev>` via
+   `nix flake update keystone --override-input keystone github:.../<rev>`,
+   then commit it with subject `chore: bump keystone to <target>`.
+   Capture the resulting commit SHA as `bump_sha`. The commit MUST NOT
+   be pushed yet — push is the final post-activation step.
+6. **Build.** Run `nix build` against the consumer flake's
+   `nixosConfigurations.<host>.config.system.build.toplevel`. The lock
+   now points at the target rev, so no `--override-input` is needed for
+   correctness; local file-source overrides (dev mode) MAY still be
+   layered.
+7. **Activation.** Drive `ks activate <store-path>` via the privileged
+   broker (`cmd::approve::run_and_wait`). Polkit MUST hit the cached
+   credential from step 3 and not re-prompt under normal conditions; if
+   the cache has expired, the user MAY be prompted again as degraded
+   UX, which is acceptable but SHOULD be rare.
+8. **Push.** On activation success, `git push origin <branch>` is
+   best-effort. A failed push is logged as a warning but does not fail
+   the run — the local generation is already promoted and the lock
+   matches it.
+9. **Final notification.** `notify-send` "Keystone update complete" on
+   success or "failed" on any failure path with a journal pointer.
+
+**REQ-019.31a** Steps 1, 2, and 3 MUST run before any filesystem mutation
+on the consumer flake. The user MAY cancel the polkit prompt to abort
+the run cleanly with no side effects.
+
+**REQ-019.31b** Steps 5 (lock bump) and 7 (activation) form the atomicity
+contract. If activation fails — including any non-zero exit other than
+the documented switch-to-configuration exit code 4 (success-with-warnings,
+see `cmd::activate::switch_to_configuration`) — the orchestrator MUST
+roll back the bump commit by verifying `HEAD` still equals `bump_sha`
+and running `git reset --hard HEAD~1`. Rollback MUST refuse if `HEAD`
+diverged from `bump_sha` between commit and failure (the user committed
+in parallel) and surface a clear error rather than discarding their work.
+
+**REQ-019.31c** Push failure (step 8) after a successful activation MUST
+NOT trigger rollback. The local generation is on the new closure; the
+lock matches; only the remote is behind. The user can resolve by hand.
+
+**REQ-019.31d** All notifications emitted by the supervised flow MUST be
+gated on `KS_UPDATE_NOTIFY=1`. The launcher (`cmd::update_menu::start_update_session`)
+sets this; direct CLI invocations do not, so they remain quiet on the
+desktop.
+
+**REQ-019.31e** The polkit dialog's `Approval request:` line MUST name
+the host (e.g., "Install Keystone update on ncrmro-laptop") so a user
+with multiple machines can tell which host the dialog is for. The
+allowlist `displayName` provides the static title; the per-request
+`Requested reason:` carries the host context.
+
 ## Edge Cases
 
 - If `gh` CLI is not available, lock mode MUST fall back to direct

--- a/specs/REQ-019-ks-cli.md
+++ b/specs/REQ-019-ks-cli.md
@@ -240,13 +240,18 @@ on every invocation:
    to a concrete keystone rev via the GitHub API.
 3. **Early polkit prompt (cache warm).** Trigger the `com.ncrmro.keystone.approve`
    action via `cmd::approve::run_and_wait` with a no-op activation payload
-   (`ks activate /run/current-system`, which short-circuits in
-   `cmd::activate::execute` because the closure is already current). The
-   prompt MUST appear within ~2 s of Walker dispatch so the user can
-   authenticate while still focused on the action. Polkit's
-   `auth_admin_keep` (configured by `keystone.security.privilegedApproval`)
-   then caches the credential for ~5 min, covering the build and
-   activation steps without a second prompt.
+   targeting the running system. The orchestrator MUST canonicalize
+   `/run/current-system` to its underlying `/nix/store/<closure>` path
+   before constructing the `ks activate <path>` argv, because
+   `cmd::activate::validate_store_path` rejects any argument not under
+   `/nix/store/` as defense-in-depth. `ks activate` then short-circuits
+   because the canonical closure already matches `/run/current-system`,
+   producing zero side effects beyond the polkit prompt. The prompt MUST
+   appear within ~2 s of Walker dispatch so the user can authenticate
+   while still focused on the action. Polkit's `auth_admin_keep`
+   (configured by `keystone.security.privilegedApproval`) then caches
+   the credential for ~5 min, covering the build and activation steps
+   without a second prompt.
 4. **Build-phase notification.** Emit a `notify-send` "Keystone update:
    building <target>…" via `cmd::util::notify_send`, gated by
    `KS_UPDATE_NOTIFY=1` in the same way the launcher already sets the

--- a/specs/REQ-019-ks-cli.md
+++ b/specs/REQ-019-ks-cli.md
@@ -308,6 +308,28 @@ with multiple machines can tell which host the dialog is for. The
 allowlist `displayName` provides the static title; the per-request
 `Requested reason:` carries the host context.
 
+**REQ-019.31f** `ks update --approve --keystone <ref>` provides a
+local-development override for the supervised flow. `<ref>` is any
+value accepted by `nix flake update keystone --override-input keystone
+<ref>` (typically `github:ncrmro/keystone/<branch-or-sha>` or
+`path:/absolute/path/to/worktree`). When set:
+
+1. Step 2 (channel resolution) is skipped; the flag value becomes the
+   target ref and target label directly.
+2. Step 5 advances `flake.lock` in the working tree only via
+   `relock_keystone_input` — **no commit, no `bump_sha`**.
+3. Step 8 (`git push`) is skipped unconditionally — the override is
+   never published.
+4. `restore_flake_lock` runs unconditionally at end-of-run (success or
+   failure), restoring `flake.lock` from `HEAD` so the consumer flake
+   ends clean.
+
+The user explicitly accepts the temporary divergence: the running
+system is activated against the override target while `flake.lock`
+points at the channel rev. Re-running `ks update --approve` without
+the flag brings the system back to the channel rev. The flag is
+invalid alongside any non-`--approve` mode.
+
 ## Edge Cases
 
 - If `gh` CLI is not available, lock mode MUST fall back to direct


### PR DESCRIPTION
## Summary

Reorder `ks update --approve` so the polkit prompt fires within ~2 s of Walker dispatch instead of after a 1.5 min silent build, and switch from activate-then-mutate to lock-first-with-rollback. Spec'd as REQ-019.31.

## The UX problem

Today's order:

```
walker → silent 1.5 min nix build → polkit dialog → user types pwd → activate → relock → commit → push
```

The user has zero feedback during the build phase. Frequently they context-switch away before the dialog appears and it times out — observed live this afternoon at 16:00:08, exit 127 "Not authorized". An otherwise-clean run failed at the auth step.

## New order (REQ-019.31)

```
walker → uwsm app -- ks update --approve  [user]
   ├─ pre-flight: refuse if local != origin
   ├─ resolve channel target via GitHub API
   ├─ ks approve … -- ks activate /run/current-system  ← polkit (warm) [~2 s]
   │     └─ no-op (current-system already matches)
   │       polkit caches credential under auth_admin_keep
   ├─ notify-send "Building <target>…"                ← bridges silent build wait
   ├─ nix flake update keystone --override-input keystone github:.../<rev>
   ├─ git commit -m "chore: bump keystone to <ref>"   ← CAPTURE bump_sha
   ├─ nix build  (against bumped lock; no per-build override needed)
   ├─ ks approve … -- ks activate <store-path>        ← polkit (cache hit)
   ├─ git push origin <branch>                        ← best-effort, soft fail
   └─ notify success/failure
```

On any failure between the lock commit and a successful activation: `rollback_lock_bump(bump_sha)` runs `git reset --hard HEAD~1` after verifying HEAD still equals the captured SHA. Refuses on divergence to avoid discarding parallel work. Push failure does NOT trigger rollback — system is on the new closure, lock matches.

## Why this is safe

- **Polkit caching already in place.** `modules/os/privileged-approval.nix` declares `<allow_active>auth_admin_keep</allow_active>` for the action; we just stop wasting the cache on dead build time.
- **Pre-flight** still requires clean tree + local == origin. Bump commit is always single-file (flake.lock) and always HEAD, so `reset --hard HEAD~1` is unambiguous.
- **Activate-then-mutate** is replaced by **lock-first + rollback on failure**. Outcome is equivalent: at end-of-run the lock and running system always agree. The new ordering buys faster UX feedback.
- **Push failure** preserves the same best-effort contract as before.

## New helpers

| Helper | Purpose |
|---|---|
| `warm_polkit_cache(host_label)` | Fires polkit dialog with a no-op activation payload; user authenticates once for the whole run. |
| `notify_build_phase(target_label)` | `notify-send "Building keystone@<target>…"` gated on `KS_UPDATE_NOTIFY=1`. |
| `bump_lock_and_commit(repo_root, rev, label) -> (bool, Option<sha>)` | Runs the existing relock + commit up front; returns the new HEAD SHA for rollback bookkeeping. |
| `rollback_lock_bump(repo_root, expected_sha)` | Verifies HEAD == expected then `git reset --hard HEAD~1`. Refuses on divergence. |
| `build_locked(repo_root, host, target_label)` | Replaces `build_with_override` — the lock now holds the rev, so no per-build `--override-input keystone` needed. |
| `run_build_and_activate(...)` | Factor for steps 6 + 7 so the orchestrator can wrap both in one rollback path. |

## Tests

- New `rollback_lock_bump_resets_to_pre_bump_when_head_matches` — happy path.
- New `rollback_lock_bump_refuses_when_head_diverged` — defence against discarding parallel work.
- Existing `should_advance_lock`, `elevated_argv`, `approval_reason`, `ensure_in_sync` (clean / dirty / ahead / behind) all still pass.
- `keystone-update-approve-flow` integration check passes (`nix build .#checks.x86_64-linux.keystone-update-approve-flow` green).
- `keystone-update-menu-wiring` passes — wiring test asserts external surface only (token strings, file references), no internal-ordering grep.

## Spec

REQ-019.31 + .31a..e in `specs/REQ-019-ks-cli.md` formalises the order, the cache contract, the rollback contract, and the failure-mode table. Cross-references `cmd::activate::switch_to_configuration`'s exit-code 4 handling (REQ from PR #501).

## Risks

- **Polkit cache TTL might not cover cold first-run builds.** Re-prompt is degraded UX, not a failure — same as today minus the up-front prompt.
- **`auth_admin_keep` per-subject caching.** Verify empirically that `cmd::approve::run_and_wait`'s spawn-wait pattern keeps subsequent invocations in the same polkit subject so the cache hits.

## Test plan

- [ ] CI green
- [ ] Live test on `ncrmro-laptop`: build with `--override-input keystone path:<worktree>`, activate, trigger Walker → Update
  - polkit dialog appears in < 5 s
  - notify-send "Building …" fires after auth
  - build runs without re-prompting
  - activation completes; second polkit prompt is either silent (cache hit) or a degraded but acceptable re-prompt
  - flake.lock bump committed; push succeeded; notify-send "complete"
- [ ] Inject synthetic build failure → rollback path: HEAD restored, flake.lock pre-update, notify-send "failed"