### PR TITLE
ci: schedule weekly flake-input bump

### DIFF
--- a/.github/workflows/bump-flake-inputs.yml
+++ b/.github/workflows/bump-flake-inputs.yml
@@ -1,35 +1,18 @@
 name: Bump flake inputs
 
-# Weekly flake-input refresh for chrome/chromium/claude-code (and friends).
-#
-# Why this exists:
-#   `claude-code` / `gemini-cli` / `codex` / `opencode` come from the
-#   `llm-agents` input (numtide/llm-agents.nix) pinned at nightly-latest.
-#   `google-chrome` comes from `browser-previews` (nix-community). Chromium
-#   ships from `nixpkgs` (`nixos-unstable`). Without a forcing mechanism
-#   these inputs only advance when someone runs `nix flake update <name>`
-#   locally — so CVE fixes and new agent releases land at human cadence.
-#
-# What this workflow does (Sundays 08:00 UTC + workflow_dispatch):
-#   1. Closes any still-open PR from last week's run (label-based) so stale
-#      bumps don't pile up. Merged PRs are unaffected.
-#   2. Runs `nix flake update llm-agents browser-previews nixpkgs` (targeted —
-#      never bare `nix flake update`, per tool.nix rule 4).
-#   3. Opens a PR with the lock diff and the `automated/flake-bump` label.
-#      Review and merge is manual — keeps the failure mode obvious.
+# Sundays 08:00 UTC: refresh llm-agents (claude-code et al), browser-previews
+# (google-chrome), and nixpkgs (chromium + fleet-wide). Opens a PR with the
+# lock diff; closes last week's PR if still open. Manual merge.
 
 on:
   schedule:
-    - cron: "0 8 * * 0"  # Sundays 08:00 UTC
+    - cron: "0 8 * * 0"
   workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
 
-# Serialize runs so a manual workflow_dispatch can't race the scheduled run.
-# cancel-in-progress: false — cancelling mid-run could leave a branch pushed
-# without an accompanying PR.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -37,98 +20,42 @@ concurrency:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Checkout main
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: main
 
       - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+          extra_nix_config: experimental-features = nix-command flakes
 
-      - name: Update flake inputs
-        id: update
+      - name: Bump and open PR
         run: |
           set -euo pipefail
           # Targeted updates per tool.nix rule 4 — never bare `nix flake update`.
           nix flake update llm-agents browser-previews nixpkgs
-          if git diff --quiet flake.lock; then
-            echo "No lock changes after bump — nothing to do."
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "changed=true" >> "$GITHUB_OUTPUT"
+          git diff --quiet flake.lock && { echo "No lock changes."; exit 0; }
 
-      - name: Ensure label exists
-        if: steps.update.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh label create "automated/flake-bump" \
-            --color "FBCA04" \
-            --description "Weekly automated flake.lock bump" \
-            2>/dev/null || true
-
-      - name: Close stale bump PRs
-        if: steps.update.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # Only open PRs — merged PRs are excluded by --state open.
-          STALE="$(gh pr list \
-            --label "automated/flake-bump" \
-            --state open \
-            --json number \
-            --jq '.[].number')"
-          if [ -z "${STALE}" ]; then
-            echo "No stale bump PRs."
-            exit 0
-          fi
-          for pr in ${STALE}; do
-            echo "Closing stale PR #${pr}"
-            gh pr close "${pr}" \
-              --comment "Superseded by this week's automated flake bump." \
-              --delete-branch
-          done
-
-      - name: Open PR
-        if: steps.update.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # %G-W%V is ISO week-year + ISO week — stays consistent across New Year.
           WEEK="$(date -u +%G-W%V)"
-          BR="automated/flake-bump-$(date -u +%Y%m%d)-${{ github.run_id }}"
+          BR="automated/flake-bump-${WEEK}-${{ github.run_id }}"
+
+          gh label create automated/flake-bump --color FBCA04 \
+            --description "Weekly automated flake.lock bump" 2>/dev/null || true
+
+          for pr in $(gh pr list --label automated/flake-bump --state open --json number --jq '.[].number'); do
+            gh pr close "$pr" --comment "Superseded by this week's bump." --delete-branch || true
+          done
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "${BR}"
-          git --no-pager diff --stat flake.lock
           git commit -am "chore(deps): weekly flake bump (${WEEK})"
           git push origin "${BR}"
 
-          cat >/tmp/pr-body.md <<'EOF'
-          Automated weekly flake bump.
-
-          **Inputs refreshed:**
-          - `llm-agents` — claude-code, gemini-cli, codex, opencode
-          - `browser-previews` — google-chrome
-          - `nixpkgs` — chromium + fleet-wide
-
-          **Downstream:** After merge, downstream consumer flakes pick this up via `nix flake update keystone`. New closures are warmed into `ks-systems.cachix.org` by `warm-cache.yml`.
-          EOF
-
-          PR_URL="$(gh pr create \
-            --base main \
-            --head "${BR}" \
-            --label "automated/flake-bump" \
-            --label "chore" \
+          gh pr create --base main --head "${BR}" \
+            --label automated/flake-bump --label chore \
             --title "chore(deps): weekly flake bump (${WEEK})" \
-            --body-file /tmp/pr-body.md)"
-          echo "Opened ${PR_URL}"
+            --body "Automated weekly refresh of \`llm-agents\` (claude-code et al), \`browser-previews\` (google-chrome), and \`nixpkgs\` (chromium + fleet-wide). Downstream flakes pick this up via \`nix flake update keystone\` after merge."

--- a/.github/workflows/bump-flake-inputs.yml
+++ b/.github/workflows/bump-flake-inputs.yml
@@ -16,6 +16,8 @@ name: Bump flake inputs
 #   2. Runs `nix flake update llm-agents browser-previews nixpkgs` (targeted —
 #      never bare `nix flake update`, per tool.nix rule 4).
 #   3. Opens a PR with the lock diff and the `automated/flake-bump` label.
+#   4. Enables auto-merge (squash) — once validate.yml goes green, the PR
+#      lands without human touch.
 #
 # What happens after the bump PR merges:
 #   - Downstream consumers (`ncrmro/nixos-config`, `noah-horton/keystone-config`)
@@ -158,3 +160,12 @@ jobs:
             --title "chore(deps): weekly flake bump (${WEEK})" \
             --body-file /tmp/pr-body.md)"
           echo "Opened ${PR_URL}"
+
+          # Enable auto-merge so the PR squashes itself once validate.yml goes
+          # green. Requires (a) "Allow auto-merge" enabled in repo settings and
+          # (b) `secrets.FLAKE_BUMP_TOKEN` set — without the PAT, validate never
+          # triggers, so auto-merge waits forever. `|| true` keeps the workflow
+          # green if auto-merge can't be enabled (e.g. token lacks scope) — the
+          # PR still exists and can be merged manually.
+          gh pr merge --auto --squash "${PR_URL}" || \
+            echo "::warning::Could not enable auto-merge on ${PR_URL} — merge manually after validate passes."

--- a/.github/workflows/bump-flake-inputs.yml
+++ b/.github/workflows/bump-flake-inputs.yml
@@ -16,30 +16,7 @@ name: Bump flake inputs
 #   2. Runs `nix flake update llm-agents browser-previews nixpkgs` (targeted —
 #      never bare `nix flake update`, per tool.nix rule 4).
 #   3. Opens a PR with the lock diff and the `automated/flake-bump` label.
-#   4. Enables auto-merge (squash) — once validate.yml goes green, the PR
-#      lands without human touch.
-#
-# What happens after the bump PR merges:
-#   - Downstream consumers (`ncrmro/nixos-config`, `noah-horton/keystone-config`)
-#     pick up the new closures via `nix flake update keystone` on their next
-#     refresh. They follow keystone's pins, so no per-consumer bump is needed.
-#   - ks-systems.cachix.org receives the rebuilt closures via warm-cache.yml,
-#     so downstream hosts get cache hits.
-#
-# Token requirement:
-#   PRs opened with the default `GITHUB_TOKEN` do NOT trigger `pull_request`
-#   workflows (validate.yml) — that's a GitHub safety rail against recursive
-#   CI. To trigger validate on the bump PR, provide a PAT as
-#   `secrets.FLAKE_BUMP_TOKEN` (repo: contents+pull-requests). Without it the
-#   PR still opens, but a maintainer must push an empty commit (or close/reopen)
-#   to trigger validate before merging.
-#
-# Failure modes:
-#   - No lock changes (rare for a 3-input bump) → skip cleanly.
-#   - Validate fails on the bump PR → don't merge; investigate which input
-#     broke. The auto-close on next Sunday will retire this PR if still open.
-#   - Network/rate-limit on `nix flake update` → workflow fails; existing
-#     locks unchanged; next Sunday retries.
+#      Review and merge is manual — keeps the failure mode obvious.
 
 on:
   schedule:
@@ -65,7 +42,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.FLAKE_BUMP_TOKEN || github.token }}
 
       - uses: cachix/install-nix-action@v31
         with:
@@ -89,11 +65,9 @@ jobs:
       - name: Ensure label exists
         if: steps.update.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.FLAKE_BUMP_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Idempotent — `gh label create` is a no-op if the label already exists
-          # when `--force` is passed; without it we ignore "already exists" errors.
           gh label create "automated/flake-bump" \
             --color "FBCA04" \
             --description "Weekly automated flake.lock bump" \
@@ -102,7 +76,7 @@ jobs:
       - name: Close stale bump PRs
         if: steps.update.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.FLAKE_BUMP_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # Only open PRs — merged PRs are excluded by --state open.
@@ -125,7 +99,7 @@ jobs:
       - name: Open PR
         if: steps.update.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.FLAKE_BUMP_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # %G-W%V is ISO week-year + ISO week — stays consistent across New Year.
@@ -148,8 +122,6 @@ jobs:
           - `nixpkgs` — chromium + fleet-wide
 
           **Downstream:** After merge, downstream consumer flakes pick this up via `nix flake update keystone`. New closures are warmed into `ks-systems.cachix.org` by `warm-cache.yml`.
-
-          If `validate` did not run on this PR, push an empty commit or close/reopen — PRs opened by `GITHUB_TOKEN` don't trigger `pull_request` workflows by default. Set `secrets.FLAKE_BUMP_TOKEN` (a PAT with `contents` + `pull-requests`) to fix this permanently.
           EOF
 
           PR_URL="$(gh pr create \
@@ -160,12 +132,3 @@ jobs:
             --title "chore(deps): weekly flake bump (${WEEK})" \
             --body-file /tmp/pr-body.md)"
           echo "Opened ${PR_URL}"
-
-          # Enable auto-merge so the PR squashes itself once validate.yml goes
-          # green. Requires (a) "Allow auto-merge" enabled in repo settings and
-          # (b) `secrets.FLAKE_BUMP_TOKEN` set — without the PAT, validate never
-          # triggers, so auto-merge waits forever. `|| true` keeps the workflow
-          # green if auto-merge can't be enabled (e.g. token lacks scope) — the
-          # PR still exists and can be merged manually.
-          gh pr merge --auto --squash "${PR_URL}" || \
-            echo "::warning::Could not enable auto-merge on ${PR_URL} — merge manually after validate passes."

--- a/.github/workflows/bump-flake-inputs.yml
+++ b/.github/workflows/bump-flake-inputs.yml
@@ -1,0 +1,160 @@
+name: Bump flake inputs
+
+# Weekly flake-input refresh for chrome/chromium/claude-code (and friends).
+#
+# Why this exists:
+#   `claude-code` / `gemini-cli` / `codex` / `opencode` come from the
+#   `llm-agents` input (numtide/llm-agents.nix) pinned at nightly-latest.
+#   `google-chrome` comes from `browser-previews` (nix-community). Chromium
+#   ships from `nixpkgs` (`nixos-unstable`). Without a forcing mechanism
+#   these inputs only advance when someone runs `nix flake update <name>`
+#   locally — so CVE fixes and new agent releases land at human cadence.
+#
+# What this workflow does (Sundays 08:00 UTC + workflow_dispatch):
+#   1. Closes any still-open PR from last week's run (label-based) so stale
+#      bumps don't pile up. Merged PRs are unaffected.
+#   2. Runs `nix flake update llm-agents browser-previews nixpkgs` (targeted —
+#      never bare `nix flake update`, per tool.nix rule 4).
+#   3. Opens a PR with the lock diff and the `automated/flake-bump` label.
+#
+# What happens after the bump PR merges:
+#   - Downstream consumers (`ncrmro/nixos-config`, `noah-horton/keystone-config`)
+#     pick up the new closures via `nix flake update keystone` on their next
+#     refresh. They follow keystone's pins, so no per-consumer bump is needed.
+#   - ks-systems.cachix.org receives the rebuilt closures via warm-cache.yml,
+#     so downstream hosts get cache hits.
+#
+# Token requirement:
+#   PRs opened with the default `GITHUB_TOKEN` do NOT trigger `pull_request`
+#   workflows (validate.yml) — that's a GitHub safety rail against recursive
+#   CI. To trigger validate on the bump PR, provide a PAT as
+#   `secrets.FLAKE_BUMP_TOKEN` (repo: contents+pull-requests). Without it the
+#   PR still opens, but a maintainer must push an empty commit (or close/reopen)
+#   to trigger validate before merging.
+#
+# Failure modes:
+#   - No lock changes (rare for a 3-input bump) → skip cleanly.
+#   - Validate fails on the bump PR → don't merge; investigate which input
+#     broke. The auto-close on next Sunday will retire this PR if still open.
+#   - Network/rate-limit on `nix flake update` → workflow fails; existing
+#     locks unchanged; next Sunday retries.
+
+on:
+  schedule:
+    - cron: "0 8 * * 0"  # Sundays 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Serialize runs so a manual workflow_dispatch can't race the scheduled run.
+# cancel-in-progress: false — cancelling mid-run could leave a branch pushed
+# without an accompanying PR.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.FLAKE_BUMP_TOKEN || github.token }}
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Update flake inputs
+        id: update
+        run: |
+          set -euo pipefail
+          # Targeted updates per tool.nix rule 4 — never bare `nix flake update`.
+          nix flake update llm-agents browser-previews nixpkgs
+          if git diff --quiet flake.lock; then
+            echo "No lock changes after bump — nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure label exists
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FLAKE_BUMP_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          # Idempotent — `gh label create` is a no-op if the label already exists
+          # when `--force` is passed; without it we ignore "already exists" errors.
+          gh label create "automated/flake-bump" \
+            --color "FBCA04" \
+            --description "Weekly automated flake.lock bump" \
+            2>/dev/null || true
+
+      - name: Close stale bump PRs
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FLAKE_BUMP_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          # Only open PRs — merged PRs are excluded by --state open.
+          STALE="$(gh pr list \
+            --label "automated/flake-bump" \
+            --state open \
+            --json number \
+            --jq '.[].number')"
+          if [ -z "${STALE}" ]; then
+            echo "No stale bump PRs."
+            exit 0
+          fi
+          for pr in ${STALE}; do
+            echo "Closing stale PR #${pr}"
+            gh pr close "${pr}" \
+              --comment "Superseded by this week's automated flake bump." \
+              --delete-branch
+          done
+
+      - name: Open PR
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FLAKE_BUMP_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          # %G-W%V is ISO week-year + ISO week — stays consistent across New Year.
+          WEEK="$(date -u +%G-W%V)"
+          BR="automated/flake-bump-$(date -u +%Y%m%d)-${{ github.run_id }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "${BR}"
+          git --no-pager diff --stat flake.lock
+          git commit -am "chore(deps): weekly flake bump (${WEEK})"
+          git push origin "${BR}"
+
+          cat >/tmp/pr-body.md <<'EOF'
+          Automated weekly flake bump.
+
+          **Inputs refreshed:**
+          - `llm-agents` — claude-code, gemini-cli, codex, opencode
+          - `browser-previews` — google-chrome
+          - `nixpkgs` — chromium + fleet-wide
+
+          **Downstream:** After merge, downstream consumer flakes pick this up via `nix flake update keystone`. New closures are warmed into `ks-systems.cachix.org` by `warm-cache.yml`.
+
+          If `validate` did not run on this PR, push an empty commit or close/reopen — PRs opened by `GITHUB_TOKEN` don't trigger `pull_request` workflows by default. Set `secrets.FLAKE_BUMP_TOKEN` (a PAT with `contents` + `pull-requests`) to fix this permanently.
+          EOF
+
+          PR_URL="$(gh pr create \
+            --base main \
+            --head "${BR}" \
+            --label "automated/flake-bump" \
+            --label "chore" \
+            --title "chore(deps): weekly flake bump (${WEEK})" \
+            --body-file /tmp/pr-body.md)"
+          echo "Opened ${PR_URL}"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/bump-flake-inputs.yml` — Sunday 08:00 UTC + `workflow_dispatch`.
- Runs `nix flake update llm-agents browser-previews nixpkgs` (targeted per tool.nix rule 4).
- Closes any still-open PR from last week's run via the `automated/flake-bump` label, then opens a fresh PR with the lock diff.
- Modeled on `Unsupervisedcom/unsupervised-main/.github/workflows/release.publish-base-image.yml` (Sunday cron, concurrency group, ISO-week tag, labelled cleanup).

## Why
- `claude-code` (`llm-agents`), `google-chrome` (`browser-previews`), and `chromium` (`nixpkgs`) currently only advance when someone runs `nix flake update <name>` locally. CVE patches and new agent releases land at human cadence.
- Downstream consumer flakes (`ncrmro/nixos-config`, `noah-horton/keystone-config`) follow keystone's pins, so refreshing here propagates through `nix flake update keystone` on their next refresh.

## Token note
PRs opened by the default `GITHUB_TOKEN` don't trigger `pull_request` workflows (GitHub safety rail against recursive CI). To get `validate.yml` to run on each bump PR automatically, create a PAT with `contents` + `pull-requests` scopes and store it as repo secret `FLAKE_BUMP_TOKEN`. Without it, the bump PR still opens, but a maintainer has to nudge CI manually (close/reopen or push an empty commit).

## Test plan
- [ ] Merge → wait for next Sunday OR trigger manually via `Actions → Bump flake inputs → Run workflow` on `main`.
- [ ] Verify it opens a PR with a non-empty `flake.lock` diff and the `automated/flake-bump` + `chore` labels.
- [ ] Don't merge that PR. Re-trigger the workflow and confirm the previous PR is closed with a "superseded" comment and the new PR opens cleanly.
- [ ] Once `FLAKE_BUMP_TOKEN` is configured, confirm `validate.yml` runs automatically on the next bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)