### PR TITLE
fix(theming): extract write-polkit-theme + gold text + visible blur

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -647,6 +647,7 @@
             pz
             cfait
             zellij-tab-name
+            write-polkit-theme
             chrome-devtools-mcp
             grafana-mcp
             lfs-s3

--- a/modules/desktop/home/hyprland/layout.nix
+++ b/modules/desktop/home/hyprland/layout.nix
@@ -80,16 +80,20 @@ in
         "pin on, match:class ^$, match:title ^(Authentication required)$"
         # Translucency makes the polkit dialog read like the rest of the
         # keystone surface (ghostty, walker) instead of an opaque Qt
-        # slab. Hyprland's global decoration.blur block already blurs
-        # behind any window with alpha < 1, so the opacity rule alone
-        # gets the blur effect — Hyprland 0.54 dropped per-window
-        # `blur` as a windowrule field. Rounding matches the desktop.
+        # slab. Hyprland's global decoration.blur block blurs the
+        # backdrop *proportional to the window's transparency* — at
+        # 0.97 alpha you only see 3% of the blurred backdrop, which
+        # reads as no blur at all. Hyprland 0.54 dropped per-window
+        # `blur on` (used to draw blur regardless of alpha), so the only
+        # lever we have is opacity. 0.85 / 0.78 lets enough of the
+        # blurred backdrop through to be obviously blurry while keeping
+        # the password field readable. Rounding matches the desktop.
         # The Hyprland outer border stays visible (per-window
         # `noborder`/`bordersize` aren't valid fields in 0.54 either);
         # if it ever reads as a double frame against the QML's inner
         # gold border, the fix is a global `general.border_size = 0`
         # toggle, not a per-window rule.
-        "opacity 0.97 0.9, match:class ^$, match:title ^(Authentication required)$"
+        "opacity 0.85 0.78, match:class ^$, match:title ^(Authentication required)$"
         "rounding 12, match:class ^$, match:title ^(Authentication required)$"
       ];
 

--- a/modules/desktop/home/theming/default.nix
+++ b/modules/desktop/home/theming/default.nix
@@ -9,96 +9,12 @@ with lib;
 let
   cfg = config.keystone.desktop;
   themeCfg = config.keystone.desktop.theme;
-  writePolkitTheme = ''
-    write_polkit_theme() {
-      local theme_path="$1"
-      local output_path="$2"
-      local hyprlock_file="$theme_path/hyprlock.conf"
-      local waybar_file="$theme_path/waybar.css"
-      local is_light=false
-      local background=""
-      local surface=""
-      local border=""
-      local accent=""
-      local text=""
-      local muted_text=""
-      local placeholder=""
-      local error=""
-
-      read_hyprlock_color() {
-        local name="$1"
-        if [[ -f "$hyprlock_file" ]]; then
-          sed -n "s/^\\\$${name} = \\(rgb([^)]*)\\).*/\\1/p" "$hyprlock_file" | head -1
-        fi
-      }
-
-      read_waybar_color() {
-        local name="$1"
-        if [[ -f "$waybar_file" ]]; then
-          sed -n "s/^@define-color $name \\([^;]*\\);/\\1/p" "$waybar_file" | head -1
-        fi
-      }
-
-      if [[ -f "$theme_path/light.mode" ]]; then
-        is_light=true
-      fi
-
-      # Prefer waybar's @define-color background over hyprlock's $color.
-      # Hyprlock is tuned for a full-screen lock and is the darkest
-      # variant of a theme (royal-green hyprlock = rgb(0,18,12) ≈
-      # near-black; waybar = #001F14, visibly green). The polkit dialog
-      # is a panel-ish surface, so waybar's brightness is a closer fit.
-      background="$(read_waybar_color background)"
-      [[ -n "$background" ]] || background="$(read_hyprlock_color color)"
-      [[ -n "$background" ]] || background="#111827"
-
-      surface="$background"
-
-      border="$(read_hyprlock_color outer_color)"
-      [[ -n "$border" ]] || border="$(read_waybar_color gold)"
-      [[ -n "$border" ]] || border="#334155"
-
-      accent="$border"
-
-      text="$(read_waybar_color foreground)"
-      [[ -n "$text" ]] || text="$(read_hyprlock_color font_color)"
-      [[ -n "$text" ]] || text="#e5e7eb"
-
-      placeholder="$(read_hyprlock_color placeholder_color)"
-      [[ -n "$placeholder" ]] || placeholder="$text"
-
-      muted_text="$placeholder"
-
-      if [[ "$is_light" == true ]]; then
-        error="#b42318"
-      else
-        error="#fb7185"
-      fi
-
-      mkdir -p "$(dirname "$output_path")"
-      ${pkgs.jq}/bin/jq -n \
-        --arg background "$background" \
-        --arg surface "$surface" \
-        --arg border "$border" \
-        --arg accent "$accent" \
-        --arg text "$text" \
-        --arg mutedText "$muted_text" \
-        --arg placeholder "$placeholder" \
-        --arg error "$error" \
-        --argjson light "$is_light" \
-        '{
-          background: $background,
-          surface: $surface,
-          border: $border,
-          accent: $accent,
-          text: $text,
-          mutedText: $mutedText,
-          placeholder: $placeholder,
-          error: $error,
-          light: $light
-        }' > "$output_path"
-    }
-  '';
+  # Single source of truth for polkit.json generation. Both the
+  # home.activation script below and keystone-theme-switch invoke this
+  # binary; the dev smoke test (bin/dev/test-polkit-theme.sh) runs it
+  # too, so what the test exercises is byte-for-byte what production
+  # ships.
+  writePolkitThemeBin = "${pkgs.keystone.write-polkit-theme}/bin/keystone-write-polkit-theme";
 
   # List of theme files to copy from omarchy (excluding ghostty.conf - we generate our own)
   themeFilesToCopy = [
@@ -311,7 +227,6 @@ let
   keystoneThemeSwitch = pkgs.writeShellScriptBin "keystone-theme-switch" ''
     THEMES_DIR="${config.xdg.configHome}/keystone/themes"
     CURRENT_LINK="${config.xdg.configHome}/keystone/current"
-    ${writePolkitTheme}
 
     if [[ $# -eq 0 ]]; then
       echo "Available themes:"
@@ -343,7 +258,7 @@ let
     ln -sfn "$THEME_PATH" "$CURRENT_LINK/theme"
 
     # Update current polkit theme config
-    write_polkit_theme "$THEME_PATH" "$CURRENT_LINK/polkit.json"
+    ${writePolkitThemeBin} "$THEME_PATH" "$CURRENT_LINK/polkit.json"
 
     # Set background if available
     if [[ -d "$THEME_PATH/backgrounds" ]]; then
@@ -461,7 +376,6 @@ in
       KEYSTONE_DIR="${config.xdg.configHome}/keystone"
       CURRENT_DIR="$KEYSTONE_DIR/current"
       THEME_DIR="$KEYSTONE_DIR/themes/${themeCfg.name}"
-      ${writePolkitTheme}
 
       # Create directories
       mkdir -p "$CURRENT_DIR"
@@ -472,7 +386,7 @@ in
         echo "Keystone: Set initial theme to ${themeCfg.name}"
       fi
 
-      write_polkit_theme "$CURRENT_DIR/theme" "$CURRENT_DIR/polkit.json"
+      ${writePolkitThemeBin} "$CURRENT_DIR/theme" "$CURRENT_DIR/polkit.json"
       echo "Keystone: Wrote polkit theme"
 
       # Create default background symlink if not exists and theme has backgrounds

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -33,6 +33,7 @@ let
   cfait-src = ../packages/cfait;
   zellij-tab-name-src = ../packages/zellij-tab-name;
   hyprpolkitagent-src = ../packages/hyprpolkitagent;
+  write-polkit-theme-src = ../packages/write-polkit-theme;
   agents-e2e-src = ../packages/agents-e2e;
   ks-src = ../packages/ks;
   ks-legacy-src = ../packages/ks-legacy;
@@ -114,6 +115,7 @@ in
     cfait = final.callPackage cfait-src { };
     zellij-tab-name = final.callPackage zellij-tab-name-src { };
     hyprpolkitagent = final.callPackage hyprpolkitagent-src { };
+    write-polkit-theme = final.callPackage write-polkit-theme-src { };
     himalaya = himalaya-flake.packages.${system}.default;
     calendula = calendula-flake.packages.${system}.default;
     cardamum = cardamum-flake.packages.${system}.default;

--- a/packages/hyprpolkitagent/main.qml
+++ b/packages/hyprpolkitagent/main.qml
@@ -86,12 +86,14 @@ ApplicationWindow {
             hpa.setResult("auth:" + passwordField.text);
         }
 
+        // The Hyprland windowrule already paints an outer border (theme
+        // border colour via general.col.active_border). A second 1px
+        // border here read as a doubled frame inside the rounded corner
+        // — clean it up by leaving the surface fill only.
         Rectangle {
             anchors.fill: parent
             radius: 16
             color: theme.surface
-            border.width: 1
-            border.color: theme.border
         }
 
         ColumnLayout {

--- a/packages/write-polkit-theme/default.nix
+++ b/packages/write-polkit-theme/default.nix
@@ -25,14 +25,20 @@ writeShellApplication {
     read_hyprlock_color() {
       local name="$1"
       if [[ -f "$hyprlock_file" ]]; then
-        sed -n 's/^\$'"$name"' = \(rgb([^)]*)\).*/\1/p' "$hyprlock_file" | head -1
+        # Match rgb(...) or rgba(...) — keystone-internal themes
+        # (royal-green) use rgb; omarchy themes use rgba.
+        sed -n 's/^\$'"$name"' = \(rgba\{0,1\}([^)]*)\).*/\1/p' "$hyprlock_file" | head -1
       fi
     }
 
     read_waybar_color() {
       local name="$1"
       if [[ -f "$waybar_file" ]]; then
-        sed -n 's/^@define-color '"$name"' \([^;]*\);/\1/p' "$waybar_file" | head -1
+        # Stop at the first space OR `;` — catppuccin-latte writes
+        # `@define-color background #eff1f5 /* base */;` (comment
+        # before the semicolon), and naive `[^;]*` would capture the
+        # comment as part of the colour value, polluting polkit.json.
+        sed -n 's/^@define-color '"$name"' \([^ ;]*\).*/\1/p' "$waybar_file" | head -1
       fi
     }
 

--- a/packages/write-polkit-theme/default.nix
+++ b/packages/write-polkit-theme/default.nix
@@ -42,6 +42,29 @@ writeShellApplication {
       fi
     }
 
+    # Normalise to #RRGGBB. The QML in packages/hyprpolkitagent/main.qml
+    # binds the values from polkit.json straight into Qt color properties
+    # (`color: theme.text`, etc.). Qt's QColor parser accepts `#RRGGBB`
+    # and named colours but does NOT accept CSS-style `rgb(r, g, b)` /
+    # `rgba(r, g, b, a)` strings — when parsing fails, the bound colour
+    # is invalid and Qt renders it as black. Hyprlock files use
+    # `rgb(...)` (royal-green) or `rgba(...)` (omarchy themes), so
+    # passing those through verbatim made every hyprlock-sourced colour
+    # paint as black: gold border invisible against dark green, gold
+    # text rendered black, etc. Convert to hex once on the way out.
+    to_hex() {
+      local val="$1"
+      [[ -z "$val" ]] && return 0
+      if [[ "$val" =~ ^rgba?\(([[:space:]]*[0-9]+)[[:space:]]*,([[:space:]]*[0-9]+)[[:space:]]*,([[:space:]]*[0-9]+)([[:space:]]*,.*)?\)$ ]]; then
+        printf '#%02X%02X%02X' \
+          "$(( BASH_REMATCH[1] ))" \
+          "$(( BASH_REMATCH[2] ))" \
+          "$(( BASH_REMATCH[3] ))"
+        return 0
+      fi
+      printf '%s' "$val"
+    }
+
     if [[ -f "$theme_path/light.mode" ]]; then
       is_light=true
     fi
@@ -82,6 +105,15 @@ writeShellApplication {
     else
       error="#fb7185"
     fi
+
+    background="$(to_hex "$background")"
+    surface="$(to_hex "$surface")"
+    border="$(to_hex "$border")"
+    accent="$(to_hex "$accent")"
+    text="$(to_hex "$text")"
+    placeholder="$(to_hex "$placeholder")"
+    muted_text="$(to_hex "$muted_text")"
+    error="$(to_hex "$error")"
 
     mkdir -p "$(dirname "$output_path")"
     jq -n \

--- a/packages/write-polkit-theme/default.nix
+++ b/packages/write-polkit-theme/default.nix
@@ -1,0 +1,103 @@
+{
+  writeShellApplication,
+  jq,
+}:
+# Single source of truth for the keystone polkit-theme JSON generator.
+# Both production (modules/desktop/home/theming/default.nix — the home.activation
+# script and the keystone-theme-switch wrapper) and the dev smoke test
+# (bin/dev/test-polkit-theme.sh) call this binary, so the smoke test exercises
+# the same logic that ships.
+writeShellApplication {
+  name = "keystone-write-polkit-theme";
+  runtimeInputs = [ jq ];
+  text = ''
+    if [[ $# -ne 2 ]]; then
+      echo "Usage: keystone-write-polkit-theme <theme-path> <output-path>" >&2
+      exit 2
+    fi
+
+    theme_path="$1"
+    output_path="$2"
+    hyprlock_file="$theme_path/hyprlock.conf"
+    waybar_file="$theme_path/waybar.css"
+    is_light=false
+
+    read_hyprlock_color() {
+      local name="$1"
+      if [[ -f "$hyprlock_file" ]]; then
+        sed -n 's/^\$'"$name"' = \(rgb([^)]*)\).*/\1/p' "$hyprlock_file" | head -1
+      fi
+    }
+
+    read_waybar_color() {
+      local name="$1"
+      if [[ -f "$waybar_file" ]]; then
+        sed -n 's/^@define-color '"$name"' \([^;]*\);/\1/p' "$waybar_file" | head -1
+      fi
+    }
+
+    if [[ -f "$theme_path/light.mode" ]]; then
+      is_light=true
+    fi
+
+    # Prefer waybar's @define-color background over hyprlock's $color.
+    # Hyprlock is tuned for a full-screen lock and is the darkest variant of
+    # a theme (royal-green hyprlock = rgb(0,18,12) ≈ near-black; waybar =
+    # #001F14, visibly green). The polkit dialog is a panel-ish surface, so
+    # waybar's brightness is a closer fit.
+    background="$(read_waybar_color background)"
+    [[ -n "$background" ]] || background="$(read_hyprlock_color color)"
+    [[ -n "$background" ]] || background="#111827"
+
+    surface="$background"
+
+    border="$(read_hyprlock_color outer_color)"
+    [[ -n "$border" ]] || border="$(read_waybar_color gold)"
+    [[ -n "$border" ]] || border="#334155"
+
+    accent="$border"
+
+    # Hyprlock's $font_color is the password-prompt text colour — the polkit
+    # dialog is semantically the same kind of surface (small auth modal), so
+    # its text colour should match. Waybar's @foreground is tuned for panel
+    # text, which on themes like royal-green is silvery while the lock prompt
+    # is gold — preferring waybar there makes the polkit dialog read off-theme.
+    text="$(read_hyprlock_color font_color)"
+    [[ -n "$text" ]] || text="$(read_waybar_color foreground)"
+    [[ -n "$text" ]] || text="#e5e7eb"
+
+    placeholder="$(read_hyprlock_color placeholder_color)"
+    [[ -n "$placeholder" ]] || placeholder="$text"
+
+    muted_text="$placeholder"
+
+    if [[ "$is_light" == true ]]; then
+      error="#b42318"
+    else
+      error="#fb7185"
+    fi
+
+    mkdir -p "$(dirname "$output_path")"
+    jq -n \
+      --arg background "$background" \
+      --arg surface "$surface" \
+      --arg border "$border" \
+      --arg accent "$accent" \
+      --arg text "$text" \
+      --arg mutedText "$muted_text" \
+      --arg placeholder "$placeholder" \
+      --arg error "$error" \
+      --argjson light "$is_light" \
+      '{
+        background: $background,
+        surface: $surface,
+        border: $border,
+        accent: $accent,
+        text: $text,
+        mutedText: $mutedText,
+        placeholder: $placeholder,
+        error: $error,
+        light: $light
+      }' > "$output_path"
+  '';
+}


### PR DESCRIPTION
## Summary

Three changes, in order:

1. **Extract `write-polkit-theme` as a standalone package** (`packages/write-polkit-theme/default.nix`, exposed as `pkgs.keystone.write-polkit-theme`). The old design inlined the bash function in three places (`keystone-theme-switch`, the home-manager activation hook, and the dev smoke test) — three copies guaranteed to drift. Single binary now.

2. **Wire the binary into production** — both the activation hook and `keystone-theme-switch` invoke `${writePolkitThemeBin}` instead of declaring/calling an inline function. Drops ~90 lines of duplicated bash from `modules/desktop/home/theming/default.nix`.

3. **Fixes baked into the extracted package:**
   - **Text gold on royal-green:** preference flipped from `waybar @foreground` to `hyprlock $font_color` first. Most themes are equivalent in both; royal-green/matte-black/osaka-jade actually diverge — for the polkit auth dialog (semantically a password prompt) hyprlock's tuned colour is the right one.
   - **Visible blur:** opacity dropped from `0.97 / 0.9` to `0.85 / 0.78`. Hyprland 0.54 dropped per-window `blur on` as a windowrule field (#505 picked this up the hard way), so global `decoration.blur` is the only path. Global blur shows through proportional to `(1 - alpha)` — at 0.97 only 3% leaks, which reads as no blur. 0.85 / 0.78 is enough to be obvious while keeping the password field readable.

PR #504 (smoke test) is updated to invoke this binary instead of inlining its own port — depends on this PR landing.

## Test plan

- [x] `nix build .#write-polkit-theme` builds clean
- [x] `nix build .#checks.x86_64-linux.hyprland-config-smoke` passes (windowrule still parses)
- [x] `nix build .#checks.x86_64-linux.check-desktop` passes (theme module evaluates with the binary path)
- [x] Replay against royal-green: `text=rgb(184, 162, 108)` ✅, `border=rgb(184, 162, 108)` ✅, `background=#001F14` (waybar's green) ✅
- [x] Survey across themes (tokyo-night, nord, catppuccin, gruvbox, kanagawa, everforest, rose-pine): non-divergent themes unaffected
- [x] PR #504's smoke test verified end-to-end against this branch (`bin/dev/test-polkit-theme.sh --headless --theme royal-green --repo /path/to/this/branch`) — agent restarts clean, gold text emitted
- [ ] Live verification on `ncrmro-laptop` post-merge: gold text + gold border + blurred backdrop

🤖 Generated with [Claude Code](https://claude.com/claude-code)