### PR TITLE
fix(polkit): apply auth_admin_keep via JS rule on canonical path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -407,6 +407,10 @@
             pkgs = ksPkgs;
             lib = ksPkgs.lib;
           };
+          polkitKeystoneApproveCache = import ./tests/module/polkit-keystone-approve-cache.nix {
+            inherit pkgs lib;
+            self = self;
+          };
           ksDoctorReport = import ./tests/module/ks-doctor-report.nix {
             inherit pkgs;
           };
@@ -546,6 +550,7 @@
           hyprland-config-smoke = hyprlandConfigSmoke;
           ks-approve = ksApprove;
           approve-exec-script = approveExecScript;
+          polkit-keystone-approve-cache = polkitKeystoneApproveCache;
           ks-doctor-report = ksDoctorReport;
           ks-rust-tests = ksRustTests;
           ks-rust-clippy = ksRustClippy;
@@ -581,6 +586,7 @@
             ln -s ${ksPhotos} "$out/photos"
             ln -s ${ksApprove} "$out/approve"
             ln -s ${approveExecScript} "$out/approve-exec-script"
+            ln -s ${polkitKeystoneApproveCache} "$out/polkit-keystone-approve-cache"
             ln -s ${ksDoctorReport} "$out/doctor-report"
             ln -s ${ksLockSync} "$out/lock-sync"
           '';

--- a/modules/os/privileged-approval.nix
+++ b/modules/os/privileged-approval.nix
@@ -194,6 +194,33 @@ in
 
     security.polkit.enable = mkDefault true;
 
+    # The XML policy in $out/share/polkit-1/actions/com.ncrmro.keystone.approve.policy
+    # declares `auth_admin_keep` and a `org.freedesktop.policykit.exec.path`
+    # annotation pointing at the symlink path
+    # `/run/current-system/sw/bin/keystone-approve-exec`. That annotation
+    # is *not* honoured at runtime: pkexec calls `realpath()` on the
+    # program before handing it to polkit, so polkit looks up the
+    # canonical Nix store path. The annotation matches the symlink path,
+    # never the canonical, so polkit silently falls back to the generic
+    # `org.freedesktop.policykit.exec` action — whose default for
+    # `allow_active` is `auth_admin` (no `_keep`). Result: a fresh
+    # password prompt on every pkexec call, including the post-build
+    # activation that `warm_polkit_cache` is meant to cover.
+    #
+    # Adding a JS rule that matches the *canonical* helper path
+    # (`${approvalHelper}/bin/keystone-approve-exec` is interpolated at
+    # build time) is the only way to actually get `AUTH_ADMIN_KEEP`
+    # applied. The XML policy stays in place for the description/message
+    # strings the dialog shows.
+    security.polkit.extraConfig = ''
+      polkit.addRule(function(action, subject) {
+        if (action.id == "org.freedesktop.policykit.exec" &&
+            action.lookup("program") == "${approvalHelper}/bin/keystone-approve-exec") {
+          return polkit.Result.AUTH_ADMIN_KEEP;
+        }
+      });
+    '';
+
     environment.etc."keystone/privileged-approval.json".text = builtins.toJSON approvalConfig;
 
     environment.systemPackages = [

--- a/modules/os/privileged-approval.nix
+++ b/modules/os/privileged-approval.nix
@@ -212,11 +212,22 @@ in
     # build time) is the only way to actually get `AUTH_ADMIN_KEEP`
     # applied. The XML policy stays in place for the description/message
     # strings the dialog shows.
+    #
+    # The rule mirrors the XML's stated `<defaults>` (allow_any=no,
+    # allow_inactive=no, allow_active=auth_admin_keep) by gating on
+    # `subject.active`: only an active local session caches; anything
+    # else is denied. Without this gate, an unattended SSH session
+    # could trigger keystone-approve-exec and the cached credential
+    # would survive — a wider blast radius than the XML policy
+    # advertised.
     security.polkit.extraConfig = ''
       polkit.addRule(function(action, subject) {
         if (action.id == "org.freedesktop.policykit.exec" &&
             action.lookup("program") == "${approvalHelper}/bin/keystone-approve-exec") {
-          return polkit.Result.AUTH_ADMIN_KEEP;
+          if (subject.active) {
+            return polkit.Result.AUTH_ADMIN_KEEP;
+          }
+          return polkit.Result.NO;
         }
       });
     '';

--- a/tests/module/polkit-keystone-approve-cache.nix
+++ b/tests/module/polkit-keystone-approve-cache.nix
@@ -69,17 +69,15 @@ let
   fail = msg: throw "polkit-keystone-approve-cache: ${msg}\nrendered extraConfig:\n${rendered}";
 
   checks =
-    lib.optional (
-      !hasCanonicalKeystonePath
-    ) "rendered rule must reference /nix/store/<hash>-keystone-approve-exec/bin/keystone-approve-exec (the canonical path pkexec hands to polkit)"
-    ++ lib.optional hasSymlinkPath
-      "rendered rule must NOT reference /run/current-system/sw/bin/keystone-approve-exec — pkexec realpath()s the target so the symlink path never matches and the rule would silently regress to auth_admin (no _keep)"
-    ++ lib.optional (
-      !hasAuthAdminKeep
-    ) "rendered rule must return AUTH_ADMIN_KEEP — without it, single-prompt update flow regresses to a re-prompt on every pkexec call"
-    ++ lib.optional (
-      !hasSubjectActiveGate
-    ) "rendered rule must gate on subject.active — without it, inactive sessions can also cache, breaching the XML policy's allow_inactive=no semantic";
+    lib.optional (!hasCanonicalKeystonePath)
+      "rendered rule must reference /nix/store/<hash>-keystone-approve-exec/bin/keystone-approve-exec (the canonical path pkexec hands to polkit)"
+    ++ lib.optional hasSymlinkPath "rendered rule must NOT reference /run/current-system/sw/bin/keystone-approve-exec — pkexec realpath()s the target so the symlink path never matches and the rule would silently regress to auth_admin (no _keep)"
+    ++
+      lib.optional (!hasAuthAdminKeep)
+        "rendered rule must return AUTH_ADMIN_KEEP — without it, single-prompt update flow regresses to a re-prompt on every pkexec call"
+    ++
+      lib.optional (!hasSubjectActiveGate)
+        "rendered rule must gate on subject.active — without it, inactive sessions can also cache, breaching the XML policy's allow_inactive=no semantic";
 
 in
 if checks != [ ] then

--- a/tests/module/polkit-keystone-approve-cache.nix
+++ b/tests/module/polkit-keystone-approve-cache.nix
@@ -1,0 +1,93 @@
+# polkit-keystone-approve-cache — regression test for the
+# canonical-path polkit rule that makes auth_admin_keep actually
+# apply to keystone-approve-exec.
+#
+# History: pkexec calls realpath() on its target before handing it to
+# polkit, so polkit looks up the canonical Nix store path. The XML
+# policy's `org.freedesktop.policykit.exec.path` annotation pointed at
+# the /run/current-system symlink — never matched, so polkit fell back
+# to the generic action's auth_admin (no _keep) and re-prompted on
+# every pkexec call. The fix is a JS rule in security.polkit.extraConfig
+# that matches the canonical helper path (Nix interpolates it).
+#
+# This test pins the fix at the rendered-config level. Specifically it
+# guards against:
+#   - reverting to /run/current-system in the rule (would break
+#     auth_admin_keep again — exactly the bug we just fixed)
+#   - dropping subject.active gating (would let inactive sessions
+#     cache, breaching the XML's allow_inactive=no semantics)
+#   - removing AUTH_ADMIN_KEEP entirely
+#
+# Build: nix build .#test-polkit-keystone-approve-cache
+{
+  pkgs,
+  lib ? pkgs.lib,
+  self,
+}:
+let
+  result = (import "${pkgs.path}/nixos/lib/eval-config.nix") {
+    system = "x86_64-linux";
+    modules = [
+      self.nixosModules.operating-system
+      {
+        system.stateVersion = "25.05";
+        boot.loader.systemd-boot.enable = true;
+        keystone.os = {
+          enable = true;
+          storage = {
+            type = "zfs";
+            devices = [ "/dev/vda" ];
+          };
+          users.testuser = {
+            fullName = "Test User";
+            initialPassword = "testpass";
+            admin = true;
+          };
+        };
+        networking.hostId = "deadbeef";
+        fileSystems."/" = {
+          device = lib.mkForce "rpool/crypt/system";
+          fsType = lib.mkForce "zfs";
+        };
+      }
+    ];
+  };
+
+  rendered = result.config.security.polkit.extraConfig;
+
+  hasCanonicalKeystonePath =
+    let
+      # Canonical store path looks like /nix/store/<32 hash chars>-keystone-approve-exec/bin/keystone-approve-exec
+      pattern = "/nix/store/[a-z0-9]+-keystone-approve-exec/bin/keystone-approve-exec";
+    in
+    builtins.match ".*${pattern}.*" rendered != null;
+
+  hasSymlinkPath = lib.hasInfix "/run/current-system/sw/bin/keystone-approve-exec" rendered;
+  hasAuthAdminKeep = lib.hasInfix "AUTH_ADMIN_KEEP" rendered;
+  hasSubjectActiveGate = lib.hasInfix "subject.active" rendered;
+
+  fail = msg: throw "polkit-keystone-approve-cache: ${msg}\nrendered extraConfig:\n${rendered}";
+
+  checks =
+    lib.optional (
+      !hasCanonicalKeystonePath
+    ) "rendered rule must reference /nix/store/<hash>-keystone-approve-exec/bin/keystone-approve-exec (the canonical path pkexec hands to polkit)"
+    ++ lib.optional hasSymlinkPath
+      "rendered rule must NOT reference /run/current-system/sw/bin/keystone-approve-exec — pkexec realpath()s the target so the symlink path never matches and the rule would silently regress to auth_admin (no _keep)"
+    ++ lib.optional (
+      !hasAuthAdminKeep
+    ) "rendered rule must return AUTH_ADMIN_KEEP — without it, single-prompt update flow regresses to a re-prompt on every pkexec call"
+    ++ lib.optional (
+      !hasSubjectActiveGate
+    ) "rendered rule must gate on subject.active — without it, inactive sessions can also cache, breaching the XML policy's allow_inactive=no semantic";
+
+in
+if checks != [ ] then
+  fail (lib.concatStringsSep "\n  - " ([ "" ] ++ checks))
+else
+  pkgs.runCommand "test-polkit-keystone-approve-cache" { } ''
+    echo "polkit-keystone-approve-cache: rule references canonical helper path,"
+    echo "  returns AUTH_ADMIN_KEEP, gates on subject.active, and avoids the"
+    echo "  /run/current-system symlink trap."
+    touch $out
+  ''


### PR DESCRIPTION
## Summary

`ks update --approve` is prompting for the password TWICE — once during \`warm_polkit_cache\`, then again post-build during \`activate_via_broker\`. The whole point of #502's warm-cache design was to consolidate this to a single prompt via \`auth_admin_keep\`. The cache wasn't holding.

Root cause is that pkexec calls \`realpath()\` on the target binary before handing it to polkit, so polkit looks up \`/nix/store/<hash>-keystone-approve-exec/bin/keystone-approve-exec\` — but our \`org.freedesktop.policykit.exec.path\` annotation in the XML policy points at the symlink \`/run/current-system/sw/bin/keystone-approve-exec\`. They never match. Polkit silently falls back to the generic \`org.freedesktop.policykit.exec\` action, whose \`allow_active\` is \`auth_admin\` (no \`_keep\`).

## Repro from journalctl

\`\`\`
17:23:51 first prompt (warm_polkit_cache)        approved
17:23:52 ks activate /run/current-system        nothing to do (warm OK)
17:23:52 ... build ...
17:26:07 SECOND prompt (activate_via_broker)    should be cached
17:26:17 polkitd: FAILED to authenticate ... action org.freedesktop.policykit.exec
                                                     ^ generic, NOT com.ncrmro.keystone.approve
\`\`\`

The action ID logged is the generic one — confirming the custom action's annotation isn't taking effect.

## Fix

Add a \`security.polkit.extraConfig\` JS rule that matches the *canonical* helper path (Nix interpolates \`\${approvalHelper}/bin/keystone-approve-exec\` at build time) and returns \`AUTH_ADMIN_KEEP\`. Verified the rendered rule contains the right \`/nix/store/<hash>-keystone-approve-exec/bin/keystone-approve-exec\` (which matches exactly what pkexec passes to polkit, per the journal).

The XML policy stays in place for the description/message strings the dialog shows. The annotation is now vestigial but harmless.

## Test plan

- [x] \`nix eval … .#nixosConfigurations.ncrmro-laptop.config.security.polkit.extraConfig\` renders the canonical store-path match
- [ ] Live: \`ks update --approve\` on \`ncrmro-laptop\` post-merge shows ONE prompt; second activation auths silently from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)