### PR TITLE
fix(desktop): grant admin systemd-inhibit so walker-launched updates run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -411,6 +411,10 @@
             inherit pkgs lib;
             self = self;
           };
+          polkitUpdateSessionInhibit = import ./tests/module/polkit-update-session-inhibit.nix {
+            inherit pkgs lib;
+            self = self;
+          };
           ksDoctorReport = import ./tests/module/ks-doctor-report.nix {
             inherit pkgs;
           };
@@ -551,6 +555,7 @@
           ks-approve = ksApprove;
           approve-exec-script = approveExecScript;
           polkit-keystone-approve-cache = polkitKeystoneApproveCache;
+          polkit-update-session-inhibit = polkitUpdateSessionInhibit;
           ks-doctor-report = ksDoctorReport;
           ks-rust-tests = ksRustTests;
           ks-rust-clippy = ksRustClippy;
@@ -587,6 +592,7 @@
             ln -s ${ksApprove} "$out/approve"
             ln -s ${approveExecScript} "$out/approve-exec-script"
             ln -s ${polkitKeystoneApproveCache} "$out/polkit-keystone-approve-cache"
+            ln -s ${polkitUpdateSessionInhibit} "$out/polkit-update-session-inhibit"
             ln -s ${ksDoctorReport} "$out/doctor-report"
             ln -s ${ksLockSync} "$out/lock-sync"
           '';

--- a/modules/desktop/nixos.nix
+++ b/modules/desktop/nixos.nix
@@ -56,6 +56,22 @@ in
   };
 
   config = mkIf cfg.enable {
+    # Walker dispatches `ks update --approve` through `systemd-inhibit`
+    # so suspend/shutdown can't wedge a switch. systemd-inhibit runs
+    # without AllowInteractive, and walker.service lives in user@.service
+    # (no logind seat session), so polkit's subject.active and
+    # subject.local are both false for it. Grant the admin user the
+    # inhibit-* actions directly — gating on session attributes would
+    # re-break walker.
+    security.polkit.extraConfig = ''
+      polkit.addRule(function(action, subject) {
+        if (subject.user == "${config.keystone.os.adminUsername}" &&
+            action.id.indexOf("org.freedesktop.login1.inhibit-") == 0) {
+          return polkit.Result.YES;
+        }
+      });
+    '';
+
     # Flatpak support (declarative via nix-flatpak)
     services.flatpak.enable = mkDefault true;
 

--- a/tests/module/polkit-update-session-inhibit.nix
+++ b/tests/module/polkit-update-session-inhibit.nix
@@ -1,0 +1,60 @@
+# Regression test for the polkit rule that lets walker-launched updates
+# take a `systemd-inhibit` lock without an interactive auth prompt.
+# Rule lives in modules/desktop/nixos.nix; servers don't get the grant.
+{
+  pkgs,
+  lib ? pkgs.lib,
+  self,
+}:
+let
+  result = (import "${pkgs.path}/nixos/lib/eval-config.nix") {
+    system = "x86_64-linux";
+    modules = [
+      self.nixosModules.operating-system
+      self.nixosModules.desktop
+      {
+        system.stateVersion = "25.05";
+        boot.loader.systemd-boot.enable = true;
+        keystone.os = {
+          enable = true;
+          storage = {
+            type = "zfs";
+            devices = [ "/dev/vda" ];
+          };
+          users.testuser = {
+            fullName = "Test User";
+            initialPassword = "testpass";
+            admin = true;
+          };
+        };
+        keystone.desktop.enable = true;
+        networking.hostId = "deadbeef";
+        fileSystems."/" = {
+          device = lib.mkForce "rpool/crypt/system";
+          fsType = lib.mkForce "zfs";
+        };
+      }
+    ];
+  };
+
+  rendered = result.config.security.polkit.extraConfig;
+
+  # Tokens in order, `.*` between, to tolerate formatting refactors. The
+  # trailing `;` after YES is what distinguishes the live rule from a
+  # comment that quotes it.
+  ruleTokensInOrder =
+    builtins.match (
+      ".*subject\\.user == \"testuser\""
+      + ".*action\\.id\\.indexOf\\(\"org\\.freedesktop\\.login1\\.inhibit-\"\\)"
+      + ".*polkit\\.Result\\.YES;.*"
+    ) rendered != null;
+
+  fail = msg: throw "polkit-update-session-inhibit: ${msg}\nrendered extraConfig:\n${rendered}";
+in
+if !ruleTokensInOrder then
+  fail ''subject.user == "<adminUsername>", action.id.indexOf("…inhibit-"), polkit.Result.YES; must appear in order''
+else
+  pkgs.runCommand "test-polkit-update-session-inhibit" { } ''
+    echo "polkit-update-session-inhibit: rule present, token order intact."
+    touch $out
+  ''


### PR DESCRIPTION
## Problem

Walker → "Update" dispatches via:

\`\`\`
uwsm app -- systemd-inhibit --what=sleep:shutdown:idle --mode=block \\
               systemd-cat --identifier=ks-update \\
               ks update --approve --flake <path>
\`\`\`

\`systemd-inhibit\` doesn't set \`AllowInteractive\`, so it relies on \`org.freedesktop.login1.inhibit-block-shutdown\`'s default \`allow_active=yes\` to auto-grant. That default doesn't apply to walker: \`walker.service\` runs under \`user@1000.service / app.slice / walker.service\` — a systemd user unit, not in any logind seat session — so \`subject.active\` is false for walker and all its descendants. polkit returns an instant deny with no prompt, and the chain dies before \`ks update --approve\` ever spawns.

Daily-driver hosts mask this once the admin has hand-authenticated one inhibit prompt (polkit caches under \`auth_admin_keep\`). Fresh hosts (today's rc.2 test laptop) have no such cache — first Walker → Update is silently a no-op.

## Fix

Add a polkit JS rule **in \`modules/desktop/nixos.nix\`** (not OS — only desktop hosts run walker, servers don't need the grant):

\`\`\`js
polkit.addRule(function(action, subject) {
  if (subject.user == "<adminUsername>" &&
      action.id.indexOf("org.freedesktop.login1.inhibit-") == 0) {
    return polkit.Result.YES;
  }
});
\`\`\`

Scope: only \`keystone.os.adminUsername\`, only the five \`inhibit-*\` actions. Same shape as \`modules/os/hypervisor.nix\` uses for \`org.libvirt.unix.manage\`.

## Test

\`tests/module/polkit-update-session-inhibit.nix\` evaluates the desktop module and asserts the three rule tokens (\`subject.user == "<admin>"\`, \`action.id.indexOf("…inhibit-")\`, \`polkit.Result.YES;\`) appear in order in the rendered config. Trailing \`;\` after \`YES\` distinguishes the live rule from a comment that quotes it.

## Test plan

- [x] \`nix build .#checks.x86_64-linux.polkit-update-session-inhibit\` green
- [x] \`nix build .#checks.x86_64-linux.polkit-keystone-approve-cache\` still green
- [ ] Live on rc.2 laptop after merge: Walker → Update produces a single polkit prompt + completion notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)