### PR TITLE
docs(conventions): forbid PR-history and preemptive trade-off comments

### DIFF
--- a/conventions/code.comments.md
+++ b/conventions/code.comments.md
@@ -1,3 +1,7 @@
 # Code comments
 
 Comments explain **why**, not what. Use prefixes for special cases: `SECURITY:` names the specific attack vector mitigated, `CRITICAL:` flags a cross-module invariant that breaks silently if violated, `TODO:` states the consequence of leaving the gap.
+
+Don't reference the current PR, fix, or session in source comments (`PR #X`, "the bug we just fixed", "what Copilot flagged"). That context belongs in commit messages and PR descriptions, which travel with the change. Source comments outlive their PR — references rot.
+
+Don't pre-emptively document trade-offs you didn't take. Defending a decision against an imaginary reviewer in a paragraph block is clutter; if a real reviewer pushes back, address it in the PR conversation. Non-obvious decisions get one sentence; obvious ones get nothing.


### PR DESCRIPTION
Two additions to \`conventions/code.comments.md\`, both surfaced today while reviewing PR #512 and its precursors:

1. **No PR-history references in source comments** (\`PR #X\`, "the bug we just fixed", "what Copilot flagged"). They rot — by the time a future reader sees them, the cross-reference means nothing. PR descriptions / commit messages carry that context.

2. **No pre-emptive trade-off paragraphs**. Defending a decision against an imaginary reviewer in a long block is clutter; if a real reviewer pushes back, address it in the PR conversation. Non-obvious decisions get one sentence; obvious ones get nothing.

Same tone and length as the existing \`code.comments.md\` (no RFC 2119 header, one short paragraph per rule). Audit/cleanup of existing offenders is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)