### PR TITLE
refactor(requirements): rename "Build + Burn ISO" stage to "OS Installer"

### DIFF
--- a/packages/ks/requirements/REQ-008-onboarding-journey.md
+++ b/packages/ks/requirements/REQ-008-onboarding-journey.md
@@ -15,7 +15,7 @@ The onboarding journey has seven stages across two machines:
 |-------|-------|---------|-------------|
 | 1 | Dev machine | Template | Generate NixOS config from user info |
 | 2 | Dev machine | Publish | Git init + push to GitHub |
-| 3 | Dev machine | Installer | Build ISO + burn to USB |
+| 3 | Dev machine | Installer | OS installer (build ISO + write to USB) |
 | 4 | Target machine | Install (ISO) | Disk setup + nixos-install + hardware capture + local commit |
 | 5 | Target machine | First Boot | Secure Boot + TPM enrollment |
 | 6 | Target machine | Security | SSH keys + push + secrets |
@@ -49,7 +49,7 @@ via `gh repo create` and push the initial commit.
 **REQ-008.7** The TUI MUST warn the user if `initialPassword` is present
 in plaintext before pushing.
 
-## Stage 3: Build + Burn ISO
+## Stage 3: OS Installer
 
 **REQ-008.8** The Installer sidebar section MUST allow the user to select
 a host and install profile (Desktop or Server).

--- a/packages/ks/requirements/REQUIREMENTS.md
+++ b/packages/ks/requirements/REQUIREMENTS.md
@@ -17,6 +17,7 @@
   automated validation contract for generated configs and ISO artifacts.
   Establishes what the TUI must produce and how that output is validated.
 - **Phase 2**: Interactive TUI, CLI subcommands with JSON I/O, template
-  scaffolding, git/GitHub publishing, ISO build + burn. Builds on Phase 1.
+  scaffolding, git/GitHub publishing, OS installer (ISO build + USB
+  write). Builds on Phase 1.
 - **Phase 3**: Remote connection, mDNS discovery, nixos-anywhere deployment,
   first-boot security enrollment, secrets + services onboarding.


### PR DESCRIPTION
## Summary

The Stage 3 heading and adjacent description in REQ-008 used "Build + Burn ISO" naming. That describes the mechanics (ISO build + USB burn) rather than the user-facing concept — an OS installer the user creates and uses to provision a new machine.

Renames the stage to **OS Installer**, matching:
- The Rust component already named `packages/ks/src/components/installer/`
- The TUI sidebar section already called "Installer"

## Files changed

| File | Change |
|---|---|
| `packages/ks/requirements/REQ-008-onboarding-journey.md` | Stage 3 heading: `## Stage 3: Build + Burn ISO` → `## Stage 3: OS Installer`. Overview-table cell: `Build ISO + burn to USB` → `OS installer (build ISO + write to USB)`. |
| `packages/ks/requirements/REQUIREMENTS.md` | Phase 2 prose mention: `ISO build + burn` → `OS installer (ISO build + USB write)`. |

## Out of scope

Other "build ISO" references keep their literal phrasing — they describe specific build mechanics, not the onboarding stage:

- `nix build .#iso` (the actual Nix invocation)
- TUI screen names `Build` and `Iso` in `packages/ks/specs/004-tui-app-framework.md`
- Release-pipeline mentions in `releases/0.1.0/*`
- Spec docs like `specs/_archive/*` (archived, not live)

## Test plan

- [ ] `rg 'Build \+ Burn|build \+ burn' packages/ks/requirements/` returns no matches
- [ ] `rg 'OS [Ii]nstaller' packages/ks/requirements/` finds the renamed references

🤖 Generated with [Claude Code](https://claude.com/claude-code)