### PR TITLE
ci(actions): add Darwin terminal validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     outputs:
       iso: ${{ steps.filter.outputs.iso }}
       installer: ${{ steps.filter.outputs.installer }}
+      macos_terminal: ${{ steps.filter.outputs.macos_terminal }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -28,6 +29,11 @@ jobs:
               - 'packages/keystone-installer-ui/**'
               - 'packages/zesh/**'
               - 'tests/installer-test.nix'
+              - 'flake.lock'
+              - 'flake.nix'
+            macos_terminal:
+              - '.github/workflows/test.yml'
+              - 'modules/terminal/**'
               - 'flake.lock'
               - 'flake.nix'
 
@@ -92,3 +98,19 @@ jobs:
       # This creates a VM, boots the installer ISO, and validates the TUI works
       - name: Run installer test
         run: ./bin/test-installer
+
+  # macOS validation stays narrow on this branch: Home Manager terminal only.
+  # Linux desktop modules (Hyprland, portals, file picker) are intentionally
+  # excluded because they are not expected to build on macOS.
+  macos-terminal:
+    needs: changes
+    if: needs.changes.outputs.macos_terminal == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Build Darwin terminal activation package
+        run: nix build -L .#checks.aarch64-darwin.terminal-home

--- a/flake.nix
+++ b/flake.nix
@@ -22,233 +22,222 @@
     hyprland.url = "github:hyprwm/Hyprland";
   };
 
-  outputs =
-    {
-      self,
-      nixpkgs,
-      disko,
-      home-manager,
-      omarchy,
-      lanzaboote,
-      hyprland,
-      ...
-    }:
-    let
-      # Create inputs attrset for desktop module
-      inputs = {
-        inherit nixpkgs hyprland;
-      };
-      darwinSystem = "aarch64-darwin";
-    in
-    {
-      formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt-rfc-style;
+  outputs = {
+    self,
+    nixpkgs,
+    disko,
+    home-manager,
+    omarchy,
+    lanzaboote,
+    hyprland,
+    ...
+  }: let
+    # Create inputs attrset for desktop module
+    inputs = {
+      inherit nixpkgs hyprland;
+    };
+    darwinSystem = "aarch64-darwin";
+  in {
+    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt-rfc-style;
 
-      # ISO configuration without SSH keys (use bin/build-iso for SSH keys)
-      # Note: Test/dev configurations are in ./tests/flake.nix
-      nixosConfigurations = {
-        keystoneIso = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
-          modules = [
-            "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
-            ./modules/iso-installer.nix
-            {
-              _module.args.sshKeys = [ ];
-              # Force kernel 6.12 - must be set here to override minimal CD
-              boot.kernelPackages = nixpkgs.lib.mkForce nixpkgs.legacyPackages.x86_64-linux.linuxPackages_6_12;
-            }
-          ];
-        };
-      };
-
-      # Overlay that provides keystone packages
-      # NOTE: Paths must be captured in `let` BEFORE the function, otherwise they
-      # get evaluated in the wrong context when the overlay is applied by a consumer flake
-      overlays.default =
-        let
-          zesh-src = ./packages/zesh;
-          claude-code-src = ./modules/terminal/claude-code;
-        in
-        final: prev: {
-          keystone = {
-            zesh = final.callPackage zesh-src { };
-            claude-code = final.callPackage claude-code-src { };
-          };
-        };
-
-      # Export Keystone modules for use in other flakes
-      nixosModules = {
-        # Core OS module - storage, secure boot, TPM, remote unlock, users, services
-        operating-system = {
-          imports = [
-            disko.nixosModules.disko
-            lanzaboote.nixosModules.lanzaboote
-            ./modules/os
-          ];
-        };
-
-        # Desktop module - Hyprland, audio, greetd (no disko/encryption dependencies)
-        desktop = {
-          imports = [ ./modules/desktop/nixos.nix ];
-          _module.args.inputs = inputs;
-        };
-
-        # Server module - VPN, monitoring, mail (optional services)
-        server = ./modules/server;
-
-        # Agent Sandbox module - isolated AI coding agent environments
-        agent = {
-          imports = [ ./modules/keystone/agent ];
-        };
-
-        # ISO installer module
-        isoInstaller = ./modules/iso-installer.nix;
-      };
-
-      # Export home-manager modules (homeModules is the standard flake output name)
-      homeModules = {
-        desktopHyprland = ./home-manager/modules/desktop/hyprland;
-        # Keystone-specific home-manager modules
-        terminal = ./modules/terminal/default.nix;
-        desktop = ./modules/desktop/home/default.nix;
-        agentTui = ./modules/keystone/agent/home/tui.nix;
-      };
-
-      checks.${darwinSystem} =
-        let
-          darwinPkgs = import nixpkgs {
-            system = darwinSystem;
-            config.allowUnfree = true;
-            overlays = [ self.overlays.default ];
-          };
-          macosTerminalHome = home-manager.lib.homeManagerConfiguration {
-            pkgs = darwinPkgs;
-            modules = [
-              self.homeModules.terminal
-              {
-                _module.args.inputs = inputs;
-
-                home.username = "ci";
-                home.homeDirectory = "/Users/ci";
-                home.stateVersion = "25.05";
-
-                keystone.terminal = {
-                  enable = true;
-                  git = {
-                    userName = "CI User";
-                    userEmail = "ci@example.com";
-                  };
-                };
-              }
-            ];
-          };
-        in
-        {
-          # Cheap macOS validation for the supported cross-platform Home Manager surface.
-          # The Hyprland desktop module stays Linux-only on this branch.
-          terminal-home = macosTerminalHome.activationPackage;
-        };
-
-      # Packages exported for consumption
-      # Note: Tests are in ./tests/flake.nix (separate flake to avoid IFD issues)
-      packages.x86_64-linux =
-        let
-          pkgs = nixpkgs.legacyPackages.x86_64-linux;
-        in
-        {
-          iso = self.nixosConfigurations.keystoneIso.config.system.build.isoImage;
-          zesh = pkgs.callPackage ./packages/zesh { };
-          keystone-installer-ui = pkgs.callPackage ./packages/keystone-installer-ui { };
-          keystone-ha-tui-client = pkgs.callPackage ./packages/keystone-ha/tui { };
-          keystone-agent = pkgs.callPackage ./packages/keystone-agent { };
-        };
-
-      # Development shell
-      devShells.x86_64-linux =
-        let
-          pkgs = nixpkgs.legacyPackages.x86_64-linux;
-        in
-        {
-          default = pkgs.mkShell {
-            name = "keystone-dev";
-
-            # Rust development
-            nativeBuildInputs = with pkgs; [
-              cargo
-              rustc
-              rust-analyzer
-              clippy
-              rustfmt
-              pkg-config
-            ];
-
-            buildInputs = with pkgs; [
-              openssl
-            ];
-
-            # Node.js development
-            packages = with pkgs; [
-              nodejs
-              nodePackages.npm
-              nodePackages.typescript
-              nodePackages.typescript-language-server
-
-              # Nix tools
-              nixfmt-rfc-style
-              nil # Nix LSP
-              nix-tree
-              nvd # Nix version diff
-
-              # VM and deployment tools
-              qemu
-              libvirt
-              virt-viewer
-              swtpm
-
-              # General utilities
-              jq
-              yq-go
-              gh # GitHub CLI
-              python3
-            ];
-
-            shellHook = ''
-              echo "🔑 Keystone development shell"
-              echo ""
-              echo "Available commands:"
-              echo "  ./bin/build-iso        - Build installer ISO"
-              echo "  ./bin/build-vm         - Fast VM testing (terminal/desktop)"
-              echo "  ./bin/virtual-machine  - Full stack VM with libvirt"
-              echo "  nix flake check        - Validate flake"
-              echo ""
-              echo "Rust packages:  packages/keystone-ha/"
-              echo "Node packages:  packages/keystone-installer-ui/"
-            '';
-
-            # Rust environment variables
-            RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
-          };
-        };
-
-      # Flake templates for users to scaffold new projects
-      templates = {
-        default = {
-          path = ./templates/default;
-          description = "Keystone infrastructure starter with OS module and home-manager";
-          welcomeText = ''
-            # Keystone Infrastructure Configuration
-
-            Your project has been initialized!
-
-            ## Quick Start
-
-            1. Edit configuration.nix - search for TODO: to find required changes
-            2. Generate hostId: head -c 4 /dev/urandom | od -A none -t x4 | tr -d ' '
-            3. Find your disk: ls -l /dev/disk/by-id/
-            4. Deploy: nixos-anywhere --flake .#my-machine root@<installer-ip>
-
-            See README.md for detailed instructions.
-          '';
-        };
+    # ISO configuration without SSH keys (use bin/build-iso for SSH keys)
+    # Note: Test/dev configurations are in ./tests/flake.nix
+    nixosConfigurations = {
+      keystoneIso = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+          ./modules/iso-installer.nix
+          {
+            _module.args.sshKeys = [];
+            # Force kernel 6.12 - must be set here to override minimal CD
+            boot.kernelPackages = nixpkgs.lib.mkForce nixpkgs.legacyPackages.x86_64-linux.linuxPackages_6_12;
+          }
+        ];
       };
     };
+
+    # Overlay that provides keystone packages
+    # NOTE: Paths must be captured in `let` BEFORE the function, otherwise they
+    # get evaluated in the wrong context when the overlay is applied by a consumer flake
+    overlays.default = let
+      zesh-src = ./packages/zesh;
+      claude-code-src = ./modules/terminal/claude-code;
+    in final: prev: {
+      keystone = {
+        zesh = final.callPackage zesh-src {};
+        claude-code = final.callPackage claude-code-src {};
+      };
+    };
+
+    # Export Keystone modules for use in other flakes
+    nixosModules = {
+      # Core OS module - storage, secure boot, TPM, remote unlock, users, services
+      operating-system = {
+        imports = [
+          disko.nixosModules.disko
+          lanzaboote.nixosModules.lanzaboote
+          ./modules/os
+        ];
+      };
+
+      # Desktop module - Hyprland, audio, greetd (no disko/encryption dependencies)
+      desktop = {
+        imports = [./modules/desktop/nixos.nix];
+        _module.args.inputs = inputs;
+      };
+
+      # Server module - VPN, monitoring, mail (optional services)
+      server = ./modules/server;
+
+      # Agent Sandbox module - isolated AI coding agent environments
+      agent = {
+        imports = [./modules/keystone/agent];
+      };
+
+      # ISO installer module
+      isoInstaller = ./modules/iso-installer.nix;
+    };
+
+    # Export home-manager modules (homeModules is the standard flake output name)
+    homeModules = {
+      desktopHyprland = ./home-manager/modules/desktop/hyprland;
+      # Keystone-specific home-manager modules
+      terminal = ./modules/terminal/default.nix;
+      desktop = ./modules/desktop/home/default.nix;
+      agentTui = ./modules/keystone/agent/home/tui.nix;
+    };
+
+    checks.${darwinSystem} = let
+      darwinPkgs = import nixpkgs {
+        system = darwinSystem;
+        config.allowUnfree = true;
+        overlays = [self.overlays.default];
+      };
+      macosTerminalHome = home-manager.lib.homeManagerConfiguration {
+        pkgs = darwinPkgs;
+        modules = [
+          self.homeModules.terminal
+          {
+            _module.args.inputs = inputs;
+
+            home.username = "ci";
+            home.homeDirectory = "/Users/ci";
+            home.stateVersion = "25.05";
+
+            keystone.terminal = {
+              enable = true;
+              git = {
+                userName = "CI User";
+                userEmail = "ci@example.com";
+              };
+            };
+          }
+        ];
+      };
+    in {
+      # Cheap macOS validation for the supported cross-platform Home Manager surface.
+      # The Hyprland desktop module stays Linux-only on this branch.
+      terminal-home = macosTerminalHome.activationPackage;
+    };
+
+    # Packages exported for consumption
+    # Note: Tests are in ./tests/flake.nix (separate flake to avoid IFD issues)
+    packages.x86_64-linux = let
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    in {
+      iso = self.nixosConfigurations.keystoneIso.config.system.build.isoImage;
+      zesh = pkgs.callPackage ./packages/zesh {};
+      keystone-installer-ui = pkgs.callPackage ./packages/keystone-installer-ui {};
+      keystone-ha-tui-client = pkgs.callPackage ./packages/keystone-ha/tui {};
+      keystone-agent = pkgs.callPackage ./packages/keystone-agent {};
+    };
+
+    # Development shell
+    devShells.x86_64-linux = let
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    in {
+      default = pkgs.mkShell {
+        name = "keystone-dev";
+
+        # Rust development
+        nativeBuildInputs = with pkgs; [
+          cargo
+          rustc
+          rust-analyzer
+          clippy
+          rustfmt
+          pkg-config
+        ];
+
+        buildInputs = with pkgs; [
+          openssl
+        ];
+
+        # Node.js development
+        packages = with pkgs; [
+          nodejs
+          nodePackages.npm
+          nodePackages.typescript
+          nodePackages.typescript-language-server
+
+          # Nix tools
+          nixfmt-rfc-style
+          nil # Nix LSP
+          nix-tree
+          nvd # Nix version diff
+
+          # VM and deployment tools
+          qemu
+          libvirt
+          virt-viewer
+          swtpm
+
+          # General utilities
+          jq
+          yq-go
+          gh # GitHub CLI
+          python3
+        ];
+
+        shellHook = ''
+          echo "🔑 Keystone development shell"
+          echo ""
+          echo "Available commands:"
+          echo "  ./bin/build-iso        - Build installer ISO"
+          echo "  ./bin/build-vm         - Fast VM testing (terminal/desktop)"
+          echo "  ./bin/virtual-machine  - Full stack VM with libvirt"
+          echo "  nix flake check        - Validate flake"
+          echo ""
+          echo "Rust packages:  packages/keystone-ha/"
+          echo "Node packages:  packages/keystone-installer-ui/"
+        '';
+
+        # Rust environment variables
+        RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+      };
+    };
+
+    # Flake templates for users to scaffold new projects
+    templates = {
+      default = {
+        path = ./templates/default;
+        description = "Keystone infrastructure starter with OS module and home-manager";
+        welcomeText = ''
+          # Keystone Infrastructure Configuration
+
+          Your project has been initialized!
+
+          ## Quick Start
+
+          1. Edit configuration.nix - search for TODO: to find required changes
+          2. Generate hostId: head -c 4 /dev/urandom | od -A none -t x4 | tr -d ' '
+          3. Find your disk: ls -l /dev/disk/by-id/
+          4. Deploy: nixos-anywhere --flake .#my-machine root@<installer-ip>
+
+          See README.md for detailed instructions.
+        '';
+      };
+    };
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -22,188 +22,233 @@
     hyprland.url = "github:hyprwm/Hyprland";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    disko,
-    home-manager,
-    omarchy,
-    lanzaboote,
-    hyprland,
-    ...
-  }: let
-    # Create inputs attrset for desktop module
-    inputs = {
-      inherit nixpkgs hyprland;
-    };
-  in {
-    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt-rfc-style;
-
-    # ISO configuration without SSH keys (use bin/build-iso for SSH keys)
-    # Note: Test/dev configurations are in ./tests/flake.nix
-    nixosConfigurations = {
-      keystoneIso = nixpkgs.lib.nixosSystem {
-        system = "x86_64-linux";
-        modules = [
-          "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
-          ./modules/iso-installer.nix
-          {
-            _module.args.sshKeys = [];
-            # Force kernel 6.12 - must be set here to override minimal CD
-            boot.kernelPackages = nixpkgs.lib.mkForce nixpkgs.legacyPackages.x86_64-linux.linuxPackages_6_12;
-          }
-        ];
+  outputs =
+    {
+      self,
+      nixpkgs,
+      disko,
+      home-manager,
+      omarchy,
+      lanzaboote,
+      hyprland,
+      ...
+    }:
+    let
+      # Create inputs attrset for desktop module
+      inputs = {
+        inherit nixpkgs hyprland;
       };
-    };
+      darwinSystem = "aarch64-darwin";
+    in
+    {
+      formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt-rfc-style;
 
-    # Overlay that provides keystone packages
-    # NOTE: Paths must be captured in `let` BEFORE the function, otherwise they
-    # get evaluated in the wrong context when the overlay is applied by a consumer flake
-    overlays.default = let
-      zesh-src = ./packages/zesh;
-      claude-code-src = ./modules/terminal/claude-code;
-    in final: prev: {
-      keystone = {
-        zesh = final.callPackage zesh-src {};
-        claude-code = final.callPackage claude-code-src {};
-      };
-    };
-
-    # Export Keystone modules for use in other flakes
-    nixosModules = {
-      # Core OS module - storage, secure boot, TPM, remote unlock, users, services
-      operating-system = {
-        imports = [
-          disko.nixosModules.disko
-          lanzaboote.nixosModules.lanzaboote
-          ./modules/os
-        ];
+      # ISO configuration without SSH keys (use bin/build-iso for SSH keys)
+      # Note: Test/dev configurations are in ./tests/flake.nix
+      nixosConfigurations = {
+        keystoneIso = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+            ./modules/iso-installer.nix
+            {
+              _module.args.sshKeys = [ ];
+              # Force kernel 6.12 - must be set here to override minimal CD
+              boot.kernelPackages = nixpkgs.lib.mkForce nixpkgs.legacyPackages.x86_64-linux.linuxPackages_6_12;
+            }
+          ];
+        };
       };
 
-      # Desktop module - Hyprland, audio, greetd (no disko/encryption dependencies)
-      desktop = {
-        imports = [./modules/desktop/nixos.nix];
-        _module.args.inputs = inputs;
+      # Overlay that provides keystone packages
+      # NOTE: Paths must be captured in `let` BEFORE the function, otherwise they
+      # get evaluated in the wrong context when the overlay is applied by a consumer flake
+      overlays.default =
+        let
+          zesh-src = ./packages/zesh;
+          claude-code-src = ./modules/terminal/claude-code;
+        in
+        final: prev: {
+          keystone = {
+            zesh = final.callPackage zesh-src { };
+            claude-code = final.callPackage claude-code-src { };
+          };
+        };
+
+      # Export Keystone modules for use in other flakes
+      nixosModules = {
+        # Core OS module - storage, secure boot, TPM, remote unlock, users, services
+        operating-system = {
+          imports = [
+            disko.nixosModules.disko
+            lanzaboote.nixosModules.lanzaboote
+            ./modules/os
+          ];
+        };
+
+        # Desktop module - Hyprland, audio, greetd (no disko/encryption dependencies)
+        desktop = {
+          imports = [ ./modules/desktop/nixos.nix ];
+          _module.args.inputs = inputs;
+        };
+
+        # Server module - VPN, monitoring, mail (optional services)
+        server = ./modules/server;
+
+        # Agent Sandbox module - isolated AI coding agent environments
+        agent = {
+          imports = [ ./modules/keystone/agent ];
+        };
+
+        # ISO installer module
+        isoInstaller = ./modules/iso-installer.nix;
       };
 
-      # Server module - VPN, monitoring, mail (optional services)
-      server = ./modules/server;
-
-      # Agent Sandbox module - isolated AI coding agent environments
-      agent = {
-        imports = [./modules/keystone/agent];
+      # Export home-manager modules (homeModules is the standard flake output name)
+      homeModules = {
+        desktopHyprland = ./home-manager/modules/desktop/hyprland;
+        # Keystone-specific home-manager modules
+        terminal = ./modules/terminal/default.nix;
+        desktop = ./modules/desktop/home/default.nix;
+        agentTui = ./modules/keystone/agent/home/tui.nix;
       };
 
-      # ISO installer module
-      isoInstaller = ./modules/iso-installer.nix;
-    };
+      checks.${darwinSystem} =
+        let
+          darwinPkgs = import nixpkgs {
+            system = darwinSystem;
+            config.allowUnfree = true;
+            overlays = [ self.overlays.default ];
+          };
+          macosTerminalHome = home-manager.lib.homeManagerConfiguration {
+            pkgs = darwinPkgs;
+            modules = [
+              self.homeModules.terminal
+              {
+                _module.args.inputs = inputs;
 
-    # Export home-manager modules (homeModules is the standard flake output name)
-    homeModules = {
-      desktopHyprland = ./home-manager/modules/desktop/hyprland;
-      # Keystone-specific home-manager modules
-      terminal = ./modules/terminal/default.nix;
-      desktop = ./modules/desktop/home/default.nix;
-      agentTui = ./modules/keystone/agent/home/tui.nix;
-    };
+                home.username = "ci";
+                home.homeDirectory = "/Users/ci";
+                home.stateVersion = "25.05";
 
-    # Packages exported for consumption
-    # Note: Tests are in ./tests/flake.nix (separate flake to avoid IFD issues)
-    packages.x86_64-linux = let
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    in {
-      iso = self.nixosConfigurations.keystoneIso.config.system.build.isoImage;
-      zesh = pkgs.callPackage ./packages/zesh {};
-      keystone-installer-ui = pkgs.callPackage ./packages/keystone-installer-ui {};
-      keystone-ha-tui-client = pkgs.callPackage ./packages/keystone-ha/tui {};
-      keystone-agent = pkgs.callPackage ./packages/keystone-agent {};
-    };
+                keystone.terminal = {
+                  enable = true;
+                  git = {
+                    userName = "CI User";
+                    userEmail = "ci@example.com";
+                  };
+                };
+              }
+            ];
+          };
+        in
+        {
+          # Cheap macOS validation for the supported cross-platform Home Manager surface.
+          # The Hyprland desktop module stays Linux-only on this branch.
+          terminal-home = macosTerminalHome.activationPackage;
+        };
 
-    # Development shell
-    devShells.x86_64-linux = let
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    in {
-      default = pkgs.mkShell {
-        name = "keystone-dev";
+      # Packages exported for consumption
+      # Note: Tests are in ./tests/flake.nix (separate flake to avoid IFD issues)
+      packages.x86_64-linux =
+        let
+          pkgs = nixpkgs.legacyPackages.x86_64-linux;
+        in
+        {
+          iso = self.nixosConfigurations.keystoneIso.config.system.build.isoImage;
+          zesh = pkgs.callPackage ./packages/zesh { };
+          keystone-installer-ui = pkgs.callPackage ./packages/keystone-installer-ui { };
+          keystone-ha-tui-client = pkgs.callPackage ./packages/keystone-ha/tui { };
+          keystone-agent = pkgs.callPackage ./packages/keystone-agent { };
+        };
 
-        # Rust development
-        nativeBuildInputs = with pkgs; [
-          cargo
-          rustc
-          rust-analyzer
-          clippy
-          rustfmt
-          pkg-config
-        ];
+      # Development shell
+      devShells.x86_64-linux =
+        let
+          pkgs = nixpkgs.legacyPackages.x86_64-linux;
+        in
+        {
+          default = pkgs.mkShell {
+            name = "keystone-dev";
 
-        buildInputs = with pkgs; [
-          openssl
-        ];
+            # Rust development
+            nativeBuildInputs = with pkgs; [
+              cargo
+              rustc
+              rust-analyzer
+              clippy
+              rustfmt
+              pkg-config
+            ];
 
-        # Node.js development
-        packages = with pkgs; [
-          nodejs
-          nodePackages.npm
-          nodePackages.typescript
-          nodePackages.typescript-language-server
+            buildInputs = with pkgs; [
+              openssl
+            ];
 
-          # Nix tools
-          nixfmt-rfc-style
-          nil # Nix LSP
-          nix-tree
-          nvd # Nix version diff
+            # Node.js development
+            packages = with pkgs; [
+              nodejs
+              nodePackages.npm
+              nodePackages.typescript
+              nodePackages.typescript-language-server
 
-          # VM and deployment tools
-          qemu
-          libvirt
-          virt-viewer
-          swtpm
+              # Nix tools
+              nixfmt-rfc-style
+              nil # Nix LSP
+              nix-tree
+              nvd # Nix version diff
 
-          # General utilities
-          jq
-          yq-go
-          gh # GitHub CLI
-          python3
-        ];
+              # VM and deployment tools
+              qemu
+              libvirt
+              virt-viewer
+              swtpm
 
-        shellHook = ''
-          echo "🔑 Keystone development shell"
-          echo ""
-          echo "Available commands:"
-          echo "  ./bin/build-iso        - Build installer ISO"
-          echo "  ./bin/build-vm         - Fast VM testing (terminal/desktop)"
-          echo "  ./bin/virtual-machine  - Full stack VM with libvirt"
-          echo "  nix flake check        - Validate flake"
-          echo ""
-          echo "Rust packages:  packages/keystone-ha/"
-          echo "Node packages:  packages/keystone-installer-ui/"
-        '';
+              # General utilities
+              jq
+              yq-go
+              gh # GitHub CLI
+              python3
+            ];
 
-        # Rust environment variables
-        RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+            shellHook = ''
+              echo "🔑 Keystone development shell"
+              echo ""
+              echo "Available commands:"
+              echo "  ./bin/build-iso        - Build installer ISO"
+              echo "  ./bin/build-vm         - Fast VM testing (terminal/desktop)"
+              echo "  ./bin/virtual-machine  - Full stack VM with libvirt"
+              echo "  nix flake check        - Validate flake"
+              echo ""
+              echo "Rust packages:  packages/keystone-ha/"
+              echo "Node packages:  packages/keystone-installer-ui/"
+            '';
+
+            # Rust environment variables
+            RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+          };
+        };
+
+      # Flake templates for users to scaffold new projects
+      templates = {
+        default = {
+          path = ./templates/default;
+          description = "Keystone infrastructure starter with OS module and home-manager";
+          welcomeText = ''
+            # Keystone Infrastructure Configuration
+
+            Your project has been initialized!
+
+            ## Quick Start
+
+            1. Edit configuration.nix - search for TODO: to find required changes
+            2. Generate hostId: head -c 4 /dev/urandom | od -A none -t x4 | tr -d ' '
+            3. Find your disk: ls -l /dev/disk/by-id/
+            4. Deploy: nixos-anywhere --flake .#my-machine root@<installer-ip>
+
+            See README.md for detailed instructions.
+          '';
+        };
       };
     };
-
-    # Flake templates for users to scaffold new projects
-    templates = {
-      default = {
-        path = ./templates/default;
-        description = "Keystone infrastructure starter with OS module and home-manager";
-        welcomeText = ''
-          # Keystone Infrastructure Configuration
-
-          Your project has been initialized!
-
-          ## Quick Start
-
-          1. Edit configuration.nix - search for TODO: to find required changes
-          2. Generate hostId: head -c 4 /dev/urandom | od -A none -t x4 | tr -d ' '
-          3. Find your disk: ls -l /dev/disk/by-id/
-          4. Deploy: nixos-anywhere --flake .#my-machine root@<installer-ip>
-
-          See README.md for detailed instructions.
-        '';
-      };
-    };
-  };
 }


### PR DESCRIPTION
## Summary
- add a path-filtered `macos-latest` job for the cross-platform terminal Home Manager surface
- expose `checks.aarch64-darwin.terminal-home` so CI can build a real Darwin activation package
- document in workflow comments that Hyprland, portals, and the yazi file-picker path stay Linux-only on this branch

## Why this shape
This repo is public, so the standard GitHub-hosted `macos-latest` runner is the cheap option; there is no need to reach for larger macOS runners for this validation path. The branch still does not ship `nix-darwin` or a macOS desktop surface, so the check intentionally validates only the supported cross-platform terminal module.

## Verification
- `nix eval --raw .#checks.aarch64-darwin.terminal-home.drvPath`
- `nix flake check --no-build --all-systems`

Stacked on #56.