### PR TITLE
feat(overlay): track chromium and signal-desktop on nixpkgs-fresh

### DIFF
--- a/.github/workflows/flake-update-fresh.yml
+++ b/.github/workflows/flake-update-fresh.yml
@@ -1,0 +1,68 @@
+name: Update nixpkgs-fresh
+
+on:
+  schedule:
+    # Mondays 14:00 UTC — single weekly bump for the curated fresh-pinned
+    # leaf packages (chromium, signal-desktop). See `overlays/default.nix`.
+    - cron: "0 14 * * MON"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: flake-update-fresh
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update nixpkgs-fresh
+        run: nix flake update nixpkgs-fresh
+
+      - name: Report new chromium / signal versions
+        id: versions
+        run: |
+          chromium_version="$(nix eval --raw .#nixosConfigurations.keystoneIso.pkgs.chromium.version)"
+          signal_version="$(nix eval --raw .#nixosConfigurations.keystoneIso.pkgs.signal-desktop.version)"
+          {
+            echo "chromium=$chromium_version"
+            echo "signal=$signal_version"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Tracked package versions"
+            echo ""
+            echo "- chromium: \`$chromium_version\`"
+            echo "- signal-desktop: \`$signal_version\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          branch: deps/nixpkgs-fresh
+          delete-branch: true
+          commit-message: "chore(deps): bump nixpkgs-fresh"
+          title: "chore(deps): bump nixpkgs-fresh"
+          labels: |
+            chore
+            ci
+          body: |
+            Weekly bump of the `nixpkgs-fresh` flake input — tracks the curated
+            leaf packages declared in `overlays/default.nix` (chromium,
+            signal-desktop).
+
+            Tracked versions in this bump:
+
+            - chromium: `${{ steps.versions.outputs.chromium }}`
+            - signal-desktop: `${{ steps.versions.outputs.signal }}`
+
+            See the `nixpkgs-fresh` input comment in `flake.nix` for rationale.

--- a/flake.lock
+++ b/flake.lock
@@ -1287,6 +1287,22 @@
         "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
       }
     },
+    "nixpkgs-fresh": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1772198003,
@@ -1520,6 +1536,7 @@
         "nix-index-database": "nix-index-database",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgs-fresh": "nixpkgs-fresh",
         "omarchy": "omarchy",
         "walker": "walker",
         "yazi": "yazi"

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,13 @@
       url = "github:nix-community/browser-previews";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # Fresh-pin nixpkgs for selected fast-moving packages (chromium,
+    # signal-desktop). Intentionally does NOT follow `nixpkgs` — the whole point
+    # is to track nixos-unstable independently of the main pin, so a stale
+    # `nixpkgs` doesn't hold back security/feature-critical leaf packages.
+    # See `overlays/default.nix` for the curated package list; keep it short to
+    # bound /nix/store divergence.
+    nixpkgs-fresh.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # Desktop tools
     ghostty.url = "github:ghostty-org/ghostty";
@@ -130,6 +137,7 @@
       comodoro,
       llm-agents,
       browser-previews,
+      nixpkgs-fresh,
       ghostty,
       yazi,
       walker,
@@ -234,6 +242,7 @@
           comodoro
           llm-agents
           browser-previews
+          nixpkgs-fresh
           ghostty
           yazi
           agenix

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -10,6 +10,7 @@
   comodoro,
   llm-agents,
   browser-previews,
+  nixpkgs-fresh,
   ghostty,
   yazi,
   agenix,
@@ -59,6 +60,12 @@ in
 final: prev:
 let
   system = final.stdenv.hostPlatform.system;
+  # Fresh-pinned nixpkgs for high-cadence leaf packages. Keep `allowUnfree`
+  # because signal-desktop and chromium-related deps require it.
+  nixpkgsFreshPkgs = import nixpkgs-fresh {
+    inherit system;
+    config.allowUnfree = true;
+  };
   llmAgentsPkgs = import prev.path {
     inherit system;
     config.allowUnfree = true;
@@ -209,6 +216,17 @@ in
   };
   # Top-level overrides so programs.ghostty/yazi use flake versions
   yazi = yazi-flake.packages.${system}.default;
+
+  # Top-level overrides pulled from the dedicated `nixpkgs-fresh` input.
+  # These packages need to track upstream more aggressively than the main
+  # nixpkgs pin (chromium ships weekly CVE patches; signal-desktop force-
+  # deprecates older clients). Add new entries here sparingly — each one
+  # duplicates a slice of transitive deps in /nix/store. See `flake.nix`
+  # `nixpkgs-fresh` input comment for the rationale.
+  inherit (nixpkgsFreshPkgs)
+    chromium
+    signal-desktop
+    ;
 }
 // prev.lib.optionalAttrs prev.stdenv.isLinux {
   ghostty = ghostty-flake.packages.${prev.stdenv.hostPlatform.system}.default;


### PR DESCRIPTION
## Summary

- Add a dedicated `nixpkgs-fresh` flake input that tracks `nixos-unstable` independently of the main `nixpkgs` pin.
- Override `pkgs.chromium` and `pkgs.signal-desktop` in `overlays/default.nix` to source from the fresh pin. Existing call-sites (desktop module `environment.systemPackages`, home-manager `home.packages`) resolve to the fresher version with no other changes.
- Add a scheduled GitHub Action (`.github/workflows/flake-update-fresh.yml`) that runs `nix flake update nixpkgs-fresh` weekly (Mondays 14:00 UTC) and opens a PR via `peter-evans/create-pull-request`. PR body surfaces the new chromium / signal-desktop versions.

## Why

The main `nixpkgs` pin can drift months behind upstream — at the time of this PR the keystone lock is at **2026-02-08**, ~3 months stale, pinning chromium at `145.0.7632.159`. Chromium ships weekly CVE patches; signal-desktop periodically force-deprecates older clients. Bumping main `nixpkgs` just to refresh a browser churns the whole system closure. A dedicated input lets us track upstream weekly for a curated set of fast-moving leaf packages.

Complements #441 (Dependabot for flake inputs): Dependabot doesn't support scheduling a single named input on its own cadence, so this Action handles `nixpkgs-fresh` specifically. Dependabot can still own the main `nixpkgs` and the other inputs.

## Verification (local)

```
$ nix eval --raw .#nixosConfigurations.keystoneIso.pkgs.chromium.version
147.0.7727.137                # was 145.0.7632.159
$ nix eval --raw .#nixosConfigurations.keystoneIso.pkgs.signal-desktop.version
8.8.0
$ nix eval .#packages.x86_64-linux --apply 'p: builtins.attrNames p'
# evaluates clean; keystone package list unchanged
```

## Adding more packages later

Append to the `inherit (nixpkgsFreshPkgs) … ;` block in `overlays/default.nix`. Keep the list short — each entry costs a slice of duplicated transitive deps in `/nix/store`. Candidates that DIDN'T make this PR: `obsidian`, `obs-studio`, `firefox`, `gh`/`gh-dash` — add only when staleness pain is felt.

## Caching impact

Minimal. Both packages come from `nixos-unstable` which is Hydra-built and lives on `cache.nixos.org` (default substituter). The Attic `watch-store` service (`modules/binary-cache-client.nix`) republishes anything a host materializes, so the keystone fleet cache fills naturally. Closure bloat is bounded: chromium + signal each duplicate a slice of Electron / Qt / icu / ffmpeg at the fresh-pin rev — tens to a few hundred MB extra per package, cleared when the main pin catches up. `bin/warm-cachix` is not auto-updated; intentional to keep this PR scoped.

## Test plan

- [ ] `validate.yml` passes on this PR
- [ ] Manually trigger `flake-update-fresh.yml` via `workflow_dispatch` and confirm it opens a clean PR (or is a no-op when already up to date)
- [ ] After merge: `cd ~/.keystone/repos/ncrmro/nixos-config && nix flake update keystone && ks build` succeeds on a workstation
- [ ] After deploy via `ks update --dev` (approval-gated), `chromium --version` reports ≥ 147, `signal-desktop --version` reports ≥ 8.8.0

## Related

- #441 — Dependabot for flake inputs (complementary, not blocking)
- #483 — overlay refactor (touches the same file; coordinate diffs if both land in the same window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)