### PR TITLE
ci(flake-bump): use a PAT instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/bump-flake-inputs.yml
+++ b/.github/workflows/bump-flake-inputs.yml
@@ -4,7 +4,7 @@ name: Bump flake inputs
 # (google-chrome), and nixpkgs (chromium + fleet-wide). Opens a PR with the
 # lock diff; closes last week's PR if still open. Manual merge.
 #
-# Uses secrets.FLAKE_BUMP_TOKEN (a fine-grained PAT scoped to this repo)
+# Uses secrets.GH_FINEGRANED_CI_TOKEN (a fine-grained PAT scoped to this repo)
 # rather than the default GITHUB_TOKEN. Two reasons:
 #   1. GITHUB_TOKEN cannot create pull requests unless the org/repo enables
 #      "Allow GitHub Actions to create and approve pull requests" — a setting
@@ -33,12 +33,12 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.FLAKE_BUMP_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_FINEGRANED_CI_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.FLAKE_BUMP_TOKEN }}
+          token: ${{ secrets.GH_FINEGRANED_CI_TOKEN }}
 
       - uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/bump-flake-inputs.yml
+++ b/.github/workflows/bump-flake-inputs.yml
@@ -4,13 +4,21 @@ name: Bump flake inputs
 # (google-chrome), and nixpkgs (chromium + fleet-wide). Opens a PR with the
 # lock diff; closes last week's PR if still open. Manual merge.
 #
-# Uses secrets.FLAKE_BUMP_TOKEN (a PAT with `repo` scope) rather than the
-# default GITHUB_TOKEN. Two reasons:
+# Uses secrets.FLAKE_BUMP_TOKEN (a fine-grained PAT scoped to this repo)
+# rather than the default GITHUB_TOKEN. Two reasons:
 #   1. GITHUB_TOKEN cannot create pull requests unless the org/repo enables
 #      "Allow GitHub Actions to create and approve pull requests" — a setting
-#      that varies between repos. Using a PAT makes this workflow portable.
+#      that varies between repos. A PAT makes this workflow portable.
 #   2. PRs opened by GITHUB_TOKEN do not trigger `pull_request` workflows
 #      (validate.yml). A PAT-opened PR triggers them normally.
+#
+# Token shape (set at https://github.com/settings/personal-access-tokens):
+#   - Repository access:  only `ncrmro/keystone`
+#   - Contents:           Read and write   (for git push)
+#   - Pull requests:      Read and write   (gh pr create/list/close)
+#   - Issues:             Read and write   (gh label create — labels live
+#                                            under the Issues API)
+#   - Expiration:         max 366d — rotate annually
 
 on:
   schedule:

--- a/.github/workflows/bump-flake-inputs.yml
+++ b/.github/workflows/bump-flake-inputs.yml
@@ -3,15 +3,19 @@ name: Bump flake inputs
 # Sundays 08:00 UTC: refresh llm-agents (claude-code et al), browser-previews
 # (google-chrome), and nixpkgs (chromium + fleet-wide). Opens a PR with the
 # lock diff; closes last week's PR if still open. Manual merge.
+#
+# Uses secrets.FLAKE_BUMP_TOKEN (a PAT with `repo` scope) rather than the
+# default GITHUB_TOKEN. Two reasons:
+#   1. GITHUB_TOKEN cannot create pull requests unless the org/repo enables
+#      "Allow GitHub Actions to create and approve pull requests" — a setting
+#      that varies between repos. Using a PAT makes this workflow portable.
+#   2. PRs opened by GITHUB_TOKEN do not trigger `pull_request` workflows
+#      (validate.yml). A PAT-opened PR triggers them normally.
 
 on:
   schedule:
     - cron: "0 8 * * 0"
   workflow_dispatch:
-
-permissions:
-  contents: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}
@@ -21,11 +25,12 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.FLAKE_BUMP_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: main
+          token: ${{ secrets.FLAKE_BUMP_TOKEN }}
 
       - uses: cachix/install-nix-action@v31
         with:


### PR DESCRIPTION
## Why

PR #523 landed the workflow but the first run failed at `gh pr create`:

> GitHub Actions is not permitted to create or approve pull requests

That's GitHub's recursive-CI guardrail — `GITHUB_TOKEN` can't create PRs unless the repo has \"Allow GitHub Actions to create and approve pull requests\" enabled. The toggle defaults off and varies between repos. There's also a secondary problem: PRs opened by `GITHUB_TOKEN` don't trigger downstream `pull_request` workflows, so `validate.yml` would never auto-run on the bump PR.

The proper fix is to use a credential GitHub doesn't restrict. PAT is the standard for a personal repo; GitHub App would be the equivalent for an org. This PR takes the PAT path.

## Changes

- `actions/checkout` uses the PAT so the branch push is PAT-credentialed (which is what makes the eventual PR trigger validate).
- `GH_TOKEN` env at job scope uses the PAT for all `gh` calls.
- Removes the now-unused `permissions:` block (GITHUB_TOKEN is no longer used by any step).

## Setup (one-time, after merge)

1. Create a PAT at https://github.com/settings/tokens — scope: `repo`. (Fine-grained alternative: `contents: write` + `pull-requests: write` on `ncrmro/keystone`.)
2. Add as repo secret:
   \`\`\`bash
   gh secret set FLAKE_BUMP_TOKEN --repo ncrmro/keystone
   \`\`\`
3. Trigger manually to verify: \`gh workflow run bump-flake-inputs.yml --ref main --repo ncrmro/keystone\`

## Cleanup
Orphan branch from PR #523's failed run still exists: \`automated/flake-bump-2026-W20-25814475322\`. The next workflow run will close+delete it via the stale-PR step — no action needed, but it can be deleted manually if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)