### PR TITLE
chore: trim PR-history and preemptive trade-off comments per convention

### DIFF
--- a/modules/desktop/home/hyprland/layout.nix
+++ b/modules/desktop/home/hyprland/layout.nix
@@ -78,21 +78,10 @@ in
         "center on, match:class ^$, match:title ^(Authentication required)$"
         "size 486 246, match:class ^$, match:title ^(Authentication required)$"
         "pin on, match:class ^$, match:title ^(Authentication required)$"
-        # Translucency makes the polkit dialog read like the rest of the
-        # keystone surface (ghostty, walker) instead of an opaque Qt
-        # slab. Hyprland's global decoration.blur block blurs the
-        # backdrop *proportional to the window's transparency* — at
-        # 0.97 alpha you only see 3% of the blurred backdrop, which
-        # reads as no blur at all. Hyprland 0.54 dropped per-window
-        # `blur on` (used to draw blur regardless of alpha), so the only
-        # lever we have is opacity. 0.85 / 0.78 lets enough of the
-        # blurred backdrop through to be obviously blurry while keeping
-        # the password field readable. Rounding matches the desktop.
-        # The Hyprland outer border stays visible (per-window
-        # `noborder`/`bordersize` aren't valid fields in 0.54 either);
-        # if it ever reads as a double frame against the QML's inner
-        # gold border, the fix is a global `general.border_size = 0`
-        # toggle, not a per-window rule.
+        # Global decoration.blur shows backdrop proportional to (1 - alpha),
+        # and Hyprland 0.54 dropped per-window `blur on`, so opacity is the
+        # only lever for a translucent-blurred dialog. 0.85/0.78 is the
+        # readability/blur sweet spot. Rounding matches the desktop.
         "opacity 0.85 0.78, match:class ^$, match:title ^(Authentication required)$"
         "rounding 12, match:class ^$, match:title ^(Authentication required)$"
       ];

--- a/modules/os/privileged-approval.nix
+++ b/modules/os/privileged-approval.nix
@@ -194,32 +194,12 @@ in
 
     security.polkit.enable = mkDefault true;
 
-    # The XML policy in $out/share/polkit-1/actions/com.ncrmro.keystone.approve.policy
-    # declares `auth_admin_keep` and a `org.freedesktop.policykit.exec.path`
-    # annotation pointing at the symlink path
-    # `/run/current-system/sw/bin/keystone-approve-exec`. That annotation
-    # is *not* honoured at runtime: pkexec calls `realpath()` on the
-    # program before handing it to polkit, so polkit looks up the
-    # canonical Nix store path. The annotation matches the symlink path,
-    # never the canonical, so polkit silently falls back to the generic
-    # `org.freedesktop.policykit.exec` action — whose default for
-    # `allow_active` is `auth_admin` (no `_keep`). Result: a fresh
-    # password prompt on every pkexec call, including the post-build
-    # activation that `warm_polkit_cache` is meant to cover.
-    #
-    # Adding a JS rule that matches the *canonical* helper path
-    # (`${approvalHelper}/bin/keystone-approve-exec` is interpolated at
-    # build time) is the only way to actually get `AUTH_ADMIN_KEEP`
-    # applied. The XML policy stays in place for the description/message
-    # strings the dialog shows.
-    #
-    # The rule mirrors the XML's stated `<defaults>` (allow_any=no,
-    # allow_inactive=no, allow_active=auth_admin_keep) by gating on
-    # `subject.active`: only an active local session caches; anything
-    # else is denied. Without this gate, an unattended SSH session
-    # could trigger keystone-approve-exec and the cached credential
-    # would survive — a wider blast radius than the XML policy
-    # advertised.
+    # pkexec realpath()s its target before handing it to polkit, so the
+    # XML policy's `exec.path` annotation (which names the
+    # /run/current-system symlink) never matches and the keep cache is
+    # never applied. This JS rule matches the canonical store path
+    # instead. `subject.active` gate mirrors the XML's allow_active /
+    # allow_inactive=no defaults — only an active local session caches.
     security.polkit.extraConfig = ''
       polkit.addRule(function(action, subject) {
         if (action.id == "org.freedesktop.policykit.exec" &&

--- a/tests/module/keystone-update-menu-wiring.nix
+++ b/tests/module/keystone-update-menu-wiring.nix
@@ -175,15 +175,11 @@ pkgs.runCommand "test-keystone-update-menu-wiring"
     #
     # CRITICAL: keystone-main-menu.sh emits a top-level "Update" entry that
     # parallels the dedicated keystone-update submenu's "Run update" action.
-    # PR #404 retired the legacy `ghostty -e ks update` terminal ceremony in
-    # the dedicated submenu (Lua → Rust dispatch), but the top-level entry
-    # was missed and silently regressed back to the terminal path on every
-    # host until #414 caught it.
-    #
-    # The fix is for keystone-main-menu.sh's dispatch to delegate to
-    # `ks menu update dispatch`, NOT to spawn its own terminal. These greps
-    # are behavior-shaped: they assert what the dispatch DOES, not just what
-    # token strings appear. Add new assertions here when the contract grows.
+    # The top-level entry MUST delegate to `ks menu update dispatch`, NOT
+    # spawn its own terminal — otherwise the two entry points diverge and
+    # the top-level silently regresses to a terminal path while the
+    # submenu uses the Lua→Rust dispatch. These greps are behavior-shaped:
+    # they assert what the dispatch DOES, not just what tokens appear.
 
     # Strip comment-only lines before grepping, so the deprecation comment
     # documenting WHY this regression matters doesn't trip its own test.

--- a/tests/module/polkit-keystone-approve-cache.nix
+++ b/tests/module/polkit-keystone-approve-cache.nix
@@ -1,22 +1,16 @@
-# polkit-keystone-approve-cache — regression test for the
-# canonical-path polkit rule that makes auth_admin_keep actually
-# apply to keystone-approve-exec.
+# Regression test for the canonical-path polkit rule that makes
+# auth_admin_keep apply to keystone-approve-exec.
 #
-# History: pkexec calls realpath() on its target before handing it to
-# polkit, so polkit looks up the canonical Nix store path. The XML
-# policy's `org.freedesktop.policykit.exec.path` annotation pointed at
-# the /run/current-system symlink — never matched, so polkit fell back
-# to the generic action's auth_admin (no _keep) and re-prompted on
-# every pkexec call. The fix is a JS rule in security.polkit.extraConfig
-# that matches the canonical helper path (Nix interpolates it).
+# pkexec calls realpath() on its target before handing it to polkit,
+# so the XML policy's `exec.path` annotation pointing at the
+# `/run/current-system` symlink never matches and polkit falls back to
+# the generic `auth_admin` (no `_keep`), re-prompting on every call.
+# The JS rule in security.polkit.extraConfig matches the canonical
+# Nix store path (interpolated at build time) so the keep cache hits.
 #
-# This test pins the fix at the rendered-config level. Specifically it
-# guards against:
-#   - reverting to /run/current-system in the rule (would break
-#     auth_admin_keep again — exactly the bug we just fixed)
-#   - dropping subject.active gating (would let inactive sessions
-#     cache, breaching the XML's allow_inactive=no semantics)
-#   - removing AUTH_ADMIN_KEEP entirely
+# Asserts the rendered rule contains the canonical store path, gates
+# on subject.active, returns AUTH_ADMIN_KEEP, and does NOT reference
+# the /run/current-system symlink.
 #
 # Build: nix build .#test-polkit-keystone-approve-cache
 {


### PR DESCRIPTION
Applies the new comment convention (#513) to existing offenders.

\`\`\`
$ rg 'PR #' modules/ tests/ packages/
tests/module/keystone-update-menu-wiring.nix:178:    # PR #404 retired the legacy ...

$ rg 'the bug we just fixed' modules/ tests/ packages/
tests/module/polkit-keystone-approve-cache.nix:16:    auth_admin_keep again — exactly the bug we just fixed
\`\`\`

Plus two paragraph-form narratives that pre-emptively documented trade-offs:

- \`modules/desktop/home/hyprland/layout.nix\` — 16-line opacity/blur narrative explaining why 0.85/0.78. Trimmed to 4 lines stating only the load-bearing facts (global blur scales with alpha, Hyprland 0.54 dropped per-window \`blur on\`, hence opacity is the only lever).
- \`modules/os/privileged-approval.nix\` — 27-line \`auth_admin_keep\` narrative. Trimmed to 6 lines: pkexec realpath()s so the XML annotation never matches; this JS rule pins the canonical store path; \`subject.active\` gate mirrors the XML's \`allow_active\` / \`allow_inactive=no\` defaults.

Net: -67 / +26 lines. All checks still green (\`polkit-keystone-approve-cache\`, \`hyprland-config-smoke\` verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)