### PR TITLE
feat(ks): emit phase progress for ks update --approve (#508)

### DIFF
--- a/packages/ks/src/cli.rs
+++ b/packages/ks/src/cli.rs
@@ -142,6 +142,15 @@ pub enum Command {
         /// Only valid alongside `--approve`. Other update modes ignore it.
         #[arg(long = "keystone")]
         keystone_override: Option<String>,
+
+        /// Emit JSON-Lines progress events to stdout at every phase
+        /// boundary of the supervised update flow. Used by Walker (and
+        /// future consumers — TUI, CI scraper) to render real-time
+        /// status while the build runs silently. Only meaningful
+        /// alongside `--approve`; ignored otherwise. Schema: one event
+        /// per line — see cmd::update_progress for the type.
+        #[arg(long = "emit-progress")]
+        emit_progress: bool,
     },
 
     /// Activate a pre-built NixOS system closure (privileged).

--- a/packages/ks/src/cmd/mod.rs
+++ b/packages/ks/src/cmd/mod.rs
@@ -28,6 +28,7 @@ pub mod tasks;
 pub mod update;
 pub mod update_approve;
 pub mod update_menu;
+pub mod update_progress;
 pub mod util;
 
 // Re-export template types and execution from their canonical location.

--- a/packages/ks/src/cmd/update_approve.rs
+++ b/packages/ks/src/cmd/update_approve.rs
@@ -884,18 +884,54 @@ async fn run_build_and_activate(
     target_label: &str,
     host_label: &str,
 ) -> Result<String> {
+    use crate::cmd::update_progress::{emit_done, emit_error, emit_start, Phase};
+    use std::time::Instant;
+
     // Step 6: build against the bumped lock.
-    let store_path = build_locked(repo_root, host, target_label).await?;
+    let build_started = Instant::now();
+    emit_start(Phase::Build, Some(target_label));
+    let store_path = match build_locked(repo_root, host, target_label).await {
+        Ok(p) => {
+            emit_done(Phase::Build, build_started.elapsed().as_millis());
+            p
+        }
+        Err(e) => {
+            emit_error(
+                Phase::Build,
+                build_started.elapsed().as_millis(),
+                &format!("{e:#}"),
+            );
+            return Err(e);
+        }
+    };
     eprintln!("Built closure: {store_path}");
 
     // Step 7: activate via the privileged broker. Polkit cache from
     // the warm step should hit; if not, the user re-prompts.
+    let activate_started = Instant::now();
+    emit_start(Phase::Activate, Some(target_label));
     let reason = approval_reason(host_label);
     eprintln!("Requesting activation of {store_path}…");
-    let activated = activate_via_broker(&reason, &store_path)?;
+    let activated = match activate_via_broker(&reason, &store_path) {
+        Ok(v) => v,
+        Err(e) => {
+            emit_error(
+                Phase::Activate,
+                activate_started.elapsed().as_millis(),
+                &format!("{e:#}"),
+            );
+            return Err(e);
+        }
+    };
     if !activated {
+        emit_error(
+            Phase::Activate,
+            activate_started.elapsed().as_millis(),
+            "activation was not approved or failed",
+        );
         anyhow::bail!("activation was not approved or failed");
     }
+    emit_done(Phase::Activate, activate_started.elapsed().as_millis());
     Ok(store_path)
 }
 

--- a/packages/ks/src/cmd/update_progress.rs
+++ b/packages/ks/src/cmd/update_progress.rs
@@ -1,0 +1,181 @@
+//! Progress emission for the `ks update --approve` supervised flow.
+//!
+//! When run with `--emit-progress`, `ks update --approve` writes
+//! JSON-Lines to stdout at every phase boundary so a consumer
+//! (Walker, future TUI, CI log scraper) can render real-time status.
+//!
+//! Draft for issue #508. The schema here is the *minimum* needed to
+//! distinguish phases and report duration; consumer work (Walker
+//! widget, layer-shell renderer) is out of scope and follows in a
+//! separate PR.
+//!
+//! ## Schema
+//!
+//! One JSON object per line, written to stdout. Required fields:
+//!
+//! - `phase`: one of [`Phase`] values — the supervised-flow step
+//! - `status`: `"start"` | `"done"` | `"error"`
+//! - `ts_ms`: emitter-side monotonic-ish timestamp (unix epoch ms)
+//!
+//! Status-conditional fields:
+//!
+//! - `target` (optional, on most `start` events): the resolved
+//!   keystone ref (e.g. `main@06bf415`). Empty in pre-resolve phases.
+//! - `duration_ms` (on `done` and `error`): elapsed since the matching
+//!   `start`.
+//! - `error` (on `error`): one-line message; the full chain still
+//!   goes to stderr in the existing log format.
+//!
+//! ## Backwards-compat
+//!
+//! Without `--emit-progress`, emission is a no-op — existing stderr
+//! log lines are unchanged. This is so the supervised flow stays
+//! quiet for users invoking `ks update --approve` directly.
+
+use serde::Serialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Phases of the supervised update flow. The names match the steps
+/// documented in `run_supervised_update`'s docstring so changes here
+/// flag a mismatch.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    /// Step 1: `ensure_in_sync` — pre-flight git fetch + branch
+    /// divergence check against origin.
+    Preflight,
+    /// Step 2: `resolve_target` — GitHub release / branch SHA lookup
+    /// (skipped in override mode).
+    Resolve,
+    /// Step 3: `warm_polkit_cache` — early polkit prompt so the
+    /// activation step can reuse the cached credential.
+    Warm,
+    /// Step 5: `bump_lock_and_commit` / `relock_keystone_input` —
+    /// `nix flake update keystone`.
+    Lock,
+    /// Step 6: `build_locked` — `nix build` of the system closure.
+    /// Typically the longest phase (60–180s).
+    Build,
+    /// Step 7: `activate_via_broker` — second pkexec → `ks activate`.
+    /// Silent if the polkit cache from Warm holds (see PR #507).
+    Activate,
+    /// Step 8: `push_lock` — best-effort `git push` of the lock bump
+    /// commit (channel mode only).
+    Push,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Status {
+    Start,
+    Done,
+    Error,
+}
+
+#[derive(Serialize)]
+struct Event<'a> {
+    phase: Phase,
+    status: Status,
+    ts_ms: u128,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_ms: Option<u128>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<&'a str>,
+}
+
+/// Module-level enable flag. Set once at the start of
+/// `run_supervised_update` when `--emit-progress` was passed; unset
+/// otherwise. Atomic so `emit*` calls don't need a mutex.
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+pub fn enable() {
+    ENABLED.store(true, Ordering::Relaxed);
+}
+
+fn now_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+fn write_line(event: &Event<'_>) {
+    if !ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+    // Errors writing to stdout are not actionable here — the consumer
+    // pipe may be gone, we still want to keep running the update.
+    if let Ok(line) = serde_json::to_string(event) {
+        println!("{line}");
+    }
+}
+
+pub fn emit_start(phase: Phase, target: Option<&str>) {
+    write_line(&Event {
+        phase,
+        status: Status::Start,
+        ts_ms: now_ms(),
+        target,
+        duration_ms: None,
+        error: None,
+    });
+}
+
+pub fn emit_done(phase: Phase, duration_ms: u128) {
+    write_line(&Event {
+        phase,
+        status: Status::Done,
+        ts_ms: now_ms(),
+        target: None,
+        duration_ms: Some(duration_ms),
+        error: None,
+    });
+}
+
+pub fn emit_error(phase: Phase, duration_ms: u128, error: &str) {
+    write_line(&Event {
+        phase,
+        status: Status::Error,
+        ts_ms: now_ms(),
+        target: None,
+        duration_ms: Some(duration_ms),
+        error: Some(error),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emit_no_op_when_disabled() {
+        // Default state: ENABLED is false → write_line returns without
+        // panicking. We can't easily assert stdout absence here, but
+        // exercising the path catches any future regressions that
+        // would panic on the unset state.
+        emit_start(Phase::Build, Some("test@deadbeef"));
+        emit_done(Phase::Build, 1234);
+        emit_error(Phase::Build, 5678, "oh no");
+    }
+
+    #[test]
+    fn event_serializes_with_snake_case_phases() {
+        let ev = Event {
+            phase: Phase::Activate,
+            status: Status::Start,
+            ts_ms: 1000,
+            target: Some("main@06bf415"),
+            duration_ms: None,
+            error: None,
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        assert!(json.contains(r#""phase":"activate""#));
+        assert!(json.contains(r#""status":"start""#));
+        assert!(json.contains(r#""target":"main@06bf415""#));
+        assert!(!json.contains("duration_ms"));
+        assert!(!json.contains("\"error\""));
+    }
+}

--- a/packages/ks/src/main.rs
+++ b/packages/ks/src/main.rs
@@ -90,9 +90,13 @@ async fn main() -> Result<()> {
                 json,
                 approve,
                 keystone_override,
+                emit_progress,
             } => {
                 let dev_mode = dev && !lock;
                 let pull_only = pull && dev_mode;
+                if emit_progress && approve {
+                    cmd::update_progress::enable();
+                }
                 run_update_command(
                     hosts.as_deref(),
                     dev_mode,


### PR DESCRIPTION
Draft scaffold for #508 — emitter side only. Walker consumer follows in a separate PR.

## What this gives you

A `--emit-progress` flag on `ks update --approve` that writes JSON-Lines to stdout at every phase boundary. Off by default → direct CLI use stays quiet. When on, looks like:

\`\`\`
{"phase":"build","status":"start","ts_ms":1778341234567,"target":"main@06bf415"}
{"phase":"build","status":"done","ts_ms":1778341337901,"duration_ms":103334}
{"phase":"activate","status":"start","ts_ms":1778341337905,"target":"main@06bf415"}
{"phase":"activate","status":"done","ts_ms":1778341344112,"duration_ms":6207}
\`\`\`

## Wired in this PR

- `cmd::update_progress` module — \`Phase\` enum (the 7 supervised-flow steps), \`Status\` enum (\`start\`/\`done\`/\`error\`), atomic on/off switch, three emit helpers.
- \`Update { emit_progress }\` CLI flag.
- Build + Activate phase boundaries — these are the longest silent phases, so they're the proof-of-concept.
- 2 unit tests (serialization shape + disabled no-op).

## Not wired yet — open for review

1. **Preflight, Resolve, Warm, Lock, Push emissions** — straightforward follow-up once the schema is agreed.
2. **Walker consumer** (layer-shell widget / Walker module reading the JSONL stream).
3. **Sub-phase progress** during \`nix build\` — would need parsing the realisation stream, separate concern.

## Why JSON-Lines on stdout

- Consumer pipe is the simplest possible IPC — no D-Bus surface, no socket lifecycle.
- Walker can subprocess \`ks update --approve --emit-progress\` and read its stdout line by line.
- A CI scraper or a future TUI can use the same stream.
- Stderr already carries the existing human log lines untouched.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo test update_progress\` passes
- [ ] Live verification on \`ncrmro-laptop\` after #507's polkit cache is deployed (single-prompt flow makes the Build/Activate split observable)

## Open questions

- **Should pre-resolve phases (Preflight, Resolve) emit anything if no \`target\` is known yet?** Current scaffold sends \`target: None\`. Probably fine — Walker shows phase name, target appears on first Resolve\`done\`.
- **Push failure: \`error\` event or \`done\` with \`pushed: false\`?** Today push failures are best-effort soft-fail. Leaning toward \`done\` to match the orchestrator semantics.
- **Should we also emit on the supervised-flow's own \`eprintln!\` messages?** Probably not — that would double-stream. The JSONL is a structured channel, the eprintln is for humans.