### PR TITLE
feat(agents): minimal cross-tool task-loop module + new-layout docs

### DIFF
--- a/conventions/process.agent-cronjobs.md
+++ b/conventions/process.agent-cronjobs.md
@@ -1,106 +1,44 @@
 ## Agent Cronjobs
 
-**Status:** MUST follow (RFC 2119)
+**Status:** SHOULD follow (RFC 2119)
 
 ## Overview
 
-Every OS agent provisioned via `keystone.os.agents.<name>` receives three systemd user timers that run automatically via lingering. These timers are defined in `.submodules/keystone/modules/os/agents.nix`.
+Each OS agent receives a single systemd user timer:
+`agent-<name>-task-loop`. The previous multi-timer arrangement
+(`notes-sync`, `scheduler`, multi-phase `task-loop`) has been removed.
 
-## Timers
+The timer fires on `OnCalendar = keystone.os.agents.<name>.taskLoop.interval`
+(default `*:0/15`) and execs the agent's CLI of choice
+(`claude` / `codex` / `gemini`) with a named skill. The skill — plain
+markdown under `~/.agents/skills/<skill>/SKILL.md` — drives all behavior.
+The systemd service holds no state and does no pre-fetch, retry, or
+backoff; the skill is responsible for being cheap when there is no work.
 
-| Timer      | Unit Name                 | Default Schedule              | Purpose                                          |
-| ---------- | ------------------------- | ----------------------------- | ------------------------------------------------ |
-| Notes Sync | `agent-{name}-notes-sync` | `*:0/5` (every 5 min)         | Git fetch/commit/push for the agent's notes repo |
-| Task Loop  | `agent-{name}-task-loop`  | `*:0/5` (every 5 min)         | Autonomous work execution cycle                  |
-| Scheduler  | `agent-{name}-scheduler`  | `*-*-* 05:00:00` (daily 5 AM) | Reads `SCHEDULES.yaml`, creates due tasks        |
-
-All timers use:
-
-- `wantedBy = [ "default.target" ]` — auto-start with user session (lingering)
-- `ConditionUser = agent-{name}` — only runs as the correct agent user
-- `Persistent = true` — catches up if the system was offline during a scheduled run
-
-## NixOS Configuration
+## Configuration
 
 ```nix
 keystone.os.agents.luce = {
-  notes = {
-    syncOnCalendar = "*:0/5";              # Every 5 minutes
-    taskLoop.onCalendar = "*:0/5";         # Every 5 minutes
-    taskLoop.maxTasks = 5;                 # Max pending tasks per run
-    scheduler.onCalendar = "*-*-* 05:00:00"; # Daily at 5 AM
+  taskLoop = {
+    enable = true;
+    tool = "claude";       # one of: claude, codex, gemini
+    interval = "*:0/15";   # systemd OnCalendar expression
+    skill = "task-loop";   # skill name under ~/.agents/skills/<skill>/
   };
 };
 ```
 
-Schedules use [systemd calendar syntax](https://www.freedesktop.org/software/systemd/man/systemd.time.html#Calendar%20Events).
-
-## Notes Sync (`agent-{name}-notes-sync`)
-
-- Runs `repo-sync` package: clone-if-absent, fetch, commit changes with `"vault sync"` prefix, rebase, push
-- Environment: `SSH_AUTH_SOCK` from the agent's SSH agent socket
-- Logs to `~/.local/state/notes-sync/logs/`
-
-## Task Loop (`agent-{name}-task-loop`)
-
-Five-phase cycle:
-
-1. **Pre-fetch** — Sync external sources (Forgejo issues, email) into the agent home
-2. **Ingest** — Parse new items into `TASKS.yaml`
-3. **Prioritize** — Rank pending tasks
-4. **Execute** — Run up to `maxTasks` pending tasks (invokes Claude Code per task)
-5. **Commit** — Push results back
-
-Key properties:
-
-- `TimeoutStartSec = "1h"` — long timeout for LLM-driven tasks
-- Uses `flock` for concurrency prevention (skips if already running)
-- Honors a pause marker at `~/.local/state/agent-task-loop/state/paused`
-- When paused, scheduled runs exit before pre-fetch and execution work
-- Structured logging with `[step=X]` and `[task=Y]` tags
-- State in `~/.local/state/agent-task-loop/state/`
-- Logs in `~/.local/state/agent-task-loop/logs/`
-- Per-task logs in `~/.local/state/agent-task-loop/logs/tasks/`
-- `SyslogIdentifier = agent-{name}-task-loop`
-
-## Scheduler (`agent-{name}-scheduler`)
-
-- Pure bash, no LLM invocation
-- Reads `SCHEDULES.yaml` from the agent's home directory
-- Creates tasks in `TASKS.yaml` when schedule conditions match (day-of-week, day-of-month, date)
-- Logs to `~/.local/state/agent-scheduler/logs/`
-- `SyslogIdentifier = agent-{name}-scheduler`
-
-## Monitoring & Debugging
+## Debugging
 
 ```bash
-# Check timer status
-agentctl luce status agent-luce-notes-sync
-agentctl luce status agent-luce-task-loop
-agentctl luce status agent-luce-scheduler
-
-# View logs
-agentctl luce journalctl -u agent-luce-task-loop -n 50
-agentctl luce journalctl -u agent-luce-scheduler -n 20
-
-# Manually trigger
-agentctl luce start agent-luce-task-loop
-
-# Pause or resume the loop without disabling timers
-agentctl luce pause "waiting for human input"
-agentctl luce paused
-agentctl luce resume
-ks agents pause all "human focus block"
+agentctl <name> status agent-<name>-task-loop
+agentctl <name> journalctl -u agent-<name>-task-loop -n 50
+agentctl <name> start agent-<name>-task-loop   # manual fire
 ```
 
-For fleet-wide journal queries across all hosts, see `tool.journal-remote`.
+## See also
 
-Alloy/Loki integration extracts `[step=X]` labels from structured log tags for observability dashboards.
-
-## Source Reference
-
-- Timer/service definitions: `keystone/modules/os/agents.nix` (lines 2082–2190)
-- Option definitions: `keystone/modules/os/agents.nix` (lines 287–313)
-- Task loop script: `keystone/modules/os/agents.nix` (lines 489–720)
-- Scheduler script: `keystone/modules/os/agents.nix` (lines 721–843)
-- Spec: `keystone/specs/007-os-agents/spec.md` (FR-010)
+- [docs/agents/os-agents.md](../docs/agents/os-agents.md) — new layout
+  and `taskLoop` option reference.
+- `process.task-tracking` — how task state files live in the consumer
+  flake and arrive in the agent home via symlinks.

--- a/conventions/process.task-tracking.md
+++ b/conventions/process.task-tracking.md
@@ -1,34 +1,34 @@
 ## Task Tracking
 
+**Status:** SHOULD follow (RFC 2119)
+
 ## TASKS.yaml
 
-1. All tasks MUST be tracked in `TASKS.yaml` at the agent-space root.
-2. `TASKS.yaml` MUST be checked for current and historical task context before starting work. See `process.vcs-context-continuity` for standards on public state tracking on Issues/PRs.
-3. Task status MUST be updated to `completed` when done.
-4. Task names MUST be descriptive slugs (e.g., `daily-priorities-2026-03-12`).
-5. Tasks MUST include `source` and `source_ref` to trace where they came from.
+Each agent's runtime state lives in three YAML files in its home
+directory: `TASKS.yaml`, `SCHEDULES.yaml`, `ISSUES.yaml`. They are
+**symlinks** into the consumer flake (e.g. `nixos-config/agents/<name>/`)
+and the source files there are gitignored. Mutations made by a running
+agent persist on the deployed host but never travel back into the
+operator's repository.
 
-## Schema
+The schema below is what the `task-loop` skill is expected to read and
+write. Skill implementations MAY add fields, but the listed ones are the
+shared minimum.
 
 ```yaml
 tasks:
   - name: "slug-style-task-name"
     description: "What the task involves"
     status: pending | completed
-    source: email | schedule # where the task originated
-    source_ref: "email-23-..." # reference to the source
-    workflow: "job/workflow" # deepwork workflow used (if any)
-    project: "project-name" # which project this relates to
-    profile: fast | medium | max # semantic model profile override
-    provider: claude | gemini | codex
-    model: "provider-specific-model"
-    fallback_model: "provider-specific-model"
-    effort: low | medium | high | max
-    needs: ["other-task-name"] # task dependencies (if any)
+    source: email | schedule | issue # where the task originated
+    source_ref: "email-23-..."       # reference to the source
+    project: "project-name"          # which project this relates to
+    needs: ["other-task-name"]       # task dependencies (if any)
 ```
 
-When these fields are omitted, the task loop MUST fall back to the stage-level
-settings (`ingest`, `prioritize`, or `execute`), then to
-`keystone.os.agents.<name>.notes.taskLoop.defaults`, then to the built-in stage
-and profile defaults. `fallback_model` and `effort` currently affect Claude
-only.
+## See also
+
+- [docs/agents/os-agents.md](../docs/agents/os-agents.md) — agent home
+  layout and how the YAML files are symlinked in.
+- `process.agent-cronjobs` — the single timer that drives task-loop
+  execution.

--- a/docs/agents/os-agents.md
+++ b/docs/agents/os-agents.md
@@ -5,15 +5,99 @@ description: Non-interactive NixOS user accounts for autonomous LLM-driven opera
 
 # OS Agents (`keystone.os.agents`)
 
-> **Note (2026-05):** the autonomous task-loop, scheduler, notes-sync, and
-> `.agents`-submodule scaffolding have been removed. The replacement layout
-> (per-agent state symlinks into the consumer flake plus a portable
-> `task-loop` skill) is being introduced in a follow-up PR; see the layout
-> plan referenced by the PR that removed this content for the new model.
-> Sections below describe the surviving surface: user provisioning,
-> mail/calendar/contacts, SSH, browser, MCP, and debugging.
-
 OS agents are non-interactive NixOS user accounts designed for autonomous LLM-driven operation. Each agent gets an isolated home directory, SSH keys, mail, and browser.
+
+## New layout (2026-05)
+
+The legacy notes subsystem (notes-sync timer, scheduler timer, multi-phase
+task-loop with state files, `.agents` submodule scaffolding, forgejo
+`<agent>/notes.git`) has been removed. The replacement model splits agent
+context between **operator-curated** files committed to the consumer flake
+and **agent-writable** runtime state that lives only on the deployed host.
+A single skill-driven systemd timer drives autonomous behavior.
+
+### Target layout in the consumer flake (e.g. `nixos-config`)
+
+```
+nixos-config/agents/
+├── _shared/                    # operating rules, conventions shared by all agents
+├── skills/                     # canonical skills tree
+│   └── task-loop/SKILL.md      # cross-tool loop skill (claude/codex/gemini all read it)
+├── TEAM.md                     # shared roster
+├── HUMAN.md                    # operator profile
+├── PROJECTS.yaml               # shared portfolio
+├── drago/
+│   ├── SOUL.md                 # identity / voice          (operator-curated)
+│   ├── ROLE.md                 # scope / responsibilities  (operator-curated)
+│   ├── AGENTS.md               # operating rules, composes the above
+│   ├── TASKS.yaml              # GITIGNORED — agent-writable runtime state
+│   ├── SCHEDULES.yaml          # GITIGNORED
+│   └── ISSUES.yaml             # GITIGNORED
+└── luce/                       # same shape as drago/
+```
+
+`agents/*/{TASKS,SCHEDULES,ISSUES}.yaml` go in the flake's `.gitignore`.
+The symlinks still resolve into the working tree, but git stays quiet
+about mutations.
+
+### Target agent home (example: luce)
+
+```
+/home/agent-luce/
+├── .agents/skills/    → <flake>/agents/skills/
+├── .claude/skills/    → <flake>/agents/skills/
+├── .claude/CLAUDE.md  → <flake>/agents/_shared/AGENTS.md
+├── .gemini/GEMINI.md  → <flake>/agents/_shared/AGENTS.md
+├── .codex/AGENTS.md   → <flake>/agents/_shared/AGENTS.md
+├── TEAM.md            → <flake>/agents/TEAM.md
+├── HUMAN.md           → <flake>/agents/HUMAN.md
+├── PROJECTS.yaml      → <flake>/agents/PROJECTS.yaml
+├── SOUL.md            → <flake>/agents/luce/SOUL.md
+├── ROLE.md            → <flake>/agents/luce/ROLE.md
+├── AGENTS.md          → <flake>/agents/luce/AGENTS.md
+├── TASKS.yaml         → <flake>/agents/luce/TASKS.yaml             # gitignored, writable
+├── SCHEDULES.yaml     → <flake>/agents/luce/SCHEDULES.yaml         # gitignored
+└── ISSUES.yaml        → <flake>/agents/luce/ISSUES.yaml            # gitignored
+```
+
+Symlinks are created by the consumer flake's home-manager profile, not by
+this module. This module only provisions the OS user, home directory,
+and (when enabled) the task-loop timer.
+
+### `@`-mention composition
+
+Per-agent `AGENTS.md` files use `@`-mention includes (Claude/Codex/Gemini
+all honor these) to compose identity from the curated files:
+
+```markdown
+You are luce. Read @SOUL.md for identity, @ROLE.md for scope, @TEAM.md
+for who you work with. Operating rules follow @../_shared/AGENTS.md.
+```
+
+### Enabling the task-loop
+
+Set `taskLoop.enable = true` on an agent. The module creates one
+`agent-<name>-task-loop` systemd user timer + service per agent.
+
+```nix
+keystone.os.agents.luce = {
+  fullName = "Luce";
+  email = "luce@example.com";
+  taskLoop = {
+    enable = true;
+    tool = "claude";       # one of: claude, codex, gemini
+    interval = "*:0/15";   # systemd OnCalendar
+    skill = "task-loop";   # name of skill under ~/.agents/skills/<skill>/
+  };
+};
+```
+
+The service is intentionally minimal: it execs
+`<tool> --print 'Run the <skill> skill.'` (or the tool's equivalent
+non-interactive form) and exits. There is no pre-fetch, no
+prioritization phase, no state-file mutation done by the module — the
+skill itself drives all of that.
+
 
 ## Quick Start
 
@@ -44,6 +128,7 @@ Each agent is provisioned by a focused set of sub-modules under
 | `dbus.nix`        | D-Bus socket activation race fix                       |
 | `perception.nix`  | Document/voice/screenshot perception layer             |
 | `tailscale.nix`   | Per-agent tailscaled (currently disabled)              |
+| `task-loop.nix`   | Per-agent skill-driven systemd timer + service         |
 
 ## Two-Agent Coordination
 

--- a/docs/agents/os-agents.md
+++ b/docs/agents/os-agents.md
@@ -92,11 +92,17 @@ keystone.os.agents.luce = {
 };
 ```
 
-The service is intentionally minimal: it execs
-`<tool> --print 'Run the <skill> skill.'` (or the tool's equivalent
-non-interactive form) and exits. There is no pre-fetch, no
-prioritization phase, no state-file mutation done by the module — the
-skill itself drives all of that.
+The service is intentionally minimal: it invokes the agent's tool with
+a fixed prompt and exits. The exact per-tool invocation is:
+
+| Tool     | Command                                                        |
+| -------- | -------------------------------------------------------------- |
+| `claude` | `unset CLAUDECODE; claude --print -p 'Run the <skill> skill.'` |
+| `codex`  | `codex exec 'Run the <skill> skill.'`                          |
+| `gemini` | `gemini --prompt 'Run the <skill> skill.'`                     |
+
+There is no pre-fetch, no prioritization phase, no state-file mutation
+done by the module — the skill itself drives all of that.
 
 
 ## Quick Start

--- a/modules/os/agents/default.nix
+++ b/modules/os/agents/default.nix
@@ -87,6 +87,7 @@ in
     ./home-manager.nix
     ./observability.nix
     ./perception.nix
+    ./task-loop.nix
   ];
 
   options.keystone.os.agents = mkOption {

--- a/modules/os/agents/task-loop.nix
+++ b/modules/os/agents/task-loop.nix
@@ -55,8 +55,10 @@ in
               XDG_CACHE_HOME = "/home/${username}/.cache";
               # CRITICAL: bare CLI names must resolve via the agent's
               # home-manager profile so version/tooling tracks the agent,
-              # not the system rebuild cadence.
-              PATH = "/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin";
+              # not the system rebuild cadence. mkForce because NixOS
+              # supplies a default PATH for user services that we need
+              # to override rather than merge with.
+              PATH = mkForce "/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin";
             };
             serviceConfig = {
               Type = "oneshot";

--- a/modules/os/agents/task-loop.nix
+++ b/modules/os/agents/task-loop.nix
@@ -1,0 +1,93 @@
+# Per-agent task-loop: one systemd user timer + service per agent.
+#
+# Each tick invokes a CLI coding agent (claude/codex/gemini) with a named
+# skill. The skill content lives in the consumer flake under
+# ~/.agents/skills/<skill>/ (symlinked by the consumer's home-manager).
+#
+# This module owns the timer + service only. No state files, no notes,
+# no pre-fetch logic, no retry/backoff — the skill itself drives the work
+# and exits quickly when there is nothing to do.
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  agentsLib = import ./lib.nix { inherit lib config pkgs; };
+  inherit (agentsLib) osCfg cfg localAgents;
+
+  taskLoopAgents = filterAttrs (_: agentCfg: agentCfg.taskLoop.enable) localAgents;
+
+  # Per-tool invocation. The CLI is resolved through the agent's
+  # home-manager profile PATH; no Nix store paths here so the agent can
+  # iterate on its own toolchain version without a system rebuild.
+  invocation =
+    tool: skill:
+    let
+      prompt = "Run the ${skill} skill.";
+    in
+    {
+      claude = "claude --print ${escapeShellArg prompt}";
+      codex = "codex exec ${escapeShellArg prompt}";
+      gemini = "gemini --prompt ${escapeShellArg prompt}";
+    }
+    .${tool};
+in
+{
+  config = mkIf (osCfg.enable && taskLoopAgents != { }) {
+    systemd.user.services = mkMerge (
+      mapAttrsToList (
+        name: agentCfg:
+        let
+          username = "agent-${name}";
+        in
+        {
+          "agent-${name}-task-loop" = {
+            description = "Task loop for ${username} (${agentCfg.taskLoop.tool} / ${agentCfg.taskLoop.skill})";
+            unitConfig.ConditionUser = username;
+            environment = {
+              HOME = "/home/${username}";
+              XDG_DATA_HOME = "/home/${username}/.local/share";
+              XDG_CONFIG_HOME = "/home/${username}/.config";
+              XDG_STATE_HOME = "/home/${username}/.local/state";
+              XDG_CACHE_HOME = "/home/${username}/.cache";
+              # CRITICAL: bare CLI names must resolve via the agent's
+              # home-manager profile so version/tooling tracks the agent,
+              # not the system rebuild cadence.
+              PATH = "/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin";
+            };
+            serviceConfig = {
+              Type = "oneshot";
+              # LLM invocations can run long; cap at 1h so a hung tick
+              # doesn't block the next one indefinitely.
+              TimeoutStartSec = "1h";
+              SyslogIdentifier = "agent-${name}-task-loop";
+            };
+            script = invocation agentCfg.taskLoop.tool agentCfg.taskLoop.skill;
+          };
+        }
+      ) taskLoopAgents
+    );
+
+    systemd.user.timers = mkMerge (
+      mapAttrsToList (
+        name: agentCfg:
+        let
+          username = "agent-${name}";
+        in
+        {
+          "agent-${name}-task-loop" = {
+            wantedBy = [ "default.target" ];
+            unitConfig.ConditionUser = username;
+            timerConfig = {
+              OnCalendar = agentCfg.taskLoop.interval;
+              Persistent = true;
+            };
+          };
+        }
+      ) taskLoopAgents
+    );
+  };
+}

--- a/modules/os/agents/task-loop.nix
+++ b/modules/os/agents/task-loop.nix
@@ -29,7 +29,7 @@ let
       prompt = "Run the ${skill} skill.";
     in
     {
-      claude = "claude --print ${escapeShellArg prompt}";
+      claude = "unset CLAUDECODE; claude --print -p ${escapeShellArg prompt}";
       codex = "codex exec ${escapeShellArg prompt}";
       gemini = "gemini --prompt ${escapeShellArg prompt}";
     }

--- a/modules/os/agents/types.nix
+++ b/modules/os/agents/types.nix
@@ -107,6 +107,32 @@ in
           };
         };
 
+        taskLoop = {
+          enable = mkEnableOption "Autonomous task-loop for this agent.";
+
+          tool = mkOption {
+            type = types.enum [
+              "claude"
+              "codex"
+              "gemini"
+            ];
+            default = "claude";
+            description = "Which CLI to invoke for each task-loop tick.";
+          };
+
+          interval = mkOption {
+            type = types.str;
+            default = "*:0/15";
+            description = "systemd OnCalendar expression for the task-loop timer.";
+          };
+
+          skill = mkOption {
+            type = types.str;
+            default = "task-loop";
+            description = "Skill name to load; must exist in ~/.agents/skills/<skill>/.";
+          };
+        };
+
         desktop = {
           enable = mkOption {
             type = types.bool;


### PR DESCRIPTION
Stacked on #546 (rip-out-notes). Companion to nixos-config PR 2B
(forthcoming) which will create the consumer-side state symlinks and
the actual \`task-loop\` skill markdown.

## Summary

- New \`modules/os/agents/task-loop.nix\`: one systemd user timer +
  service per agent. Each tick execs the agent's chosen CLI
  (\`claude\` / \`codex\` / \`gemini\`) with a named skill loaded from
  \`~/.agents/skills/<skill>/\`. No state, no pre-fetch, no retry —
  the skill itself drives behavior and exits cheaply when idle.
- Adds the \`taskLoop\` option group to the agent submodule:

  \`\`\`nix
  keystone.os.agents.luce = {
    taskLoop = {
      enable = true;
      tool = "claude";       # one of: claude, codex, gemini
      interval = "*:0/15";   # systemd OnCalendar
      skill = "task-loop";   # ~/.agents/skills/task-loop/
    };
  };
  \`\`\`

- \`docs/agents/os-agents.md\` updated: removes the stub note left by
  PR #546, documents the new repo layout (operator-curated docs +
  agent-writable yaml gitignored), the agent home-dir symlink pattern,
  the \`@\`-mention include composition, and the \`taskLoop\` option
  reference.
- Two convention docs (\`process.agent-cronjobs\`,
  \`process.task-tracking\`) shrunk to short pointers at the new model.
  Kept in place — multiple conventions and \`archetypes.yaml\` still
  reference them by slug.

## What's not in this PR

- The skill content itself (\`agents/skills/task-loop/SKILL.md\`) and
  the symlink wiring live in the consumer flake — PR 2B in
  \`nixos-config\`.
- Per-agent \`taskLoop.enable = true\` toggles also flip in
  \`nixos-config\` (PR 3 — \`hosts/common/agent-identities.nix\`).
- No new VM test — the legacy ones tested the deleted subsystem;
  live ping-pong on ocean (PR 3) replaces them.

## Test plan

- [x] \`nix flake check\` passes locally
- [ ] After PR 2B merges, deploy to ocean and confirm
  \`agent-luce-task-loop.timer\` is the only timer for the agent.
- [ ] PR 3 (\`feat(nixos-config): luce/drago ping-pong live\`) captures
  end-to-end evidence in its description.