### PR TITLE
feat(terminal): GitHub PAT standard (keystone.terminal.github)

### DIFF
--- a/conventions/tool.github-pats.md
+++ b/conventions/tool.github-pats.md
@@ -1,0 +1,129 @@
+# Convention: GitHub Personal Access Tokens (tool.github-pats)
+
+Standards for managing GitHub Personal Access Tokens (PATs) on keystone hosts.
+Two distinct tokens MUST be used, scoped to two distinct call sites: an
+interactive user PAT and an agents PAT. Sharing one token across both blurs
+audit trails and grants agents more than they need.
+
+## Purpose
+
+1. The user PAT MUST authenticate interactive `gh`, `git` over HTTPS, and any
+   tool that reads `GITHUB_TOKEN` or `GH_TOKEN` from the environment.
+2. The user PAT MUST also be the credential used for `ghcr.io` container
+   registry login.
+3. The agents PAT MUST be used only by autonomous agent flows that open pull
+   requests, fetch repos, or comment on issues. It MUST NOT be exported as
+   `GITHUB_TOKEN` in interactive shells.
+4. The user PAT and the agents PAT MUST be distinct GitHub tokens with
+   distinct scopes — they MUST NOT alias to the same token value.
+
+## The user PAT
+
+5. The secret name MUST follow the user-home naming convention
+   `${username}-github-token` (e.g. `ncrmro-github-token`). See CLAUDE.md
+   secret-class rules 22-28.
+6. The recipient set MUST include every system where the user's home-manager
+   profile is installed (rule 26).
+7. The agenix file MUST be declared with `owner = <username>; mode = "0400";`
+   so the daemon makes it readable only to the owning user.
+8. Recommended scopes (fine-grained PAT, preferred):
+   - `contents`: Read and write
+   - `pull_requests`: Read and write
+   - `issues`: Read and write
+   - `packages`: Read and write (required for `ghcr.io` push)
+   - `metadata`: Read
+   - `workflow`: Read and write (only if the user edits Actions YAML)
+9. Recommended scopes (classic PAT, fallback for org features fine-grained
+   PATs do not yet cover):
+   - `repo`
+   - `read:org`
+   - `read:packages`, `write:packages`
+   - `workflow` (optional)
+   - `admin:ssh_signing_key` (only when bootstrapping SSH signing per
+     `tool.github` rules 11, 18)
+10. The user PAT MUST NOT include `delete_repo`, `admin:org`, or
+    `admin:enterprise` scopes.
+
+## The agents PAT
+
+11. The secret name SHOULD be `github-agents-token` for a single-owner fleet,
+    or `${owner}-github-agents-token` for multi-owner fleets where multiple
+    GitHub accounts run agents on the same host.
+12. The recipient set MUST include every system that runs agents under this
+    GitHub identity. It MAY be broader than the user PAT recipient set when
+    agents run on hosts where the human does not log in interactively.
+13. The agenix file MUST be declared with `owner = <user-the-agent-runs-as>;
+    mode = "0400";`.
+14. Recommended scopes (fine-grained PAT):
+    - `contents`: Read
+    - `pull_requests`: Read and write
+    - `issues`: Read and write
+    - `metadata`: Read
+15. The agents PAT MUST NOT include `packages`, `workflow`, `admin:*`,
+    `delete_repo`, or `write` on `contents`.
+16. When an agent needs write access to a specific repo, the fine-grained PAT
+    SHOULD be scoped to that repo via the resource selector rather than
+    granted org-wide.
+
+## Adopter contract
+
+17. The adopter MUST encrypt each token in its agenix-secrets repo. Keystone
+    does not ship the `.age` files — they live in the adopter's private
+    secrets repo.
+18. The adopter MUST declare `age.secrets.<name>` on every host listed as a
+    recipient, matching the owner/mode rules above.
+19. The adopter MUST enable the keystone module in the user's home-manager
+    profile:
+    ```nix
+    keystone.terminal.github = {
+      enable = true;
+      username = "<github-username>";
+      # userTokenFile defaults to /run/agenix/<username>-github-token
+      agentsTokenFile = "/run/agenix/github-agents-token";  # optional
+    };
+    ```
+20. The module exports `GITHUB_TOKEN` and `GH_TOKEN` at shell startup by
+    reading `userTokenFile` at runtime. If the file is not readable, the
+    shell continues without setting the variables — the module never fails
+    the shell on missing credentials.
+21. When `agentsTokenFile` is set, the module exports
+    `GITHUB_AGENTS_TOKEN_FILE` (the path, not the value). Agents MUST read
+    this file explicitly; the token value MUST NOT be exposed as
+    `GITHUB_TOKEN`.
+
+## ghcr.io usage
+
+22. The module installs a `ghcr-login` shell function. To authenticate to the
+    registry:
+    ```
+    ghcr-login
+    podman pull ghcr.io/<owner>/<image>:<tag>
+    ```
+23. `ghcr-login` MUST use `--password-stdin` — never pass the token via argv
+    or environment, since both leak through `ps` and shell history.
+24. The helper writes credentials to the runtime's standard auth file
+    (`~/.config/containers/auth.json` for podman, `~/.docker/config.json` for
+    docker). Keystone MUST NOT manage this file declaratively because the
+    runtime writes other registries into the same file.
+25. To log out, use the runtime's native command:
+    `podman logout ghcr.io` or `docker logout ghcr.io`.
+
+## Non-uses
+
+26. The user PAT MUST NOT be placed in `nix.settings.access-tokens`. The
+    nix-daemon runs as root and cannot read a `mode 0400 owner=<user>` file;
+    even if it could, daemon-level access requires its own os-level secret
+    with a recipient set that includes every host that fetches flake inputs.
+    See `tool.nix` for the os-level access-tokens convention (TODO).
+27. Neither token MUST be baked into CI runner images or container images.
+28. Neither token MUST be written to a long-lived disk location outside the
+    agenix runtime (e.g. `~/.config/gh/hosts.yml`). The module deliberately
+    does not run `gh auth login --with-token` for this reason — `gh` reads
+    `GH_TOKEN` from env, which is sufficient.
+
+## See also
+
+- `tool.github` — device-flow auth, SSH key sync, commit signing.
+- `tool.bitwarden` — model for the agenix runtime path convention.
+- CLAUDE.md secret-class rules 22-31 — user-home vs. os-level vs. service
+  secret classes and recipient discipline.

--- a/conventions/tool.github.md
+++ b/conventions/tool.github.md
@@ -38,10 +38,18 @@
 22. Built-in project workflows (Item closed → Done, PR merged → Done) handle Done transitions automatically — agents MUST NOT duplicate these.
 23. See `process.project-board` for full board lifecycle and CLI reference.
 
+## Personal Access Tokens
+
+For PATs (interactive user tokens and agent tokens — including the
+`GITHUB_TOKEN` env var, ghcr.io login, and the keystone two-PAT model), see
+`tool.github-pats`. Device-flow auth above is the bootstrap path; PATs cover
+the steady state.
+
 ## See Also
 
 - For internal Forgejo repos (git.ncrmro.com), use `tool.forgejo` instead of this convention.
 - `gh` is used only for public GitHub repos.
+- `tool.github-pats` for personal access token standards.
 
 ## Issue Comments
 

--- a/modules/terminal/default.nix
+++ b/modules/terminal/default.nix
@@ -53,6 +53,7 @@ in
     ./secrets.nix
     ./ssh-auto-load.nix
     ./forgejo.nix
+    ./github.nix
     ./grafana.nix
     ./projects.nix
     ./cli-coding-agent-configs.nix

--- a/modules/terminal/github.nix
+++ b/modules/terminal/github.nix
@@ -1,0 +1,125 @@
+# Keystone Terminal — GitHub PATs
+#
+# Provides a two-PAT model for GitHub authentication:
+#   - User PAT: broad-scope interactive token. Exported as GITHUB_TOKEN /
+#     GH_TOKEN at shell startup so `gh`, `git`, and any tool that reads these
+#     env vars work without manual `gh auth login`. Also consumed by the
+#     `ghcr-login` helper for ghcr.io registry login.
+#   - Agents PAT: narrower-scope token used by autonomous agent flows. The
+#     token value is NEVER exported as GITHUB_TOKEN — only the file path is
+#     exported as GITHUB_AGENTS_TOKEN_FILE so agent harnesses load it
+#     explicitly.
+#
+# Adopter contract:
+#   - Declare age.secrets entries for each token on every host where the
+#     home-manager user runs.
+#   - Set userTokenFile / agentsTokenFile to the decrypted runtime paths.
+#   - See conventions/tool.github-pats.md for scopes, naming, and recipients.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  cfg = config.keystone.terminal;
+  ghCfg = cfg.github;
+
+  userTokenInit = ''
+    if [ -r "${ghCfg.userTokenFile}" ]; then
+      GITHUB_TOKEN="$(tr -d '\n' < "${ghCfg.userTokenFile}")"
+      export GITHUB_TOKEN
+      export GH_TOKEN="$GITHUB_TOKEN"
+    fi
+  '';
+
+  ghcrLoginFn = ''
+    ghcr-login() {
+      local file="${ghCfg.userTokenFile}"
+      if [ ! -r "$file" ]; then
+        echo "ghcr-login: token file not readable: $file" >&2
+        return 1
+      fi
+      local cli
+      if command -v podman >/dev/null 2>&1; then
+        cli=podman
+      elif command -v docker >/dev/null 2>&1; then
+        cli=docker
+      else
+        echo "ghcr-login: neither podman nor docker found on PATH" >&2
+        return 1
+      fi
+      tr -d '\n' < "$file" | "$cli" login ghcr.io -u "${toString ghCfg.username}" --password-stdin
+    }
+  '';
+
+  shellInit = userTokenInit + optionalString ghCfg.ghcrLoginHelper ghcrLoginFn;
+in
+{
+  options.keystone.terminal.github = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable keystone GitHub PAT wiring (env vars + ghcr-login helper).";
+    };
+
+    username = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "ncrmro";
+      description = "GitHub username. Required when enable is true (used by ghcr-login).";
+    };
+
+    userTokenFile = mkOption {
+      type = types.str;
+      default = if ghCfg.username == null then "" else "/run/agenix/${ghCfg.username}-github-token";
+      defaultText = literalExpression ''"/run/agenix/''${cfg.github.username}-github-token"'';
+      description = ''
+        Path to the decrypted user PAT (broad scope). The keystone module reads
+        this file at shell startup and exports GITHUB_TOKEN/GH_TOKEN. The
+        adopter is responsible for declaring an age.secrets entry that
+        produces this file with owner=<user> mode=0400.
+      '';
+    };
+
+    agentsTokenFile = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "/run/agenix/github-agents-token";
+      description = ''
+        Path to the decrypted agents PAT (narrow scope). When set,
+        GITHUB_AGENTS_TOKEN_FILE is exported pointing at this path. The token
+        value is never exported as GITHUB_TOKEN — agents must read the file
+        explicitly so the broader user PAT remains the only ambient
+        credential.
+      '';
+    };
+
+    ghcrLoginHelper = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Install the `ghcr-login` shell function (uses podman, falls back to docker).";
+    };
+  };
+
+  config = mkIf (cfg.enable && ghCfg.enable) {
+    assertions = [
+      {
+        assertion = ghCfg.username != null;
+        message = "keystone.terminal.github.username must be set when keystone.terminal.github.enable is true";
+      }
+      {
+        assertion = ghCfg.userTokenFile != "";
+        message = "keystone.terminal.github.userTokenFile must be set (or set username so the default resolves)";
+      }
+    ];
+
+    programs.zsh.initExtra = shellInit;
+    programs.bash.initExtra = shellInit;
+
+    home.sessionVariables = optionalAttrs (ghCfg.agentsTokenFile != null) {
+      GITHUB_AGENTS_TOKEN_FILE = ghCfg.agentsTokenFile;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- New keystone home-manager module `keystone.terminal.github` exposing a two-PAT model: a broad-scope user PAT exported as `GITHUB_TOKEN`/`GH_TOKEN` for interactive `gh`/`git`/ghcr.io use, and a narrow-scope agents PAT exposed only by file-path via `GITHUB_AGENTS_TOKEN_FILE`.
- `ghcr-login` shell helper that authenticates to ghcr.io via `--password-stdin` (podman, falling back to docker) so the token never appears in argv or shell history.
- New `tool.github-pats` convention defining naming (`${username}-github-token`, `github-agents-token`), recommended scopes (fine-grained + classic), recipient discipline, and adopter contract. Existing `tool.github` device-flow doc cross-references it for the steady-state path.

## Motivation

Keystone had no standard for GitHub PATs. The `github-agents-token.age` secret existed in private agenix-secrets but was declared-and-unused across the fleet. Adopters needed a portable, agnostic way to wire two distinct GitHub credentials (interactive vs. agent) into home-manager without each consumer reinventing shell init, naming, and registry-login plumbing.

## Adopter contract

The module is agnostic to the source of `.age` files (mirrors the `modules/binary-cache-client.nix` `tokenFile` pattern). Adopters:

1. Encrypt PATs in their own agenix-secrets repo with recipients = adminKeys + every host where the user runs.
2. Declare `age.secrets.<name>` per host with `owner=<user>` `mode=0400`.
3. Enable:
   ```nix
   keystone.terminal.github = {
     enable = true;
     username = "<github-username>";
     agentsTokenFile = "/run/agenix/github-agents-token";  # optional
   };
   ```

## Out of scope (follow-ups)

- Os-level `nix.settings.access-tokens` secret to fix the anonymous-flake rate-limit (root-owned, different recipient set — separate convention).
- nixos-config adopter PR consuming this module on `workstation` + `ncrmro-laptop`.

## Test plan

- [x] `nix flake check` passes on the worktree (exit 0; remaining stderr lines are binary-cache misses, not failures).
- [x] `nix-instantiate --parse` on `modules/terminal/github.nix` and `modules/terminal/default.nix` succeed.
- [ ] After consumer adopts: `echo $GH_TOKEN | head -c 4` in a fresh shell shows the first chars of the decrypted user PAT.
- [ ] After consumer adopts: `gh auth status` reports authenticated via `GH_TOKEN` env.
- [ ] After consumer adopts: `ghcr-login && podman pull ghcr.io/<owner>/<private-image>:latest` succeeds.
- [ ] After consumer adopts: `set | grep -i github` shows `GITHUB_TOKEN`/`GH_TOKEN`/`GITHUB_AGENTS_TOKEN_FILE` exported, but `GITHUB_AGENTS_TOKEN` is **not** in the environment.
- [ ] After consumer adopts: `ps auxww` during `ghcr-login` shows no token in argv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)