### PR TITLE
ci(flake-bump): scope PAT to release environment

### DIFF
--- a/.github/workflows/bump-flake-inputs.yml
+++ b/.github/workflows/bump-flake-inputs.yml
@@ -32,6 +32,10 @@ concurrency:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    # `release` env scopes GH_FINEGRANED_CI_TOKEN to workflows running from
+    # main (only branch allowed by the env's deployment policy). PR-authored
+    # workflow files can't pull the secret, since they don't run from main.
+    environment: release
     env:
       GH_TOKEN: ${{ secrets.GH_FINEGRANED_CI_TOKEN }}
     steps:

--- a/.github/workflows/bump-flake-inputs.yml
+++ b/.github/workflows/bump-flake-inputs.yml
@@ -32,9 +32,16 @@ concurrency:
 jobs:
   bump:
     runs-on: ubuntu-latest
-    # `release` env scopes GH_FINEGRANED_CI_TOKEN to workflows running from
-    # main (only branch allowed by the env's deployment policy). PR-authored
-    # workflow files can't pull the secret, since they don't run from main.
+    # Hard-gate to main. The job mutates main's flake.lock and opens a PR
+    # against main — running from another ref is never the intent and would
+    # also fail silently to read GH_FINEGRANED_CI_TOKEN unless that ref is
+    # in the release env's deployment policy. Better to skip with a clear
+    # log line than fail mid-run with empty-token errors.
+    if: github.ref == 'refs/heads/main'
+    # `release` env scopes GH_FINEGRANED_CI_TOKEN to workflows whose ref is
+    # allowed by the env's deployment policy. Combined with the `if:` above,
+    # only scheduled runs and manual dispatches from main can read the PAT —
+    # a PR-authored workflow file can't exfil it.
     environment: release
     env:
       GH_TOKEN: ${{ secrets.GH_FINEGRANED_CI_TOKEN }}


### PR DESCRIPTION
## Summary

Adds \`environment: release\` to the flake-bump job. The PAT
(\`GH_FINEGRANED_CI_TOKEN\`) now lives in the \`release\` environment instead
of at repo scope.

## Security benefit

The \`release\` env's branch policy only allows deployments from \`main\` (and one feature branch). Workflows running on a PR can't access env-scoped secrets unless the PR's branch is on the allowed list — so a malicious PR can't add a workflow file that exfils the PAT. With repo-level secrets, that attack would have worked on the PR's own runs.

## Verified

- \`release\` env has 0 required reviewers (no approval gate that would block the weekly bot).
- \`main\` is in the env's allowed branches.

## After merge
Re-trigger to confirm the env wiring works end-to-end:
\`\`\`
gh workflow run bump-flake-inputs.yml --ref main --repo ncrmro/keystone
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)