### PR TITLE
refactor(overlays): consume llm-agents flake packages directly

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -49,7 +49,6 @@ let
   calendula-flake = calendula;
   cardamum-flake = cardamum;
   comodoro-flake = comodoro;
-  llm-agents-src = llm-agents;
   browser-previews-flake = browser-previews;
   ghostty-flake = ghostty;
   yazi-flake = yazi;
@@ -59,34 +58,6 @@ in
 final: prev:
 let
   system = final.stdenv.hostPlatform.system;
-  llmAgentsPkgs = import prev.path {
-    inherit system;
-    config.allowUnfree = true;
-  };
-  llmAgentsWrapBuddy =
-    llmAgentsPkgs.callPackage "${llm-agents-src}/packages/wrapBuddy/package.nix"
-      { };
-  llmAgentsVersionCheckHomeHook =
-    llmAgentsPkgs.callPackage "${llm-agents-src}/packages/versionCheckHomeHook/default.nix"
-      { };
-  # Required since llm-agents.nix commit 4049025 (2026-04-26): packages like
-  # gemini-cli `inherit (perSystem.self) buildNpmPackage`. Upstream wraps
-  # nixpkgs' buildNpmPackage with an eval-time guard that requires
-  # fetchNpmDeps to support `fetcherVersion = 2`. The guard's failure message
-  # tells you to bump nixpkgs (>= 203662a570c4, 2026-02-15) or switch to
-  # overlays.default / the flake packages directly. Without this attr, the
-  # inherit fails with "attribute 'buildNpmPackage' missing" and blocks every
-  # host build.
-  llmAgentsBuildNpmPackage =
-    llmAgentsPkgs.callPackage "${llm-agents-src}/packages/buildNpmPackage/default.nix"
-      { };
-  llmAgentsPerSystem = {
-    self = {
-      wrapBuddy = llmAgentsWrapBuddy;
-      versionCheckHomeHook = llmAgentsVersionCheckHomeHook;
-      buildNpmPackage = llmAgentsBuildNpmPackage;
-    };
-  };
 in
 {
   # Expose crane library for Rust package builds — auto-resolved by callPackage
@@ -142,43 +113,15 @@ in
         '';
       }
     );
-    # Import only the four upstream agent packages Keystone exposes. Avoid
-    # llm-agents.packages.${system}: unrelated broken upstream packages can make
-    # the whole package set fail evaluation during nixos-install.
-    claude-code = import "${llm-agents-src}/packages/claude-code/default.nix" {
-      pkgs = llmAgentsPkgs;
-      perSystem = llmAgentsPerSystem;
-    };
-    gemini-cli = import "${llm-agents-src}/packages/gemini-cli/default.nix" {
-      pkgs = llmAgentsPkgs;
-      perSystem = llmAgentsPerSystem;
-    };
-    codex =
-      (import "${llm-agents-src}/packages/codex/default.nix" {
-        pkgs = llmAgentsPkgs;
-      }).overrideAttrs
-        (old: {
-          cargoDeps = llmAgentsPkgs.rustPlatform.fetchCargoVendor {
-            inherit (old) src;
-            name = "codex-${old.version}";
-            sourceRoot = "source/codex-rs";
-            hash = "sha256-nXdZrcmI935E5OGZBp0YbkOQFsqKllwdf+HJlvhn4n4=";
-            postBuild = ''
-              # SECURITY: nixpkgs' vendoring helper recursively probes every
-              # Cargo.toml in git dependencies. The rules_rust repo pulled in by
-              # Codex's `runfiles` crate contains many intentionally broken test
-              # and example workspaces, so keep only the standalone runfiles
-              # crate subtree that Codex actually depends on.
-              rules_rust_tree="$out/git/b56cbaa8465e74127f1ea216f813cd377295ad81"
-              find "$rules_rust_tree" -mindepth 1 -maxdepth 1 ! -name rust -exec rm -rf {} +
-              find "$rules_rust_tree/rust" -mindepth 1 -maxdepth 1 ! -name runfiles -exec rm -rf {} +
-            '';
-          };
-        });
-    opencode = import "${llm-agents-src}/packages/opencode/default.nix" {
-      pkgs = llmAgentsPkgs;
-      perSystem = llmAgentsPerSystem;
-    };
+    # Consume llm-agents' own flake outputs rather than re-importing source.
+    # llm-agents owns the package's nixpkgs alignment, helper plumbing
+    # (wrapBuddy, versionCheckHomeHook, buildNpmPackage), and Rust vendor
+    # hashes — keeping those downstream caused recurring drift every time
+    # a Cargo.lock moved upstream.
+    claude-code = llm-agents.packages.${system}.claude-code;
+    gemini-cli = llm-agents.packages.${system}.gemini-cli;
+    codex = llm-agents.packages.${system}.codex;
+    opencode = llm-agents.packages.${system}.opencode;
     # Browsers from browser-previews
     google-chrome = browser-previews-flake.packages.${system}.google-chrome;
     # Desktop tools from flake inputs


### PR DESCRIPTION
## Summary

- Replace the manual source-import block at `overlays/default.nix:148-181` with direct references to `llm-agents.packages.${system}.<name>` for `claude-code`, `gemini-cli`, `codex`, `opencode`.
- Drop the codex `cargoDeps` override — upstream's `cargoHash` vendors cleanly against keystone's current nixpkgs; the `rules_rust` trim added downstream is no longer needed.
- Remove now-dead helper plumbing: `llmAgentsPkgs` (separate nixpkgs instance), `llmAgentsPerSystem` (blueprint shim), and the three callPackaged-from-source helpers (`wrapBuddy`, `versionCheckHomeHook`, `buildNpmPackage`).
- Drop the `llm-agents-src` local binding; the overlay's `llm-agents` argument is now referenced directly.

Net change: `overlays/default.nix` **+9 / −66**.

## Why

Vendor-hash ownership for codex was downstream, which meant every llm-agents bump that touched its `Cargo.lock` invalidated keystone's pinned hash and broke release runs. The 2026-05-14 release outage (`codex-0.130.0-vendor-staging.drv hash mismatch`) was a direct symptom — the codex hash bump in `a74305df` patched today's failure but the recurring tax would have continued on every llm-agents bump.

The inline comment at the old `overlays/default.nix:72-79` actually documented upstream's own guidance ("switch to overlays.default / the flake packages directly") as the way out. This PR takes that path.

The "Avoid `llm-agents.packages.${system}`" warning at the old lines 116-118 also turns out to be stale — current llm-agents is lazy enough that selecting individual packages does not force evaluation of broken siblings. Confirmed by a clean `nix eval` of all four drvPaths.

## Test plan

- [x] `nix eval` resolves `claude-code`, `gemini-cli`, `codex`, `opencode` derivation paths cleanly through the new overlay.
- [x] `nix build` of `claude-code` + `gemini-cli` + `opencode` succeeds (cache-substituted from `cache.nixos.org` / `ks-systems`, with small local npm-hook builds).
- [x] `nix build` of `codex` succeeds end-to-end: passes `vendor-staging.drv` (the stage that previously failed with hash mismatch), full cargo compile, and produces `/nix/store/idhkwl20086bqfas3rwwgxqykxz3z7cx-codex-0.130.0/bin/codex`.
- [ ] CI warm-cache exercises all four package builds end-to-end on a clean runner.

## Follow-up notes

- Commit `a74305df` (`fix(overlays/codex): bump cargoDeps vendor hash after upstream drift`) becomes vestigial after this PR — the override that needed the hash bump is deleted. The commit doesn't need reverting; the deletion of the override subsumes its effect.
- The `pkgs.keystone.{claude-code, gemini-cli, codex, opencode}` attribute paths are unchanged for consumers (`modules/terminal/ai.nix` and downstream) — only the right-hand-side construction changes.