### PR TITLE
feat(services): add keystone.services.vaultwarden + auto-rbw bridge

### DIFF
--- a/lib/templates.nix
+++ b/lib/templates.nix
@@ -178,9 +178,21 @@ let
       email ? defaults.email,
       timeZone ? defaults.timeZone or "UTC",
       updateChannel ? defaults.updateChannel or "stable",
+      keystoneServices ? defaults.keystoneServices or { },
       modules ? [ ],
       ...
     }@args:
+    let
+      # Mac homeConfigurations are standalone — they do not share a NixOS
+      # evaluation with the fleet, so the `modules/services.nix` defaults
+      # never fire here. Read keystoneServices.vaultwarden.{host,domain}
+      # directly; only enable rbw when both are explicit (otherwise rbw
+      # would silently target the official Bitwarden service).
+      vaultwarden = keystoneServices.vaultwarden or { };
+      vwBaseUrl = if (vaultwarden.domain or null) != null then "https://${vaultwarden.domain}" else "";
+      enableVwSecrets =
+        (vaultwarden.host or null) != null && (vaultwarden.domain or null) != null && email != null;
+    in
     home-manager.lib.homeManagerConfiguration {
       pkgs = nixpkgs.legacyPackages.${system};
       modules = [
@@ -201,6 +213,11 @@ let
             git = {
               userName = fullName;
               userEmail = email;
+            };
+            secrets = {
+              enable = lib.mkDefault enableVwSecrets;
+              email = lib.mkDefault (if email != null then email else "");
+              baseUrl = lib.mkDefault vwBaseUrl;
             };
           };
         }
@@ -962,6 +979,11 @@ rec {
               email = if hostCfg ? email then hostCfg.email else sharedAdmin.email;
               timeZone = if hostCfg ? timeZone then hostCfg.timeZone else sharedTimeZone;
               updateChannel = if hostCfg ? updateChannel then hostCfg.updateChannel else sharedUpdateChannel;
+              # Pass the fleet service registry so the Mac home template can
+              # auto-derive rbw / vaultwarden config the same way the Linux
+              # users.nix bridge does.
+              keystoneServices =
+                if hostCfg ? keystoneServices then hostCfg.keystoneServices else keystoneServices;
               modules = sharedUserModules ++ modules;
             };
         in

--- a/modules/os/users.nix
+++ b/modules/os/users.nix
@@ -516,12 +516,14 @@ in
                     };
 
                     # rbw (Bitwarden CLI) auto-enables when the fleet declares
-                    # a Vaultwarden host and the user has a known email.
+                    # a Vaultwarden host AND a domain (otherwise rbw would
+                    # silently fall back to the official Bitwarden service).
                     secrets = {
                       enable = mkDefault (
                         userCfg.terminal.enable
                         && userCfg.email != null
                         && config.keystone.services.vaultwarden.host != null
+                        && config.keystone.services.vaultwarden.domain != null
                       );
                       email = mkDefault (if userCfg.email != null then userCfg.email else "");
                       baseUrl = mkDefault (

--- a/modules/os/users.nix
+++ b/modules/os/users.nix
@@ -515,6 +515,23 @@ in
                       forgejo.enable = mkDefault (config.keystone.services.git.host != null);
                     };
 
+                    # rbw (Bitwarden CLI) auto-enables when the fleet declares
+                    # a Vaultwarden host and the user has a known email.
+                    secrets = {
+                      enable = mkDefault (
+                        userCfg.terminal.enable
+                        && userCfg.email != null
+                        && config.keystone.services.vaultwarden.host != null
+                      );
+                      email = mkDefault (if userCfg.email != null then userCfg.email else "");
+                      baseUrl = mkDefault (
+                        if config.keystone.services.vaultwarden.domain != null then
+                          "https://${config.keystone.services.vaultwarden.domain}"
+                        else
+                          ""
+                      );
+                    };
+
                     sshAutoLoad.enable = mkDefault userCfg.sshAutoLoad.enable;
                   };
                 }

--- a/modules/server/services/vaultwarden.nix
+++ b/modules/server/services/vaultwarden.nix
@@ -25,16 +25,27 @@ in
     registerDNS = true;
   };
 
-  config = lib.mkIf (serverCfg.enable && cfg.enable) {
-    keystone.server._enabledServices.vaultwarden = {
-      inherit (cfg)
-        subdomain
-        port
-        access
-        maxBodySize
-        websockets
-        registerDNS
-        ;
-    };
-  };
+  config = lib.mkMerge [
+    # Auto-enable when keystone.services.vaultwarden.host matches this
+    # machine's hostname — mirrors the mail/git auto-enable pattern.
+    {
+      keystone.server.services.vaultwarden.enable = lib.mkDefault (
+        config.keystone.services.vaultwarden.host != null
+        && config.keystone.services.vaultwarden.host == config.networking.hostName
+      );
+    }
+
+    (lib.mkIf (serverCfg.enable && cfg.enable) {
+      keystone.server._enabledServices.vaultwarden = {
+        inherit (cfg)
+          subdomain
+          port
+          access
+          maxBodySize
+          websockets
+          registerDNS
+          ;
+      };
+    })
+  ];
 }

--- a/modules/services.nix
+++ b/modules/services.nix
@@ -112,6 +112,24 @@ in
       description = "List of hostnames acting as GPU/ML workers.";
     };
 
+    vaultwarden.host = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "ocean";
+      description = ''
+        The networking.hostName of the Vaultwarden server.
+        Auto-enables keystone.server.services.vaultwarden on that host
+        and defaults keystone.terminal.secrets (rbw) on for users with
+        terminal enabled across the fleet.
+      '';
+    };
+
+    vaultwarden.domain = mkOption {
+      type = types.nullOr types.str;
+      default = if config.keystone.domain != null then "vaultwarden.${config.keystone.domain}" else null;
+      description = "FQDN of the Vaultwarden instance (e.g., vaultwarden.ncrmro.com). Used by the terminal secrets bridge to set rbw base_url.";
+    };
+
     generatedTagOwners = mkOption {
       type = types.attrsOf (types.listOf types.str);
       default = { };
@@ -166,5 +184,6 @@ in
     (validateHost "mail" cfg.mail.host)
     ++ (validateHost "git" cfg.git.host)
     ++ (validateHost "immich" cfg.immich.host)
-    ++ (concatMap (h: validateHost "immich.workers" h) cfg.immich.workers);
+    ++ (concatMap (h: validateHost "immich.workers" h) cfg.immich.workers)
+    ++ (validateHost "vaultwarden" cfg.vaultwarden.host);
 }

--- a/modules/services.nix
+++ b/modules/services.nix
@@ -185,5 +185,16 @@ in
     ++ (validateHost "git" cfg.git.host)
     ++ (validateHost "immich" cfg.immich.host)
     ++ (concatMap (h: validateHost "immich.workers" h) cfg.immich.workers)
-    ++ (validateHost "vaultwarden" cfg.vaultwarden.host);
+    ++ (validateHost "vaultwarden" cfg.vaultwarden.host)
+    ++ (optional (cfg.vaultwarden.host != null && cfg.vaultwarden.domain == null) {
+      assertion = false;
+      message = ''
+        keystone.services.vaultwarden.host is set ("${cfg.vaultwarden.host}") but
+        keystone.services.vaultwarden.domain is null. The terminal secrets bridge
+        cannot derive an rbw base_url without a domain.
+
+        Either set keystone.domain (domain auto-derives to vaultwarden.''${keystone.domain})
+        or set keystone.services.vaultwarden.domain explicitly.
+      '';
+    });
 }

--- a/modules/terminal/secrets.nix
+++ b/modules/terminal/secrets.nix
@@ -3,7 +3,24 @@
 # This module provides rbw (unofficial Bitwarden CLI) configuration.
 # rbw is a Rust-based alternative with better ergonomics and session caching.
 #
-# ## Example Usage
+# ## Fleet auto-enable
+#
+# Setting `keystone.services.vaultwarden.host` (and a domain, either via
+# `keystone.domain` or explicit `keystone.services.vaultwarden.domain`) in
+# the consumer flake's `mkSystemFlake { keystoneServices = { ... }; }` is
+# enough to install and configure rbw everywhere it makes sense:
+#
+# - **NixOS hosts**: `modules/os/users.nix` bridges this into each terminal
+#   user's home-manager — `enable`, `email`, and `baseUrl` default in.
+# - **macOS hosts** (`kind = "macbook"`): `lib/templates.nix`'s
+#   `mkSharedMacosHome` reads the same fleet `keystoneServices` and applies
+#   the same defaults to the standalone home-manager configuration.
+#
+# On both platforms the bridge stays off until *both* `host` and `domain`
+# are set — otherwise rbw would silently fall back to the official
+# Bitwarden service.
+#
+# ## Manual usage
 #
 # ```nix
 # keystone.terminal.secrets = {

--- a/tests/module/server-evaluation.nix
+++ b/tests/module/server-evaluation.nix
@@ -169,6 +169,48 @@ let
         };
       }
     ];
+    # Vaultwarden auto-enable: declaring keystone.services.vaultwarden.host
+    # equal to networking.hostName must flip keystone.server.services.vaultwarden
+    # on (and register it in _enabledServices) without an explicit enable line.
+    vaultwarden-auto-enable =
+      let
+        result = nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            self.nixosModules.repos
+            self.nixosModules.server
+            {
+              system.stateVersion = "25.05";
+              boot.loader.systemd-boot.enable = true;
+              fileSystems."/" = {
+                device = "/dev/vda1";
+                fsType = "ext4";
+              };
+              networking.hostName = "vault-host";
+              keystone = {
+                domain = "example.com";
+                server.enable = true;
+                services.vaultwarden.host = "vault-host";
+              };
+            }
+          ];
+        };
+        enabled = result.config.keystone.server.services.vaultwarden.enable;
+        registered = builtins.hasAttr "vaultwarden" (result.config.keystone.server._enabledServices or { });
+      in
+      pkgs.runCommand "vaultwarden-auto-enable" { } ''
+        if [ "${builtins.toJSON enabled}" != "true" ]; then
+          echo "FAIL: expected vaultwarden.enable=true on matching host" >&2
+          exit 1
+        fi
+        if [ "${builtins.toJSON registered}" != "true" ]; then
+          echo "FAIL: expected vaultwarden in _enabledServices" >&2
+          exit 1
+        fi
+        echo "OK: vaultwarden auto-enabled from keystone.services.vaultwarden.host"
+        touch $out
+      '';
+
     grafana-locked-dashboards = eval "grafana-locked-dashboards" [
       {
         keystone = {
@@ -213,6 +255,7 @@ pkgs.runCommand "test-server-evaluation"
     echo "  - journal-remote-proxy: Journal HTTPS proxy registration"
     echo "  - grafana-locked-dashboards: keystone dashboards are provisioned outside development mode"
     echo "  - grafana-development-dashboards: keystone dashboards are not provisioned in development mode"
+    echo "  - vaultwarden-auto-enable: keystone.services.vaultwarden.host turns on the server module"
     echo ""
     echo "All configurations evaluated successfully!"
     touch $out


### PR DESCRIPTION
## Summary
- Mirror the existing `keystone.services.{mail,git,immich}.host` registry for Vaultwarden: declare `keystone.services.vaultwarden.{host,domain}` in `modules/services.nix`. `domain` auto-derives to `vaultwarden.\${keystone.domain}`.
- Default `keystone.server.services.vaultwarden.enable` to `(vaultwarden.host == networking.hostName)` so the server comes up automatically on the matching host — same shape as the mail/git auto-enable.
- Bridge each terminal user in `modules/os/users.nix`: when `vaultwarden.host` is set and the user has a known email, default `keystone.terminal.secrets` (rbw) on and point `baseUrl` at `https://\${vaultwarden.domain}`.

Net effect: declaring `keystone.services.vaultwarden.host = "ocean"` in the consumer flake turns the server on at `ocean` and installs/configures rbw across every terminal user — no per-host wiring needed.

## Test plan
- [x] `nix build .#checks.x86_64-linux.os-evaluation .#checks.x86_64-linux.server-evaluation` passes
- [ ] On a consumer flake, set `keystone.services.vaultwarden.host = "<host>"` and confirm: server activates on `<host>` at port 8222 / `vaultwarden.<domain>`, and a terminal user gets `rbw config show` reporting the expected `email` and `base_url`
- [ ] On a fleet without `vaultwarden.host` set, confirm no rbw appears in the user's environment (defaults remain `enable = false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)