### PR TITLE
feat(desktop): enable fprintd daemon and ship CLI tools

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -498,6 +498,12 @@
             inherit home-manager;
             self = self;
           };
+          desktopFprintd = import ./tests/module/desktop-fprintd.nix {
+            pkgs = ksPkgs;
+            lib = ksPkgs.lib;
+            inherit nixpkgs;
+            self = self;
+          };
           agentctlRegression = import ./tests/module/agentctl-regression.nix {
             inherit pkgs;
           };
@@ -548,6 +554,7 @@
           desktop-walker-surfaces = desktopWalkerSurfaces;
           desktop-autostart-assertion = desktopAutostartAssertion;
           hyprland-config-smoke = hyprlandConfigSmoke;
+          desktop-fprintd = desktopFprintd;
           ks-approve = ksApprove;
           approve-exec-script = approveExecScript;
           polkit-keystone-approve-cache = polkitKeystoneApproveCache;
@@ -612,6 +619,7 @@
             ln -s ${desktopWalkerSurfaces} "$out/desktop-walker-surfaces"
             ln -s ${desktopAutostartAssertion} "$out/desktop-autostart-assertion"
             ln -s ${hyprlandConfigSmoke} "$out/hyprland-config-smoke"
+            ln -s ${desktopFprintd} "$out/desktop-fprintd"
           '';
 
           # Agent runtime and miscellaneous module tests

--- a/modules/desktop/nixos.nix
+++ b/modules/desktop/nixos.nix
@@ -124,6 +124,11 @@ in
     hardware.bluetooth.enable = mkDefault true;
     services.blueman.enable = mkDefault true;
 
+    # Fingerprint reader daemon — required for fprintd-enroll/verify/delete to
+    # find the D-Bus service. PAM integration (fprintAuth) is intentionally
+    # deferred; enable the daemon first so enrollment via the Walker menu works.
+    services.fprintd.enable = mkDefault true;
+
     # Printing (CUPS + Avahi/mDNS discovery)
     services.printing.enable = mkDefault true;
     services.avahi = {
@@ -171,6 +176,10 @@ in
         file-roller
         sushi
         loupe
+
+        # Fingerprint CLI tools — enrollment terminal inherits user PATH, not
+        # the wrapper's runtimeInputs, so the binaries must be globally present.
+        fprintd
 
         # System utilities
         pavucontrol

--- a/tests/module/desktop-fprintd.nix
+++ b/tests/module/desktop-fprintd.nix
@@ -1,0 +1,82 @@
+# desktop-fprintd — regression guard for the fprintd daemon + CLI wiring.
+#
+# The Walker fingerprint menu spawns `ghostty -e bash -lc '... fprintd-enroll'`
+# for the actual enrollment step. That terminal does NOT inherit the wrapper's
+# runtimeInputs PATH, so both the daemon and the CLI tools must be present at
+# the NixOS system level. This test pins that at the rendered-config layer.
+#
+# Build: nix build .#checks.x86_64-linux.desktop-fprintd
+{
+  pkgs,
+  lib,
+  self,
+  nixpkgs,
+}:
+let
+  result = nixpkgs.lib.nixosSystem {
+    system = "x86_64-linux";
+    modules = [
+      self.nixosModules.operating-system
+      self.nixosModules.desktop
+      {
+        system.stateVersion = "25.05";
+        boot.loader.systemd-boot.enable = true;
+
+        # Apply keystone overlay so pkgs.keystone.* (hyprpolkitagent etc.)
+        # resolve during evaluation of nixos.nix's environment.systemPackages.
+        nixpkgs.overlays = [ self.overlays.default ];
+
+        keystone.os = {
+          enable = true;
+          storage = {
+            type = "ext4";
+            devices = [ "/dev/vda" ];
+          };
+          users.testuser = {
+            fullName = "Test User";
+            initialPassword = "testpass";
+            admin = true;
+          };
+        };
+
+        keystone.desktop = {
+          enable = true;
+          user = "testuser";
+        };
+
+        fileSystems."/" = {
+          device = lib.mkForce "/dev/vda2";
+          fsType = lib.mkForce "ext4";
+        };
+      }
+    ];
+  };
+
+  fprintdEnabled = result.config.services.fprintd.enable;
+
+  systemPackageNames = map (p: lib.getName p) result.config.environment.systemPackages;
+  fprintdInSystemPackages = builtins.elem "fprintd" systemPackageNames;
+in
+pkgs.runCommand "desktop-fprintd-check" { } ''
+  errors=0
+
+  if [ "${lib.boolToString fprintdEnabled}" = "true" ]; then
+    echo "PASS: services.fprintd.enable is true when keystone.desktop.enable = true"
+  else
+    echo "FAIL: services.fprintd.enable must be true on desktop hosts — enrollment terminal inherits user PATH, not wrapper runtimeInputs" >&2
+    errors=$((errors + 1))
+  fi
+
+  if [ "${lib.boolToString fprintdInSystemPackages}" = "true" ]; then
+    echo "PASS: pkgs.fprintd is in environment.systemPackages"
+  else
+    echo "FAIL: pkgs.fprintd must be in environment.systemPackages so fprintd-enroll/list/verify/delete are on the global PATH" >&2
+    errors=$((errors + 1))
+  fi
+
+  if [ "$errors" -gt 0 ]; then
+    exit 1
+  fi
+
+  touch "$out"
+''


### PR DESCRIPTION
## Summary

The Walker fingerprint menu (`keystone-fingerprint-menu`) wraps `fprintd-enroll`/`fprintd-list`/`fprintd-verify`/`fprintd-delete` via `runtimeInputs` so its own `command -v` guards succeed. But the actual enrollment step dispatches `ghostty -e bash -lc '... exec fprintd-enroll'` — that terminal starts a fresh interactive shell that does **not** inherit the wrapper PATH, so `fprintd-enroll` was silently unavailable. `services.fprintd` was also never enabled, so there was no `net.reactivated.Fprint` D-Bus service even when the binary was found.

## Changes

- `modules/desktop/nixos.nix`: enable `services.fprintd` and add `pkgs.fprintd` to `environment.systemPackages` under `keystone.desktop.enable`.
- `tests/module/desktop-fprintd.nix`: new evaluation test asserting both invariants at the rendered-config layer.
- `flake.nix`: wire the test into `checks.x86_64-linux` and the `check-desktop` CI group.

PAM integration (`fprintAuth` for sudo/login) is intentionally out of scope — daemon + CLI first, then PAM in a follow-up.

## Test plan

- [x] `nix build .#checks.x86_64-linux.desktop-fprintd` green
- [ ] Deploy to laptop, run `fprintd-enroll`, observe successful enrollment
- [ ] Walker → Accounts → Fingerprint → Enroll opens a ghostty with a working `fprintd-enroll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)