### PR TITLE
docs(terminal): address post-merge Copilot review on PR #542

### DIFF
--- a/conventions/tool.cli-coding-agents.md
+++ b/conventions/tool.cli-coding-agents.md
@@ -199,8 +199,12 @@ discovery paths; they are reference material keystone reads itself.
 `<consumer-flake>/agents/_shared/skills.yaml` is an **optional** user-authored
 file with the same flat-map schema as `conventions/archetypes.yaml.skills` in
 the keystone repo. When present, `ks sync-agent-assets` merges it on top of
-the keystone defaults: user keys win wholesale (no field-level merge). Keys
-only in the user file are emitted as new skills.
+the keystone defaults using jq's recursive merge operator (`*`): explicit
+user fields override keystone fields per-field, missing user fields fall
+back to keystone defaults, and keys only in the user file are emitted as
+new skills. Overriding just `description` on a built-in skill preserves
+the keystone-shipped `template:` and `colocated_conventions:`/`colocated_roles:`
+automatically.
 
 ```yaml
 skills:

--- a/modules/terminal/agents/extensions.nix
+++ b/modules/terminal/agents/extensions.nix
@@ -4,7 +4,7 @@
 #   - `resolvedCapabilities` — capability set after merging base/archetype/explicit
 #   - `publishedCommands`    — list of slash-command ids for this host
 #
-# Both are surfaced as internal options that `generated-agent-assets.nix`
+# Both are surfaced as internal options that `modules/terminal/agents/assets.nix`
 # reads when writing `~/.config/keystone/agent-assets.json`. The actual
 # rendering of skill content, instruction files, and Claude subagents is
 # done by `modules/terminal/agents/keystone-sync-agent-assets.sh`, which
@@ -95,7 +95,7 @@ in
       type = types.listOf capabilityType;
       default = [ ];
       internal = true;
-      description = "Resolved capability set used to generate `/ks` and `/ks-dev`.";
+      description = "Resolved capability set used to generate hyphenated slash commands like `/ks-system`, `/ks-engineer`, and (in dev mode) `/ks-dev`.";
     };
 
     publishedCommands = mkOption {

--- a/modules/terminal/agents/keystone-sync-agent-assets.sh
+++ b/modules/terminal/agents/keystone-sync-agent-assets.sh
@@ -42,8 +42,10 @@ spec-compliant naming makes one canonical tree sufficient for every agent.
 
 The merged skill map is built from conventions/archetypes.yaml.skills
 (keystone defaults) plus an optional <consumer-flake>/agents/_shared/skills.yaml
-(user overrides, wholesale-replace on key conflict). See
-docs/research/agent-skills.md for the standard.
+(user overrides). The merge is field-level via jq's recursive merge operator
+(`*`): explicit user fields override keystone fields, missing user fields
+fall back to keystone defaults, and keys only in the user file are emitted
+as new skills. See docs/research/agent-skills.md for the standard.
 EOF
 }
 
@@ -64,7 +66,7 @@ fi
 #   3. Manifest's eval-time consumerFlakeAgents value (Nix-eval fallback)
 # The runtime pointer is a *regular file* written by modules/shared/system-flake.nix
 # containing the path as text — not a symlink — so read with `read`, not
-# `readlink`. The activation in generated-agent-assets.nix uses the same pattern.
+# `readlink`. The activation in modules/terminal/agents/assets.nix uses the same pattern.
 consumer_flake_root="${KEYSTONE_CONSUMER_FLAKE:-}"
 if [[ -z "$consumer_flake_root" && -f /run/current-system/keystone-system-flake ]]; then
   IFS= read -r consumer_flake_root < /run/current-system/keystone-system-flake || consumer_flake_root=""

--- a/tests/update-native-cli-agent-preview.sh
+++ b/tests/update-native-cli-agent-preview.sh
@@ -17,16 +17,17 @@ cat > "$manifest_path" <<EOF
   "repoCheckout": "$repo_root",
   "archetype": "keystone-system-host",
   "resolvedCapabilities": ["ks", "assistant", "project", "engineer", "product", "project-manager"],
-  "publishedCommands": ["ks.system", "ks.assistant", "ks.projects", "ks.engineer", "ks.product", "ks.project-manager"],
+  "publishedCommands": ["ks-system", "ks-assistant", "ks-projects", "ks-engineer", "ks-product", "ks-project-manager"],
   "repos": ["ncrmro/keystone"],
-  "agents": {}
+  "agents": {},
+  "consumerFlakeAgents": "$output_root/agents"
 }
 EOF
 
 rm -rf "$output_root"
 mkdir -p "$output_root"
 
-HOME="$output_root" KEYSTONE_AGENT_ASSETS_MANIFEST="$manifest_path" \
+HOME="$output_root" KEYSTONE_CONSUMER_FLAKE="$output_root" KEYSTONE_AGENT_ASSETS_MANIFEST="$manifest_path" \
   bash "$repo_root/modules/terminal/agents/keystone-sync-agent-assets.sh"
 
 # Restore the gitignore after the sync script wipes output_root.


### PR DESCRIPTION
## Summary

Six doc/comment fixes from the third [Copilot review on PR #542](https://github.com/ncrmro/keystone/pull/542#pullrequestreview-4330658209), submitted after the PR merged to main. All are accuracy fixes — no behavior change except the test-fixture update which actually exercises the sync script against the new naming.

## Fixes

| Path | Issue | Fix |
|---|---|---|
| `tests/update-native-cli-agent-preview.sh` | Fixture manifest used dotted command IDs (`ks.system`); invocation missing `KEYSTONE_CONSUMER_FLAKE` | Updated to hyphenated IDs (`ks-system`, …), added `consumerFlakeAgents` to manifest, passed `KEYSTONE_CONSUMER_FLAKE` |
| `conventions/tool.cli-coding-agents.md` § Skill schema | Said overrides were "wholesale (no field-level merge)" | Reworded to describe the actual field-level merge via jq `*`; called out that overriding just `description` preserves keystone's `template:` and colocation lists |
| `modules/terminal/agents/keystone-sync-agent-assets.sh` usage text | Same "wholesale-replace" claim | Same reword |
| `modules/terminal/agents/keystone-sync-agent-assets.sh` comment | Referenced `generated-agent-assets.nix` (renamed during consolidation) | Updated to `modules/terminal/agents/assets.nix` |
| `modules/terminal/agents/extensions.nix` module header | Same stale `generated-agent-assets.nix` reference | Same update |
| `modules/terminal/agents/extensions.nix` `resolvedCapabilities` description | Said "`/ks` and `/ks-dev`" — out of date after spec adoption renamed slash commands to hyphenated | Reworded to mention `/ks-system`, `/ks-engineer`, `/ks-dev` |

## Test plan

- [ ] CI eval passes
- [ ] `bash tests/update-native-cli-agent-preview.sh` runs to completion (the test fixture changes are exercised here)
- [ ] Review the doc wording in `tool.cli-coding-agents.md` § Skill schema for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)