### PR TITLE
feat(os/zram): add experimental compressed RAM swap module

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -59,6 +59,24 @@ In development mode, also generates `~/.keystone/repos/AGENTS.md`.
 generated file format are actively evolving. Role definitions and convention
 assignment patterns may change.
 
+### `keystone.os.zram` — Compressed RAM swap
+
+| | |
+|---|---|
+| **Module** | `modules/os/zram.nix` |
+| **Flag** | `keystone.os.zram.enable` (defaults to `keystone.experimental`) |
+| **Milestone** | [v2 — Un-experimental](https://github.com/ncrmro/keystone/milestone/10) |
+
+Wraps nixpkgs `zramSwap` with keystone defaults: one zstd-compressed
+zram device sized at 50% of RAM and `vm.swappiness=150` so the kernel
+reaches for compressed swap before evicting clean page-cache.
+
+**Why experimental**: the right defaults differ between workstation,
+laptop, and server profiles, and we have not yet tuned per-archetype
+or validated the interaction with existing disk swap on every host.
+
+**Options**: `keystone.os.zram.enable`, `.memoryPercent`, `.swappiness`
+
 ## For module authors
 
 To mark a module as experimental:

--- a/modules/os/default.nix
+++ b/modules/os/default.nix
@@ -248,6 +248,7 @@ in
     ./storage.nix
     ./secure-boot.nix
     ./tpm.nix
+    ./zram.nix
     ./hardware-key.nix
     ./privileged-approval.nix
     ./uhk.nix

--- a/modules/os/zram.nix
+++ b/modules/os/zram.nix
@@ -1,0 +1,59 @@
+# Keystone OS Zram Module  [EXPERIMENTAL]
+#
+# EXPERIMENTAL: not part of the stable v1 surface; option surface and
+# defaults may change as we tune for workstation/laptop/server profiles.
+#
+# Wraps nixpkgs `zramSwap` with keystone-flavoured defaults: a single
+# zstd-compressed zram device sized at 50% of RAM and a higher
+# vm.swappiness so the kernel actually reaches for compressed swap
+# before evicting clean page-cache.
+#
+{ lib, config, ... }:
+let
+  osCfg = config.keystone.os;
+  cfg = osCfg.zram;
+in
+{
+  imports = [ ../shared/experimental.nix ];
+
+  options.keystone.os.zram = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = config.keystone.experimental;
+      description = ''
+        Enable zstd-compressed RAM swap via the kernel zram device
+        (EXPERIMENTAL).
+      '';
+    };
+
+    memoryPercent = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 50;
+      description = ''
+        Cap on zram swap capacity as a percentage of physical RAM.
+        Reflects the compressed-block-device size, not residency.
+      '';
+    };
+
+    swappiness = lib.mkOption {
+      type = lib.types.ints.between 0 200;
+      default = 150;
+      description = ''
+        `vm.swappiness` value applied when zram is enabled. Default
+        kernel value (60) is tuned for slow disk swap; with zram the
+        backing store is RAM-fast and a higher value lets the kernel
+        compress cold anonymous pages before evicting page-cache.
+      '';
+    };
+  };
+
+  config = lib.mkIf (osCfg.enable && cfg.enable) {
+    zramSwap = {
+      enable = true;
+      algorithm = "zstd";
+      memoryPercent = cfg.memoryPercent;
+    };
+
+    boot.kernel.sysctl."vm.swappiness" = lib.mkDefault cfg.swappiness;
+  };
+}

--- a/modules/os/zram.nix
+++ b/modules/os/zram.nix
@@ -48,10 +48,12 @@ in
   };
 
   config = lib.mkIf (osCfg.enable && cfg.enable) {
+    # mkDefault so hosts can override individual zramSwap.* knobs (or
+    # disable zramSwap entirely) without needing mkForce.
     zramSwap = {
-      enable = true;
-      algorithm = "zstd";
-      memoryPercent = cfg.memoryPercent;
+      enable = lib.mkDefault true;
+      algorithm = lib.mkDefault "zstd";
+      memoryPercent = lib.mkDefault cfg.memoryPercent;
     };
 
     boot.kernel.sysctl."vm.swappiness" = lib.mkDefault cfg.swappiness;

--- a/tests/module/os-evaluation.nix
+++ b/tests/module/os-evaluation.nix
@@ -278,6 +278,62 @@ let
       }
     ];
 
+    # Experimental zram module: defaults pin zstd/50%/swappiness=150.
+    zram-experimental =
+      let
+        result = (import "${pkgs.path}/nixos/lib/eval-config.nix") {
+          system = "x86_64-linux";
+          modules = [
+            self.nixosModules.operating-system
+            {
+              system.stateVersion = "25.05";
+              boot.loader.systemd-boot.enable = true;
+              keystone.os = {
+                enable = true;
+                storage = {
+                  type = "ext4";
+                  devices = [ "/dev/vda" ];
+                };
+                zram.enable = true;
+                users.testuser = {
+                  fullName = "Test User";
+                  initialPassword = "testpass";
+                  admin = true;
+                };
+              };
+              fileSystems."/" = {
+                device = lib.mkForce "/dev/vda2";
+                fsType = lib.mkForce "ext4";
+              };
+            }
+          ];
+        };
+        z = result.config.zramSwap;
+        swappiness = result.config.boot.kernel.sysctl."vm.swappiness";
+      in
+      pkgs.runCommand "zram-experimental" { } ''
+        fail=0
+        ${lib.optionalString (!z.enable) ''
+          echo "FAIL: zramSwap.enable expected true" >&2
+          fail=1
+        ''}
+        if [ "${z.algorithm}" != "zstd" ]; then
+          echo "FAIL: zramSwap.algorithm expected zstd, got ${z.algorithm}" >&2
+          fail=1
+        fi
+        if [ "${toString z.memoryPercent}" != "50" ]; then
+          echo "FAIL: zramSwap.memoryPercent expected 50, got ${toString z.memoryPercent}" >&2
+          fail=1
+        fi
+        if [ "${toString swappiness}" != "150" ]; then
+          echo "FAIL: vm.swappiness expected 150, got ${toString swappiness}" >&2
+          fail=1
+        fi
+        if [ "$fail" -ne 0 ]; then exit 1; fi
+        echo "OK: zram defaults pinned (zstd, 50%, swappiness=150)"
+        touch $out
+      '';
+
     journal-remote-server = eval "journal-remote-server" [
       {
         keystone = {
@@ -664,6 +720,7 @@ pkgs.runCommand "test-os-evaluation"
     echo "  - full-zfs: Full ZFS with all options"
     echo "  - ext4-simple: Simple ext4 setup"
     echo "  - ext4-hibernate: ext4 with hibernation enabled"
+    echo "  - zram-experimental: experimental keystone.os.zram defaults"
     echo "  - journal-remote-server: Journal collection server (HTTPS via nginx)"
     echo "  - journal-remote-client: Journal upload client (HTTPS via nginx)"
     echo "  - journal-remote-client-no-domain: Journal upload client (HTTP fallback)"


### PR DESCRIPTION
## Summary
- Adds `modules/os/zram.nix` as an experimental keystone wrapper around nixpkgs `zramSwap`.
- Defaults: one zstd-compressed zram device sized at 50% of RAM, `vm.swappiness=150` so the kernel reaches compressed swap before evicting clean page-cache.
- `keystone.os.zram.enable` is gated on `keystone.experimental` per the experimental-module convention.
- Documented in `docs/experimental.md`.

## Test plan
- [x] `nix build .#checks.x86_64-linux.os-evaluation` passes
- [ ] Enable on a consumer host (`keystone.os.zram.enable = true;`), confirm `zramctl` shows one zstd device at the expected size and `cat /proc/sys/vm/swappiness` reports 150
- [ ] Sanity check disk-swap interaction on hosts that already declare swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)