### PR TITLE
fix(ks): gate Linux-only runtime deps for darwin compatibility

### DIFF
--- a/packages/ks/default.nix
+++ b/packages/ks/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   craneLib,
   pkg-config,
   openssl,
@@ -53,22 +54,26 @@ let
 
   cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
-  runtimePath = lib.makeBinPath [
-    bash
-    coreutils
-    cups
-    fzf
-    git
-    glow
-    hostname
-    nix
-    openssh
-    pandoc
-    polkit
-    sudo
-    systemd
-    python3Packages.weasyprint
-  ];
+  runtimePath = lib.makeBinPath (
+    [
+      bash
+      coreutils
+      fzf
+      git
+      glow
+      hostname
+      nix
+      openssh
+      pandoc
+      python3Packages.weasyprint
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      cups
+      polkit
+      sudo
+      systemd
+    ]
+  );
 
   package = craneLib.buildPackage (
     commonArgs


### PR DESCRIPTION
## Summary

- Gate `polkit`, `cups`, `sudo`, and `systemd` in `packages/ks/default.nix` behind `stdenv.hostPlatform.isLinux` so the `ks` package evaluates on aarch64-darwin.
- Unblocks `home-manager switch` for darwin hosts that import `keystone.homeModules.terminal` (`nicholas@unsup-macbook`, `ncrmro@ncrmro-macbook`).
- Targeting rc.4.

Closes #537

## Verification

- `nix build .#ks` on x86_64-linux: ✅ builds successfully (runtime PATH unchanged on Linux).
- `nix eval` of `keystone.ks.drvPath` on `aarch64-darwin` (with `allowUnsupportedSystem`): ✅ now yields a valid derivation path. Previously failed at eval with `Refusing to evaluate package 'polkit-127' ... aarch64-darwin`.

## Test plan

- [x] `nix build .#ks` succeeds on linux
- [x] aarch64-darwin evaluation returns a `.drv` without polkit refusal
- [ ] Confirm `home-manager switch` succeeds on `nicholas@unsup-macbook` / `ncrmro@ncrmro-macbook`
- [ ] CI green (`check-ks`, `check-eval`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)