### PR TITLE
feat: keystone GitHub token convention for nix-daemon

### DIFF
--- a/conventions/tool.nix.md
+++ b/conventions/tool.nix.md
@@ -85,31 +85,48 @@ home.activation.claudeJsonConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
 '';
 ```
 
-When a user-level Home Manager profile needs reusable credentials across multiple hosts, the secret recipients and runtime exports must follow the user rather than a single machine:
+When a user-level Home Manager profile needs reusable credentials across multiple hosts, the user PAT secret recipients and runtime exports must follow the user rather than a single machine. The keystone module that implements this (`keystone.terminal.github`) and the convention for naming, scope, and recipient discipline are documented in `tool.github-pats`. The adopter declares one `age.secrets.<name>` entry per host and enables the keystone module; do not write a bespoke `programs.zsh.initExtra` block.
+
+## Os-level GitHub access tokens for the nix daemon
+
+32. The nix daemon authenticating to GitHub for flake fetches (`nix flake update`, `ks update`) MUST use an **os-level** agenix secret distinct from the user-PAT secret described in `tool.github-pats`. The daemon runs as root and cannot read a `mode 0400 owner=<user>` file; even if it could, daemon-level access requires its own recipient set drawn from system keys.
+33. The os-level secret basename MUST follow one of:
+    - `nix-flake-github-token` — portable, recommended default.
+    - `<hostname>-nix-flake-github-token` — host-scoped when blast radius must be smaller. `<hostname>` is the agenix `systems.*` key.
+34. The recipient set for the os-level secret MUST include the **system** keys of every host that runs `nix flake update` against `github:` inputs. It MUST NOT include user or yubikey keys — those are user-PAT territory.
+35. The `age.secrets.<name>` declaration MUST set `owner = "root"; mode = "0400";`.
+36. The keystone module `keystone.os.githubTokenNix` MUST be used to wire the secret into `nix.conf`. The module materializes `/etc/nix/access-tokens.conf` from the runtime file via a hardened systemd oneshot and appends `!include` to `nix.extraOptions` — the token value never enters the Nix store.
+37. The os-level secret MAY share its plaintext PAT value with the user-readable agents PAT (`github-agents-token`) during bootstrap, but SHOULD be rotated to a distinct, narrowly-scoped token before relying on the audit trail. Distinct secret names with distinct recipient sets and distinct file ownership are required regardless of whether the underlying token value is shared.
+
+### Golden example: os-level nix-daemon token
 
 ```nix
 # agenix-secrets/secrets.nix
-"secrets/ncrmro-github-token.age".publicKeys = adminKeys ++ [
-  systems.ocean
-  systems.ncrmro-laptop
+"secrets/nix-flake-github-token.age".publicKeys = adminKeys ++ [
   systems.ncrmro-workstation
+  systems.ncrmro-laptop
 ];
 
-# every host that installs home-manager.users.ncrmro and expects the runtime file
-age.secrets.ncrmro-github-token = {
-  file = "${inputs.agenix-secrets}/secrets/ncrmro-github-token.age";
-  owner = "ncrmro";
+# nixos host that runs `ks update` / `nix flake update`
+age.secrets.nix-flake-github-token = {
+  file = "${inputs.agenix-secrets}/secrets/nix-flake-github-token.age";
+  owner = "root";
   mode = "0400";
 };
 
-# home-manager/ncrmro/base.nix
-home.sessionVariables = {
-  GITHUB_API_URL = "https://api.github.com";
+keystone.os.githubTokenNix = {
+  enable = true;
+  # tokenFile defaults to /run/agenix/nix-flake-github-token
 };
+```
 
-programs.zsh.initExtra = ''
-  if [ -f /run/agenix/ncrmro-github-token ]; then
-    export GITHUB_TOKEN="$(tr -d '\n' < /run/agenix/ncrmro-github-token)"
-  fi
-'';
+### Darwin parity (per-user nix.conf)
+
+On Darwin keystone hosts there is no nix-darwin system module — `mkDarwinInventoryHost` produces standalone home-manager only. `nix flake update` runs as the user, so the equivalent wiring is per-user. Use `keystone.terminal.githubTokenNix` (the home-manager module) with `source = "gh-auth"` to materialize `~/.config/nix/access-tokens.conf` at activation time from the existing `gh auth` login. No additional agenix secret is required on macOS for this path.
+
+```nix
+keystone.terminal.githubTokenNix = {
+  enable = true;
+  # source defaults to "gh-auth"
+};
 ```

--- a/modules/os/default.nix
+++ b/modules/os/default.nix
@@ -249,6 +249,7 @@ in
     ./secure-boot.nix
     ./tpm.nix
     ./zram.nix
+    ./github-token-nix.nix
     ./hardware-key.nix
     ./privileged-approval.nix
     ./uhk.nix

--- a/modules/os/github-token-nix.nix
+++ b/modules/os/github-token-nix.nix
@@ -1,0 +1,127 @@
+# Keystone OS — GitHub token for the nix daemon.
+#
+# Materializes /etc/nix/access-tokens.conf from a root-readable agenix
+# secret and `!include`s it into nix.conf so flake fetches (e.g.
+# `nix flake update`, `ks update`) authenticate to GitHub and hit the
+# 5000/hr authenticated rate ceiling instead of the 60/hr anonymous one.
+#
+# The token value never enters the Nix store: the secret stays in
+# /run/agenix, and a systemd oneshot copies it into the include file at
+# activation time.
+#
+# This is the OS-level counterpart to keystone.terminal.github (the
+# user-PAT module). The user PAT is mode 0400 owner=<user> and serves
+# `gh`/`git`; the nix-daemon runs as root and needs its own secret with
+# system-key recipients. See conventions/tool.github-pats.md rule 26 and
+# conventions/tool.nix.md for the os-level access-tokens convention.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.keystone.os.githubTokenNix;
+  basename = baseNameOf cfg.tokenFile;
+  # Accepted patterns (also documented in tool.nix.md):
+  #   nix-flake-github-token             — portable, recommended default
+  #   <hostname>-nix-flake-github-token  — host-scoped
+  validBasename =
+    basename == "nix-flake-github-token"
+    || (
+      lib.hasSuffix "-nix-flake-github-token" basename && builtins.match "[a-z0-9-]+" basename != null
+    );
+in
+{
+  options.keystone.os.githubTokenNix = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Wire an agenix-decrypted GitHub token into /etc/nix/nix.conf via
+        a root-readable include file, so the nix daemon uses the
+        authenticated 5000/hr GitHub rate-limit ceiling for flake fetches.
+      '';
+    };
+
+    tokenFile = lib.mkOption {
+      type = lib.types.str;
+      default = "/run/agenix/nix-flake-github-token";
+      description = ''
+        Path to the decrypted token file. The adopter is responsible for
+        declaring an `age.secrets.<name>` entry that produces this file
+        with `owner = "root"; mode = "0400";` and a recipient set drawn
+        from system keys (not user keys).
+
+        The basename SHOULD follow the convention
+        `nix-flake-github-token` (portable) or
+        `<hostname>-nix-flake-github-token` (host-scoped). See
+        conventions/tool.nix.md.
+      '';
+    };
+
+    includePath = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/nix/access-tokens.conf";
+      description = ''
+        Path of the include file the oneshot writes. Referenced from
+        `nix.extraOptions` as `!include <path>`.
+      '';
+    };
+  };
+
+  config = lib.mkIf (config.keystone.os.enable && cfg.enable) {
+    assertions = [
+      {
+        assertion = validBasename;
+        message =
+          "keystone.os.githubTokenNix.tokenFile basename '${basename}' does not match "
+          + "the OS-level naming convention. Use 'nix-flake-github-token' (portable) "
+          + "or '<hostname>-nix-flake-github-token' (host-scoped). See "
+          + "conventions/tool.nix.md.";
+      }
+    ];
+
+    systemd.services.nix-github-access-token = {
+      description = "Materialize ${cfg.includePath} from ${cfg.tokenFile}";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "agenix.service" ];
+      requires = [ "agenix.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        # Hardening — write only to /etc/nix.
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [ (builtins.dirOf cfg.includePath) ];
+        # /run/agenix is a tmpfs mount; PrivateTmp would shadow it.
+        PrivateTmp = false;
+      };
+
+      script = ''
+        set -eu
+        if [ ! -s ${lib.escapeShellArg cfg.tokenFile} ]; then
+          echo "nix-github-access-token: ${cfg.tokenFile} missing or empty" >&2
+          exit 1
+        fi
+        umask 0137
+        tmp="$(${pkgs.coreutils}/bin/mktemp ${lib.escapeShellArg (cfg.includePath + ".XXXXXX")})"
+        trap '${pkgs.coreutils}/bin/rm -f "$tmp"' EXIT
+        {
+          printf 'access-tokens = github.com=%s\n' \
+            "$(${pkgs.coreutils}/bin/tr -d '\n' < ${lib.escapeShellArg cfg.tokenFile})"
+        } > "$tmp"
+        ${pkgs.coreutils}/bin/chown root:root "$tmp"
+        ${pkgs.coreutils}/bin/chmod 0640 "$tmp"
+        ${pkgs.coreutils}/bin/mv "$tmp" ${lib.escapeShellArg cfg.includePath}
+        trap - EXIT
+      '';
+    };
+
+    nix.extraOptions = lib.mkAfter ''
+      !include ${cfg.includePath}
+    '';
+  };
+}

--- a/modules/terminal/default.nix
+++ b/modules/terminal/default.nix
@@ -53,6 +53,7 @@ in
     ./secrets.nix
     ./ssh-auto-load.nix
     ./forgejo.nix
+    ./github-token-nix.nix
     ./grafana.nix
     ./projects.nix
     ./conventions.nix

--- a/modules/terminal/github-token-nix.nix
+++ b/modules/terminal/github-token-nix.nix
@@ -1,0 +1,111 @@
+# Keystone Terminal — GitHub token for per-user nix.conf (Darwin focus).
+#
+# On Darwin keystone hosts there is no nix-darwin system module (see
+# lib/templates.nix mkDarwinInventoryHost — Darwin hosts are standalone
+# home-manager only). `nix flake update` runs as the user, so authenticating
+# GitHub flake fetches happens via the user's ~/.config/nix/nix.conf, not
+# /etc/nix/nix.conf.
+#
+# This module materializes ~/.config/nix/access-tokens.conf at home-manager
+# activation time from a token source — by default `gh auth token`, which
+# leverages the existing gh CLI login the user already has. No agenix secret
+# is required on macOS for this path.
+#
+# Pair with `keystone.terminal.github` (the PAT module) when you also want
+# GITHUB_TOKEN/GH_TOKEN exported into the shell; the two modules are
+# independent and complement each other.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  termCfg = config.keystone.terminal;
+  cfg = termCfg.githubTokenNix;
+  accessTokensFile = "${config.xdg.configHome}/nix/access-tokens.conf";
+in
+{
+  options.keystone.terminal.githubTokenNix = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Materialize ~/.config/nix/access-tokens.conf at home-manager
+        activation time so per-user `nix flake update` invocations
+        authenticate to GitHub. Primarily useful on Darwin where there
+        is no system-level nix.conf writer.
+      '';
+    };
+
+    source = lib.mkOption {
+      type = lib.types.enum [
+        "gh-auth"
+        "tokenFile"
+      ];
+      default = "gh-auth";
+      description = ''
+        Where to read the token at activation time.
+          gh-auth   : shell out to `gh auth token`. Requires gh CLI logged
+                      in. Recommended on Darwin where agenix is not
+                      typically wired.
+          tokenFile : read from `tokenFile` (e.g. an agenix runtime path).
+      '';
+    };
+
+    tokenFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/run/agenix/nix-flake-github-token";
+      description = ''
+        Path to a token file when `source = "tokenFile"`. Ignored
+        otherwise.
+      '';
+    };
+  };
+
+  config = lib.mkIf (termCfg.enable && cfg.enable) {
+    assertions = [
+      {
+        assertion = cfg.source == "gh-auth" || cfg.tokenFile != null;
+        message =
+          "keystone.terminal.githubTokenNix.tokenFile must be set when " + "source = \"tokenFile\".";
+      }
+    ];
+
+    # Append the include directive into the user nix.conf. `home.file.<p>.text`
+    # is typed as `lines`, which concatenates across modules — composes with
+    # the Darwin block in shell.nix that sets experimental-features.
+    home.file.".config/nix/nix.conf".text = lib.mkAfter ''
+      !include ${accessTokensFile}
+    '';
+
+    home.activation.keystoneGithubTokenNix = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      ${pkgs.coreutils}/bin/mkdir -p "$(dirname ${lib.escapeShellArg accessTokensFile})"
+      umask 0177
+      token=""
+      ${
+        if cfg.source == "gh-auth" then
+          ''
+            if command -v gh >/dev/null 2>&1; then
+              token="$(gh auth token 2>/dev/null || true)"
+            fi
+          ''
+        else
+          ''
+            if [ -r ${lib.escapeShellArg cfg.tokenFile} ]; then
+              token="$(${pkgs.coreutils}/bin/tr -d '\n' < ${lib.escapeShellArg cfg.tokenFile})"
+            fi
+          ''
+      }
+      if [ -n "$token" ]; then
+        tmp="$(${pkgs.coreutils}/bin/mktemp ${lib.escapeShellArg (accessTokensFile + ".XXXXXX")})"
+        printf 'access-tokens = github.com=%s\n' "$token" > "$tmp"
+        ${pkgs.coreutils}/bin/chmod 0600 "$tmp"
+        ${pkgs.coreutils}/bin/mv "$tmp" ${lib.escapeShellArg accessTokensFile}
+      else
+        echo "keystone.terminal.githubTokenNix: no token available; skipping ${accessTokensFile}" >&2
+      fi
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `keystone.os.githubTokenNix` — NixOS module that materializes `/etc/nix/access-tokens.conf` from a root-readable agenix secret via a hardened systemd oneshot, and appends `!include` to `nix.extraOptions` so the nix daemon authenticates GitHub flake fetches (5000/hr authenticated rather than 60/hr anonymous).
- Adds `keystone.terminal.githubTokenNix` — home-manager module that writes `~/.config/nix/access-tokens.conf` at activation time from `gh auth token` (Darwin path; `mkDarwinInventoryHost` is home-manager-only, so per-user is the only nix.conf path). `source = "tokenFile"` stub wired for future agenix-darwin parity.
- Documents the **os-level GitHub access-tokens** convention in `conventions/tool.nix.md`: naming patterns (`nix-flake-github-token` portable, `<hostname>-nix-flake-github-token` host-scoped), recipient discipline (system keys only), and ownership (root mode 0400). Fills the `(TODO)` in `tool.github-pats.md` rule 26.

## Design notes

- **Distinct from the user PAT** (`keystone.terminal.github` on feat/terminal-github-pats). The user PAT serves `gh`/`git` as mode 0400 owner=`<user>`; the nix-daemon runs as root and needs its own recipient set + ownership. The two modules are independent.
- **Token never enters the Nix store** — the systemd oneshot copies from `/run/agenix/...` into `/etc/nix/access-tokens.conf` at activation time. Only the `!include` directive lives in the closure.
- **Adopter contract**: declare `age.secrets.<name>` with `owner = "root"; mode = "0400";` and system-key recipients; enable the module. The module validates the secret basename matches the convention.

## Test plan

- [x] `nix build .#checks.x86_64-linux.os-evaluation` passes against this branch
- [x] `nix build .#checks.x86_64-linux.agent-evaluation` passes (covers convention regen + agent-config evaluations)
- [x] Both new module files pass `nix-instantiate --parse`
- [ ] Deploy via `ks update --dev` on ncrmro-workstation/ncrmro-laptop (requires the paired agenix-secrets and nixos-config PRs to merge first, and the .age file to be encrypted)
- [ ] Confirm `systemctl status nix-github-access-token.service` is `active (exited)` and `/etc/nix/access-tokens.conf` mode is 0640
- [ ] Confirm `curl -H "Authorization: token \$(sudo cat /run/agenix/nix-flake-github-token)" https://api.github.com/rate_limit` reports `x-ratelimit-limit: 5000`

## Related

- Depends on: ncrmro/agenix-secrets PR (new `nix-flake-github-token.age` secret entry)
- Consumer: ncrmro/nixos-config PR (enables on both desktops)
- Fills TODO in: `conventions/tool.github-pats.md` rule 26 (on feat/terminal-github-pats branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)