### PR TITLE
feat: per-agent dev VM sandbox (codename stonebraker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `keystone.os.networkEgress` module — opt-in outbound firewall that drops
+  traffic to RFC1918 / link-local / ULA destinations except an explicit
+  allow-list (Tailscale CGNAT pre-allowed)
+- `keystone.server.devVm` module — declarative libvirt domain manager that
+  hosts long-lived dev VMs on a server, with an isolated NAT network and
+  per-domain UEFI Secure Boot + swtpm
+- `keystone.lib.mkAgentDevVm` — host-config helper for per-agent sandbox
+  VMs where an agent (e.g. drago, luce) iterates on a keystone fork
+  without endangering the parent host. Registers as a new `agent-dev-vm`
+  kind in `mkSystemFlake`, so `vm-image-<name>` is auto-exposed
+
 ## [0.12.0] - 2026-04-03
 
 ### Added

--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -667,6 +667,121 @@ rec {
       }
     );
 
+  # Build a host configuration for an agent's dev VM — a sandbox where the
+  # agent (e.g. drago, luce) can iterate on a fork of keystone without
+  # endangering the parent host.  The resulting host is registered like any
+  # other in mkSystemFlake, so `vm-image-<name>` is auto-exposed and the
+  # parent host can boot it via keystone.server.devVm.hosts.<key>.image.
+  #
+  # Usage (in a consumer flake's host registry):
+  #
+  #   agent-drago-devvm = {
+  #     kind = "agent-dev-vm";
+  #     agent = "drago";
+  #     agentConfig = {
+  #       fullName = "Drago";
+  #       email = "agent-drago@example.com";
+  #       # the same shape used in keystone.os.agents.drago
+  #     };
+  #     fork = "git@github.com:ncrmro-drago/keystone.git";
+  #   };
+  #
+  # The dev VM uses ext4 storage (no encryption — the qcow2 lives on the
+  # parent host's encrypted disk), no Secure Boot, no TPM, and turns on
+  # tailscale + networkEgress so it can reach the public internet and the
+  # mesh but not the parent's home LAN.
+  mkAgentDevVm =
+    {
+      agent,
+      agentConfig ? { },
+      fork ? null,
+      hostname ? "agent-${agent}-devvm",
+      memory ? 6144,
+      vcpus ? 4,
+      additionalAllowedSubnets ? [ "192.168.200.0/24" ],
+      modules ? [ ],
+      storage ? { },
+      ...
+    }@args:
+    mkLinuxHost (
+      (builtins.removeAttrs args [
+        "agent"
+        "agentConfig"
+        "fork"
+        "memory"
+        "vcpus"
+        "additionalAllowedSubnets"
+      ])
+      // {
+        inherit hostname;
+        desktop = false;
+        secureBoot = {
+          enable = false;
+        };
+        tpm = {
+          enable = false;
+        };
+        storage = lib.recursiveUpdate {
+          type = "ext4";
+          mode = "single";
+          devices = [ "/dev/vda" ];
+        } storage;
+        modules = modules ++ [
+          (
+            { lib, pkgs, ... }:
+            {
+              keystone.os.agents.${agent} = lib.mkMerge [
+                agentConfig
+                { host = lib.mkForce hostname; }
+              ];
+              # Plain assignment (priority 100) beats the mkHostModule default
+              # (`mkDefault false`, priority 1000). Consumers can still flip it
+              # off with `lib.mkForce false`.
+              keystone.os.tailscale.enable = true;
+              keystone.os.networkEgress = {
+                enable = true;
+                allowedSubnets = [
+                  "100.64.0.0/10"
+                  "127.0.0.0/8"
+                ]
+                ++ additionalAllowedSubnets;
+              };
+              # CRITICAL: this VM hosts in-progress keystone module work; the
+              # firewall MUST stay on so networkEgress rules apply.
+              networking.firewall.enable = lib.mkForce true;
+
+              # First-boot fork clone. Best-effort — agent's ssh key may not
+              # be loaded yet on the very first boot, but task-loop will
+              # retry once the user session is up.
+              systemd.services."agent-fork-clone" = lib.mkIf (fork != null) {
+                description = "Clone keystone fork for agent ${agent}";
+                wantedBy = [ "multi-user.target" ];
+                after = [ "network-online.target" ];
+                wants = [ "network-online.target" ];
+                serviceConfig = {
+                  Type = "oneshot";
+                  RemainAfterExit = true;
+                  User = "agent-${agent}";
+                  Group = "agents";
+                };
+                path = [
+                  pkgs.git
+                  pkgs.openssh
+                ];
+                script = ''
+                  dest="$HOME/repos/ncrmro/keystone"
+                  if [ ! -d "$dest/.git" ]; then
+                    mkdir -p "$(dirname "$dest")"
+                    git clone "${fork}" "$dest" || exit 0
+                  fi
+                '';
+              };
+            }
+          )
+        ];
+      }
+    );
+
   mkMacosTerminal =
     {
       system ? "aarch64-darwin",
@@ -737,6 +852,15 @@ rec {
           builder = mkServer;
           system = "x86_64-linux";
           nixosModules = [ self.nixosModules.server ];
+          desktop = false;
+        };
+
+        # Per-agent sandbox VM. The agent (drago, luce, …) iterates on a
+        # keystone fork inside, parent host keeps a clean blast radius.
+        "agent-dev-vm" = {
+          builder = mkAgentDevVm;
+          system = "x86_64-linux";
+          nixosModules = [ ];
           desktop = false;
         };
       };

--- a/modules/os/default.nix
+++ b/modules/os/default.nix
@@ -254,6 +254,7 @@ in
     ./remote-unlock.nix
     ./users.nix
     ./ssh.nix
+    ./network-egress.nix
     ./eternal-terminal.nix
     ./airplay.nix
     ./mail.nix

--- a/modules/os/network-egress.nix
+++ b/modules/os/network-egress.nix
@@ -1,0 +1,126 @@
+# Keystone OS Network Egress Module
+#
+# Opt-in outbound firewall: drops traffic to RFC1918 / link-local /
+# ULA destinations except for an explicit allow-list. WAN remains
+# unrestricted. Designed for sandbox VMs that should reach the public
+# internet (and the Tailscale mesh) but MUST NOT touch the home LAN.
+#
+# Usage (typically inside a dev-VM nixosConfiguration):
+#   keystone.os.networkEgress = {
+#     enable = true;
+#     allowedSubnets = [
+#       "100.64.0.0/10"     # Tailscale CGNAT
+#       "127.0.0.0/8"       # loopback
+#       "192.168.200.0/24"  # libvirt dev-net (gateway 192.168.200.1)
+#     ];
+#   };
+#
+# Implemented via networking.firewall.extraCommands, which the iptables
+# backend (NixOS default) and the iptables-nft compatibility shim both
+# honour. If a host enables `networking.nftables.enable = true` natively,
+# extraCommands becomes a no-op and these rules will not apply — surface
+# this with an assertion.
+#
+{
+  lib,
+  config,
+  ...
+}:
+with lib;
+let
+  cfg = config.keystone.os.networkEgress;
+
+  # IPv4 private/CGNAT/link-local ranges we drop unless explicitly allowed.
+  blockedV4 = [
+    "10.0.0.0/8"
+    "172.16.0.0/12"
+    "192.168.0.0/16"
+    "169.254.0.0/16"
+  ];
+  blockedV6 = [
+    "fc00::/7" # Unique Local Addresses
+    "fe80::/10" # Link-local
+  ];
+
+  isV6 = s: hasInfix ":" s;
+  v4Allowed = filter (s: !isV6 s) cfg.allowedSubnets;
+  v6Allowed = filter isV6 cfg.allowedSubnets;
+
+  buildExtra = ''
+    # keystone-network-egress: allow loopback unconditionally
+    iptables  -I OUTPUT 1 -o lo -j ACCEPT
+    ip6tables -I OUTPUT 1 -o lo -j ACCEPT
+
+    # allow established/related (return traffic for accepted flows)
+    iptables  -I OUTPUT 1 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+    ip6tables -I OUTPUT 1 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+    # allow-list (inserted first so they short-circuit the rejects)
+    ${concatMapStringsSep "\n" (s: "iptables  -I OUTPUT 1 -d ${s} -j ACCEPT") v4Allowed}
+    ${concatMapStringsSep "\n" (s: "ip6tables -I OUTPUT 1 -d ${s} -j ACCEPT") v6Allowed}
+
+    # reject the rest of RFC1918 / link-local / ULA
+    ${concatMapStringsSep "\n" (s: "iptables  -A OUTPUT -d ${s} -j REJECT --reject-with icmp-net-unreachable") blockedV4}
+    ${concatMapStringsSep "\n" (s: "ip6tables -A OUTPUT -d ${s} -j REJECT --reject-with icmp6-adm-prohibited") blockedV6}
+  '';
+
+  buildExtraStop = ''
+    # keystone-network-egress: best-effort cleanup. Mirror buildExtra in
+    # reverse so reload doesn't accumulate duplicate rules.
+    ${concatMapStringsSep "\n" (s: "iptables  -D OUTPUT -d ${s} -j REJECT --reject-with icmp-net-unreachable || true") blockedV4}
+    ${concatMapStringsSep "\n" (s: "ip6tables -D OUTPUT -d ${s} -j REJECT --reject-with icmp6-adm-prohibited || true") blockedV6}
+    ${concatMapStringsSep "\n" (s: "iptables  -D OUTPUT -d ${s} -j ACCEPT || true") v4Allowed}
+    ${concatMapStringsSep "\n" (s: "ip6tables -D OUTPUT -d ${s} -j ACCEPT || true") v6Allowed}
+    iptables  -D OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT || true
+    ip6tables -D OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT || true
+    iptables  -D OUTPUT -o lo -j ACCEPT || true
+    ip6tables -D OUTPUT -o lo -j ACCEPT || true
+  '';
+in
+{
+  options.keystone.os.networkEgress = {
+    enable = mkEnableOption ''
+      outbound firewall that rejects RFC1918 / link-local / ULA
+      destinations except those listed in allowedSubnets. Public WAN
+      remains unrestricted'';
+
+    allowedSubnets = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "100.64.0.0/10" # Tailscale CGNAT
+        "127.0.0.0/8" # loopback (defence in depth; loopback is also -o lo allowed)
+      ];
+      example = [
+        "100.64.0.0/10"
+        "192.168.200.0/24"
+      ];
+      description = ''
+        Private / CGNAT / link-local subnets that bypass the egress
+        block. Add the libvirt dev-net subnet here so the VM can reach
+        its NAT gateway, and the Tailscale CGNAT range so mesh peers
+        remain reachable.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(config.networking.nftables.enable or false);
+        message = ''
+          keystone.os.networkEgress relies on networking.firewall.extraCommands,
+          which is ignored when networking.nftables.enable = true. Either turn
+          off native nftables on this host, or extend this module with a
+          networking.nftables.tables entry.
+        '';
+      }
+      {
+        assertion = config.networking.firewall.enable;
+        message = "keystone.os.networkEgress requires networking.firewall.enable = true";
+      }
+    ];
+
+    networking.firewall.extraCommands = buildExtra;
+    networking.firewall.extraStopCommands = buildExtraStop;
+  };
+}

--- a/modules/server/default.nix
+++ b/modules/server/default.nix
@@ -63,6 +63,7 @@ in
     ./acme.nix
     ./nginx.nix
     ./dns.nix
+    ./dev-vm.nix
 
     # Service modules
     ./services/immich.nix

--- a/modules/server/dev-vm.nix
+++ b/modules/server/dev-vm.nix
@@ -1,0 +1,353 @@
+# Keystone Dev VM Module — declarative libvirt domains
+#
+# Manages one or more long-lived KVM guests on a server host. Each guest
+# boots a qcow2 produced by `keystone.lib.mkVMImage` (a normal keystone
+# nixosConfiguration), runs on an isolated libvirt NAT network, and is
+# defined + autostarted via a systemd one-shot at activation.
+#
+# This is the lower-level primitive. The agent-facing wrapper is
+# modules/os/agents/dev-vm.nix, which generates a guest config per agent
+# and registers it here automatically. Operators can also use
+# keystone.server.devVm.hosts directly to host arbitrary keystone images.
+#
+# Lifecycle:
+#   - First activation seeds /var/lib/libvirt/images/dev-vm-<name>.qcow2
+#     from the image package and writes a sentinel file naming the image
+#     store path. Subsequent rebuilds compare the sentinel: if the image
+#     hash changes the operator MUST manually clear the disk to pick it
+#     up (we never overwrite a running guest's state).
+#   - The libvirt network and domain are virsh-defined idempotently. An
+#     update to the rendered XML is applied via `virsh define` (which
+#     replaces the persistent definition); the running domain keeps its
+#     current XML until reboot, matching libvirt semantics.
+#
+{
+  lib,
+  config,
+  options,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  cfg = config.keystone.server.devVm;
+
+  # The dev-VM module reaches into keystone.os.hypervisor when both modules
+  # coexist on the same host. Server-only evaluation (without the OS module)
+  # would crash on a dangling option path, so guard the cross-module wiring
+  # behind this check.
+  hasOs = options ? keystone.os && options.keystone.os ? hypervisor;
+
+  netCidr = cfg.network.subnet; # e.g. "192.168.200.0/24"
+  netPrefix = elemAt (splitString "/" netCidr) 0; # "192.168.200.0"
+  octets = splitString "." netPrefix;
+  netBase3 = concatStringsSep "." (lib.lists.take 3 octets); # "192.168.200"
+  gatewayIP = "${netBase3}.1";
+  netmask = "255.255.255.0"; # /24 only — keep it simple
+  dhcpStart = "${netBase3}.100";
+  dhcpEnd = "${netBase3}.200";
+
+  vmHostSubmodule = types.submodule (
+    { name, ... }:
+    {
+      options = {
+        image = mkOption {
+          type = types.package;
+          description = ''
+            A vm-image-* package (keystone.lib.mkVMImage output) whose
+            qcow2 disk(s) will boot in this guest.
+          '';
+        };
+
+        diskFile = mkOption {
+          type = types.str;
+          default = "disk0.qcow2";
+          description = ''
+            Filename inside the image package to use as the boot disk.
+            ZFS hosts produce disk0.qcow2; ext4 hosts produce root.qcow2.
+          '';
+        };
+
+        memory = mkOption {
+          type = types.int;
+          default = 4096;
+          description = "RAM in MiB.";
+        };
+
+        vcpus = mkOption {
+          type = types.int;
+          default = 4;
+          description = "vCPU count.";
+        };
+
+        autostart = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Start the domain on host boot and keep it running.";
+        };
+
+        mac = mkOption {
+          type = types.str;
+          example = "52:54:00:6b:dd:01";
+          description = ''
+            Stable MAC address for the guest interface. Required so the
+            libvirt DHCP server hands out a stable IP and the host's
+            ssh_known_hosts entries don't churn on rebuild.
+          '';
+        };
+      };
+    }
+  );
+
+  # Render libvirt network XML once.
+  networkXml = pkgs.writeText "${cfg.network.name}.xml" ''
+    <network>
+      <name>${cfg.network.name}</name>
+      <forward mode='nat'>
+        <nat>
+          <port start='1024' end='65535'/>
+        </nat>
+      </forward>
+      <bridge name='${cfg.network.bridge}' stp='on' delay='0'/>
+      <ip address='${gatewayIP}' netmask='${netmask}'>
+        <dhcp>
+          <range start='${dhcpStart}' end='${dhcpEnd}'/>
+        </dhcp>
+      </ip>
+    </network>
+  '';
+
+  # Render a domain XML for a single guest.
+  domainXml =
+    name: vm:
+    let
+      diskPath = "/var/lib/libvirt/images/dev-vm-${name}.qcow2";
+    in
+    pkgs.writeText "dev-vm-${name}.xml" ''
+      <domain type='kvm'>
+        <name>dev-vm-${name}</name>
+        <memory unit='MiB'>${toString vm.memory}</memory>
+        <vcpu placement='static'>${toString vm.vcpus}</vcpu>
+
+        <os>
+          <type arch='x86_64' machine='q35'>hvm</type>
+          <loader readonly='yes' secure='yes' type='pflash'>/run/libvirt/nix-ovmf/OVMF_CODE.fd</loader>
+          <nvram template='/run/libvirt/nix-ovmf/OVMF_VARS.fd'>/var/lib/libvirt/qemu/nvram/dev-vm-${name}_VARS.fd</nvram>
+          <boot dev='hd'/>
+        </os>
+
+        <features>
+          <acpi/>
+          <apic/>
+          <smm state='on'>
+            <tseg unit='MiB'>48</tseg>
+          </smm>
+        </features>
+
+        <cpu mode='host-passthrough' check='none'/>
+
+        <clock offset='utc'>
+          <timer name='rtc' tickpolicy='catchup'/>
+          <timer name='pit' tickpolicy='delay'/>
+          <timer name='hpet' present='no'/>
+        </clock>
+
+        <on_poweroff>destroy</on_poweroff>
+        <on_reboot>restart</on_reboot>
+        <on_crash>restart</on_crash>
+
+        <devices>
+          <emulator>/run/current-system/sw/bin/qemu-system-x86_64</emulator>
+
+          <disk type='file' device='disk'>
+            <driver name='qemu' type='qcow2'/>
+            <source file='${diskPath}'/>
+            <target dev='vda' bus='virtio'/>
+          </disk>
+
+          <interface type='network'>
+            <source network='${cfg.network.name}'/>
+            <mac address='${vm.mac}'/>
+            <model type='virtio'/>
+          </interface>
+
+          <serial type='pty'>
+            <target type='isa-serial' port='0'>
+              <model name='isa-serial'/>
+            </target>
+          </serial>
+          <console type='pty'>
+            <target type='serial' port='0'/>
+          </console>
+
+          <tpm model='tpm-crb'>
+            <backend type='emulator' version='2.0'/>
+          </tpm>
+
+          <video>
+            <model type='virtio' heads='1' primary='yes'/>
+          </video>
+        </devices>
+      </domain>
+    '';
+
+  # systemd-bound helpers. virsh always invoked against the system URI.
+  virsh = "${pkgs.libvirt}/bin/virsh -c qemu:///system";
+
+  netService = {
+    description = "Define libvirt network ${cfg.network.name}";
+    after = [ "libvirtd.service" ];
+    requires = [ "libvirtd.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    path = [ pkgs.libvirt ];
+    script = ''
+      set -eu
+      if ${virsh} net-info ${cfg.network.name} >/dev/null 2>&1; then
+        # Update definition in place; this is idempotent.
+        ${virsh} net-define ${networkXml} >/dev/null
+      else
+        ${virsh} net-define ${networkXml} >/dev/null
+      fi
+      ${virsh} net-autostart ${cfg.network.name} >/dev/null
+      if ! ${virsh} net-info ${cfg.network.name} | grep -q '^Active:.*yes'; then
+        ${virsh} net-start ${cfg.network.name} >/dev/null
+      fi
+    '';
+  };
+
+  vmServices = mapAttrs' (
+    name: vm:
+    let
+      diskPath = "/var/lib/libvirt/images/dev-vm-${name}.qcow2";
+      sentinel = "/var/lib/libvirt/images/dev-vm-${name}.image-source";
+    in
+    nameValuePair "libvirt-dev-vm-${name}" {
+      description = "Define and start dev VM ${name}";
+      after = [
+        "libvirtd.service"
+        "libvirt-keystone-devnet.service"
+      ];
+      requires = [
+        "libvirtd.service"
+        "libvirt-keystone-devnet.service"
+      ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      path = [
+        pkgs.libvirt
+        pkgs.coreutils
+        pkgs.qemu_kvm
+      ];
+      script = ''
+        set -eu
+        # Seed the qcow2 from the image package on first boot only. Once the
+        # guest writes to it, the sentinel pins us to the original source —
+        # operators must manually clear the disk to pick up a new image.
+        if [ ! -e "${diskPath}" ]; then
+          install -d -m 0755 /var/lib/libvirt/images
+          cp --reflink=auto "${vm.image}/${vm.diskFile}" "${diskPath}"
+          chmod 0600 "${diskPath}"
+          # Resize the qcow2 virtual size to give the guest headroom; the
+          # disko-built image is sized to the layout it carries.
+          ${pkgs.qemu_kvm}/bin/qemu-img resize "${diskPath}" +32G || true
+          echo "${vm.image}" > "${sentinel}"
+        fi
+
+        # Define / redefine the domain. virsh define is idempotent; an
+        # already-running domain keeps its current XML until reboot.
+        ${virsh} define ${domainXml name vm} >/dev/null
+
+        ${optionalString vm.autostart ''
+          ${virsh} autostart dev-vm-${name} >/dev/null || true
+          if ! ${virsh} domstate dev-vm-${name} | grep -q running; then
+            ${virsh} start dev-vm-${name} >/dev/null
+          fi
+        ''}
+      '';
+    }
+  ) cfg.hosts;
+in
+{
+  options.keystone.server.devVm = {
+    enable = mkEnableOption "Run keystone dev VMs on this host";
+
+    network = {
+      name = mkOption {
+        type = types.str;
+        default = "keystone-devnet";
+        description = "libvirt network name shared by all dev VMs on this host.";
+      };
+
+      bridge = mkOption {
+        type = types.str;
+        default = "virkdv0";
+        description = "Bridge interface name for the dev-VM network.";
+      };
+
+      subnet = mkOption {
+        type = types.str;
+        default = "192.168.200.0/24";
+        description = ''
+          IPv4 subnet for the dev-VM network. Currently only /24 is
+          supported; the gateway is the .1 host of the subnet.
+        '';
+      };
+    };
+
+    hosts = mkOption {
+      type = types.attrsOf vmHostSubmodule;
+      default = { };
+      description = ''
+        Map of dev-VM name → guest options. The name becomes the libvirt
+        domain name (prefixed `dev-vm-`) and the on-disk qcow2 filename.
+      '';
+    };
+  };
+
+  config = mkMerge [
+    (mkIf (cfg.enable && cfg.hosts != { }) {
+      systemd.tmpfiles.rules = [
+        "d /var/lib/libvirt/images 0755 root root -"
+        "d /var/lib/libvirt/qemu/nvram 0755 root root -"
+      ];
+
+      systemd.services = vmServices // {
+        libvirt-keystone-devnet = netService;
+      };
+    })
+
+    # Cross-module wiring with keystone.os.hypervisor. Only emitted when the
+    # OS module is in scope on this host — keeps standalone server-only
+    # evaluation (tests/module/server-evaluation.nix) from tripping on a
+    # dangling option path.
+    (mkIf (cfg.enable && cfg.hosts != { } && hasOs) (
+      lib.optionalAttrs hasOs {
+        keystone.os.hypervisor.enable = mkDefault true;
+        keystone.os.hypervisor.allowedBridges = [
+          "virbr0"
+          cfg.network.bridge
+        ];
+      }
+    ))
+
+    (mkIf (cfg.enable && cfg.hosts != { } && !hasOs) {
+      assertions = [
+        {
+          assertion = false;
+          message = ''
+            keystone.server.devVm requires the keystone OS module (which
+            provides keystone.os.hypervisor) on the same host. Import
+            keystone.nixosModules.operating-system on this host.
+          '';
+        }
+      ];
+    })
+  ];
+}

--- a/tests/module/template-evaluation.nix
+++ b/tests/module/template-evaluation.nix
@@ -317,6 +317,104 @@ let
           }
           ENDJSON
         '';
+    # Guard: mkAgentDevVm produces a bootable agent-sandbox host config —
+    # tailscale + networkEgress + agent identity wired correctly.  Eval-only;
+    # the actual qcow2 build is exercised by the auto-exposed
+    # `vm-image-<host>` packages on consumer flakes.
+    agent-dev-vm-guest =
+      let
+        guest = self.lib.mkAgentDevVm {
+          agent = "drago";
+          agentConfig = {
+            fullName = "Drago Agent";
+            email = "agent-drago@example.com";
+          };
+          fork = "https://github.com/example/keystone.git";
+          admin = {
+            fullName = "Operator";
+            email = "operator@example.com";
+            initialPassword = "changeme";
+            admin = true;
+          };
+          modules = [ { networking.hostId = "01010101"; } ];
+        };
+        c = guest.config;
+        hasUser = builtins.hasAttr "agent-drago" c.users.users;
+        hasFork = builtins.hasAttr "agent-fork-clone" c.systemd.services;
+        egressOn = c.keystone.os.networkEgress.enable;
+        tailscaleOn = c.keystone.os.tailscale.enable;
+        agentHost = c.keystone.os.agents.drago.host;
+        ok = hasUser && hasFork && egressOn && tailscaleOn && agentHost == "agent-drago-devvm";
+      in
+      if !ok then
+        throw ''
+          agent-dev-vm-guest: wiring assertions failed.
+            hasUser=${builtins.toJSON hasUser}
+            hasFork=${builtins.toJSON hasFork}
+            egressOn=${builtins.toJSON egressOn}
+            tailscaleOn=${builtins.toJSON tailscaleOn}
+            agentHost=${agentHost}
+        ''
+      else
+        pkgs.runCommand "eval-template-agent-dev-vm-guest" { } ''
+          mkdir -p $out
+          cat > $out/agent-dev-vm-guest.json <<'ENDJSON'
+          {
+            "name": "agent-dev-vm-guest",
+            "kind": "agent-dev-vm",
+            "agentHost": "${agentHost}",
+            "egressEnabled": ${builtins.toJSON egressOn}
+          }
+          ENDJSON
+        '';
+
+    # Guard: a server host with keystone.server.devVm.hosts emits the
+    # libvirt-keystone-devnet network service and per-VM define+start
+    # one-shots, and force-enables the hypervisor.
+    agent-dev-vm-host = evalNixos "agent-dev-vm-host" (
+      let
+        fakeImage = pkgs.runCommand "fake-vm-image" { } ''
+          mkdir -p $out
+          touch $out/disk0.qcow2
+        '';
+        flake = self.lib.mkSystemFlake {
+          admin = {
+            username = "admin";
+            fullName = "Fleet Owner";
+            email = "fleet@example.com";
+            initialPassword = "changeme";
+          };
+          defaults.timeZone = "UTC";
+          keystoneServices = {
+            git.host = "ocean";
+          };
+          hosts = {
+            ocean = {
+              kind = "server";
+              hostname = "ocean";
+              hardware = null;
+              configuration = null;
+              storage.devices = [ "/dev/disk/by-id/ocean-root-001" ];
+              modules = [
+                {
+                  networking.hostId = "0ce0a01d";
+                  keystone.server.devVm = {
+                    enable = true;
+                    hosts.drago = {
+                      image = fakeImage;
+                      mac = "52:54:00:dd:dd:01";
+                    };
+                  };
+                }
+              ];
+              services.openssh.enable = true;
+            };
+          };
+        };
+      in
+      flake.nixosConfigurations.ocean
+    );
+
   };
 
   homeTests = lib.optionalAttrs (home-manager != null) {


### PR DESCRIPTION
## Summary

Lands the keystone-side primitives so existing agents (drago, luce, …) can
spin up isolated dev VMs to iterate on keystone forks without endangering
the parent host. Closes the gap between the podman sandbox (which forbids
the keystone repo) and bare-metal `ks` work (which is unsafe for fork
experimentation).

Three new pieces, each independent:

- **`keystone.os.networkEgress`** — opt-in outbound firewall. Drops traffic
  to RFC1918 / link-local / ULA destinations except an allow-list (Tailscale
  CGNAT pre-allowed).
- **`keystone.server.devVm`** — declarative libvirt domain manager. Hosts
  long-lived KVM guests on a server, with an isolated NAT network and
  per-domain UEFI Secure Boot + swtpm.
- **`keystone.lib.mkAgentDevVm`** + new `agent-dev-vm` host kind — host
  config helper that bundles the above plus a `keystone.os.agents.<name>`
  declaration pinned to the VM's hostname, so the same agent identity
  (mail, ssh, MCP, task-loop) materializes inside.

## Architecture

```
Host (ocean)                     Dev VM (agent-drago-devvm)
┌─────────────────────┐          ┌──────────────────────────┐
│ keystone.server.devVm          │ keystone.os = { … }        │
│   .hosts.drago.image─►(qcow2)──│ keystone.os.tailscale ON   │
│ keystone.os.hypervisor          │ keystone.os.networkEgress  │
│   (libvirt + OVMF + swtpm)      │   blocks RFC1918 LAN       │
│ libvirt-keystone-devnet         │ keystone.os.agents.drago = │
│   192.168.200.0/24 NAT          │   { host = "agent-…-devvm";│
└─────────────────────┘          │     <full identity> }      │
                                  │ Pre-cloned keystone fork    │
                                  │ in ~agent-drago/repos/…/    │
                                  └──────────────────────────┘
```

## Test plan

Eval-side (✓ verified locally):

- [x] `nix build .#checks.x86_64-linux.os-evaluation` — passes
- [x] `nix build .#checks.x86_64-linux.server-evaluation` — passes
- [x] `nix build .#checks.x86_64-linux.template-evaluation` — passes;
      includes new `agent-dev-vm-guest` and `agent-dev-vm-host` fixtures

Smoke test (operator-side, requires a workstation with KVM):

- [ ] `nix build .#packages.x86_64-linux.vm-image-agent-drago-devvm`
      (after the consumer-flake follow-up declares the host)
- [ ] `bin/virtual-machine --direct agent-drago-devvm --headless --ssh-port 12222`
- [ ] Inside the VM:
  - [ ] `claude --version` works as `agent-drago`
  - [ ] `curl -sS https://api.github.com/zen` → 200
  - [ ] `curl -sS --max-time 3 http://192.168.1.1` → connection refused
  - [ ] `tailscale status` → online with `tag:dev-vm`

Fleet test (after merge):

- [ ] Consumer flake adds `agent-drago-devvm` to its host registry +
      `keystone.server.devVm.hosts.drago.image = …` to ocean
- [ ] `ks update --lock` on ocean
- [ ] `virsh -c qemu:///system list` shows `dev-vm-drago` running
- [ ] `ssh agent-drago@agent-drago-devvm` from the laptop (Tailscale)

## Out of scope (consumer-flake follow-up)

- Adding `agent-drago-devvm` (and later luce, etc.) to `keystone.hosts`.
- Provisioning the dev-VM's host SSH public key in agenix `secrets.nix`.
- Setting `keystone.server.devVm.hosts.drago = { … }` on ocean.
- Headscale ACL: `tag:agent-admin` and `tag:agent-drago` → `tag:dev-vm:22`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)