### PR TITLE
feat(notes): add daily rollover sync

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -41,7 +41,8 @@ module's role is shifting to pure knowledge management. The option surface and
 zk integration may be restructured.
 
 **Options**: `keystone.notes.enable`, `.repo`, `.path`, `.syncInterval`,
-`.commitPrefix`, `.sync.enable`, `.zk.enable`
+`.commitPrefix`, `.sync.enable`, `.daily.enable`, `.daily.symlinkPath`,
+`.daily.journalPath`, `.daily.dateFormat`, `.zk.enable`
 
 ### `keystone.terminal.conventions` — Agent instruction generation
 

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -56,6 +56,11 @@ Keystone automatically fetches and pushes the notes repo on a timer.
 This makes the notes repo usable as shared state between the human operator,
 desktop project navigation, `pz`, and agent workflows.
 
+When `keystone.notes.daily.enable = true`, the same sync path also keeps
+`daily.md` pointed at today's dated journal note (for example
+`journal/2026-05-22.md`). The first sync after a day rollover commits and
+pushes the symlink move automatically.
+
 ## What the notes system is for
 
 Use the notes system to:
@@ -95,6 +100,7 @@ bodies into a new note each day.
 The current notes model uses these groups:
 
 - `inbox/` for quick captures and raw notes
+- `journal/` for dated daily notes such as `journal/2026-05-22.md`
 - `literature/` for source summaries
 - `notes/` for durable idea notes
 - `decisions/` for explicit decisions
@@ -344,7 +350,9 @@ and update a relevant system or operations hub if one exists.
 ## Where this is configured
 
 - The home-manager notes module syncs the notes repo and can scaffold a zk
-  notebook for human users.
+  notebook for human users. When `keystone.notes.daily.enable = true`, it also
+  rotates `daily.md` to the current `journal/YYYY-MM-DD.md` target before the
+  sync commit/push step.
 - OS agents use the same notebook model in their agent-space.
 - The AI command layer exposes the notes workflows across the supported coding
   agents, with tool-specific UX differences.

--- a/flake.nix
+++ b/flake.nix
@@ -444,6 +444,13 @@
               ;
             self = self;
           };
+          notesEvaluation = import ./tests/module/notes-evaluation.nix {
+            inherit
+              pkgs
+              home-manager
+              ;
+            self = self;
+          };
           templateUpdateChannel = import ./tests/module/template-update-channel.nix {
             inherit pkgs lib;
             self = self;
@@ -540,6 +547,7 @@
           os-evaluation = osEvaluation;
           agent-evaluation = agentEvaluation;
           template-evaluation = templateEvaluation;
+          notes-evaluation = notesEvaluation;
           template-update-channel = templateUpdateChannel;
           template-special-args = templateSpecialArgs;
           server-evaluation = serverEvaluation;
@@ -583,6 +591,7 @@
             ln -s ${osEvaluation} "$out/os-evaluation"
             ln -s ${agentEvaluation} "$out/agent-evaluation"
             ln -s ${templateEvaluation} "$out/template-evaluation"
+            ln -s ${notesEvaluation} "$out/notes-evaluation"
             ln -s ${templateUpdateChannel} "$out/template-update-channel"
             ln -s ${templateSpecialArgs} "$out/template-special-args"
             ln -s ${serverEvaluation} "$out/server-evaluation"

--- a/modules/notes/default.nix
+++ b/modules/notes/default.nix
@@ -276,6 +276,87 @@ let
       chmod g+s "$NOTES_PATH/.zk"
     fi
   '';
+
+  dailyRolloverScript = pkgs.writeShellScript "keystone-notes-daily-rollover" ''
+    set -euo pipefail
+
+    NOTES_PATH=${lib.escapeShellArg cfg.path}
+    DAILY_REL=${lib.escapeShellArg cfg.daily.symlinkPath}
+    JOURNAL_REL=${lib.escapeShellArg cfg.daily.journalPath}
+    TODAY_FILE_NAME="$(date +${lib.escapeShellArg cfg.daily.dateFormat}).md"
+
+    DAILY_PATH="$NOTES_PATH/$DAILY_REL"
+    JOURNAL_PATH="$NOTES_PATH/$JOURNAL_REL"
+    TARGET_REL="$JOURNAL_REL/$TODAY_FILE_NAME"
+    TARGET_PATH="$NOTES_PATH/$TARGET_REL"
+
+    if [[ ! -d "$NOTES_PATH/.git" ]]; then
+      exit 0
+    fi
+
+    ${pkgs.coreutils}/bin/mkdir -p \
+      "$JOURNAL_PATH" \
+      "$(${pkgs.coreutils}/bin/dirname "$DAILY_PATH")"
+
+    if [[ -L "$DAILY_PATH" ]] && [[ "$(${pkgs.coreutils}/bin/readlink "$DAILY_PATH")" == "$TARGET_REL" ]]; then
+      if [[ ! -e "$TARGET_PATH" ]]; then
+        : > "$TARGET_PATH"
+      fi
+      exit 0
+    fi
+
+    if [[ -e "$DAILY_PATH" ]] && [[ ! -L "$DAILY_PATH" ]]; then
+      if [[ "$(${pkgs.coreutils}/bin/realpath -m "$DAILY_PATH")" != "$(${pkgs.coreutils}/bin/realpath -m "$TARGET_PATH")" ]]; then
+        if [[ ! -e "$TARGET_PATH" ]]; then
+          ${pkgs.coreutils}/bin/mv "$DAILY_PATH" "$TARGET_PATH"
+        else
+          if ! ${pkgs.diffutils}/bin/cmp -s "$DAILY_PATH" "$TARGET_PATH"; then
+            printf '\n' >> "$TARGET_PATH"
+            ${pkgs.coreutils}/bin/cat "$DAILY_PATH" >> "$TARGET_PATH"
+          fi
+          ${pkgs.coreutils}/bin/rm -f "$DAILY_PATH"
+        fi
+      fi
+    fi
+
+    if [[ ! -e "$TARGET_PATH" ]]; then
+      : > "$TARGET_PATH"
+    fi
+
+    TMP_LINK="$DAILY_PATH.tmp"
+    ${pkgs.coreutils}/bin/ln -sfn "$TARGET_REL" "$TMP_LINK"
+    ${pkgs.coreutils}/bin/mv -Tf "$TMP_LINK" "$DAILY_PATH"
+  '';
+
+  notesSyncScript = pkgs.writeShellScript "keystone-notes-sync" ''
+    set -euo pipefail
+
+    NOTES_GIT_DIR=${lib.escapeShellArg "${cfg.path}/.git"}
+
+    repo_sync() {
+      ${pkgs.keystone.repo-sync}/bin/repo-sync \
+        --repo ${lib.escapeShellArg cfg.repo} \
+        --path ${lib.escapeShellArg cfg.path} \
+        --commit-prefix ${lib.escapeShellArg cfg.commitPrefix} \
+        --log-dir ${lib.escapeShellArg "${config.home.homeDirectory}/.local/state/notes-sync/logs"}
+    }
+
+    if [[ ! -d "$NOTES_GIT_DIR" ]]; then
+      repo_sync
+
+      # First-run daily rollover needs a second sync pass because repo-sync is
+      # responsible for the initial clone.
+      ${lib.optionalString cfg.daily.enable ''
+        ${dailyRolloverScript}
+        repo_sync
+      ''}
+    else
+      ${lib.optionalString cfg.daily.enable ''
+        ${dailyRolloverScript}
+      ''}
+      repo_sync
+    fi
+  '';
 in
 {
   imports = [ ../shared/experimental.nix ];
@@ -320,12 +401,45 @@ in
       };
     };
 
+    daily = {
+      enable = lib.mkEnableOption "git-tracked daily note rollover";
+
+      symlinkPath = lib.mkOption {
+        type = lib.types.str;
+        default = "daily.md";
+        description = "Path to the current daily note entrypoint, relative to the notes repo root.";
+      };
+
+      journalPath = lib.mkOption {
+        type = lib.types.str;
+        default = "journal";
+        description = "Directory for dated daily notes, relative to the notes repo root.";
+      };
+
+      dateFormat = lib.mkOption {
+        type = lib.types.str;
+        default = "%Y-%m-%d";
+        description = "Format string passed to date(1) when deriving the dated daily note filename.";
+      };
+    };
+
     zk = {
       enable = lib.mkEnableOption "zk Zettelkasten notebook initialization";
     };
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = lib.optionals cfg.daily.enable [
+      {
+        assertion = !lib.hasPrefix "/" cfg.daily.symlinkPath;
+        message = "keystone.notes.daily.symlinkPath must be relative to keystone.notes.path.";
+      }
+      {
+        assertion = !lib.hasPrefix "/" cfg.daily.journalPath;
+        message = "keystone.notes.daily.journalPath must be relative to keystone.notes.path.";
+      }
+    ];
+
     systemd.user.services.keystone-notes-sync = lib.mkIf (cfg.sync.enable && cfg.repo != "") {
       Unit = {
         Description = "Sync notes repo via repo-sync";
@@ -336,13 +450,7 @@ in
         Environment = [
           "SSH_AUTH_SOCK=${sshAuthSock}"
         ];
-        ExecStart = builtins.concatStringsSep " " [
-          "${pkgs.keystone.repo-sync}/bin/repo-sync"
-          "--repo ${lib.escapeShellArg cfg.repo}"
-          "--path ${lib.escapeShellArg cfg.path}"
-          "--commit-prefix ${lib.escapeShellArg cfg.commitPrefix}"
-          "--log-dir ${config.home.homeDirectory}/.local/state/notes-sync/logs"
-        ];
+        ExecStart = "${notesSyncScript}";
         ExecStartPost = "${pkgs.bash}/bin/bash -lc 'if command -v pz >/dev/null 2>&1; then pz export-menu-cache --write-state >/dev/null 2>&1 || true; fi'";
       };
     };

--- a/modules/notes/default.nix
+++ b/modules/notes/default.nix
@@ -27,6 +27,7 @@
 }:
 let
   cfg = config.keystone.notes;
+  pathHasParentTraversal = path: builtins.elem ".." (lib.splitString "/" path);
   sshAuthSock =
     if
       lib.hasAttrByPath [
@@ -298,6 +299,14 @@ let
       "$JOURNAL_PATH" \
       "$(${pkgs.coreutils}/bin/dirname "$DAILY_PATH")"
 
+    DAILY_REAL="$(${pkgs.coreutils}/bin/realpath -m "$DAILY_PATH")"
+    TARGET_REAL="$(${pkgs.coreutils}/bin/realpath -m "$TARGET_PATH")"
+
+    if [[ "$DAILY_REAL" == "$TARGET_REAL" ]]; then
+      echo "keystone-notes-daily-rollover: daily.symlinkPath resolves to today's journal target; refusing to replace the note with a symlink" >&2
+      exit 1
+    fi
+
     if [[ -L "$DAILY_PATH" ]] && [[ "$(${pkgs.coreutils}/bin/readlink "$DAILY_PATH")" == "$TARGET_REL" ]]; then
       if [[ ! -e "$TARGET_PATH" ]]; then
         : > "$TARGET_PATH"
@@ -431,12 +440,14 @@ in
   config = lib.mkIf cfg.enable {
     assertions = lib.optionals cfg.daily.enable [
       {
-        assertion = !lib.hasPrefix "/" cfg.daily.symlinkPath;
-        message = "keystone.notes.daily.symlinkPath must be relative to keystone.notes.path.";
+        assertion =
+          !lib.hasPrefix "/" cfg.daily.symlinkPath && !pathHasParentTraversal cfg.daily.symlinkPath;
+        message = "keystone.notes.daily.symlinkPath must stay under keystone.notes.path and must not contain '..' segments.";
       }
       {
-        assertion = !lib.hasPrefix "/" cfg.daily.journalPath;
-        message = "keystone.notes.daily.journalPath must be relative to keystone.notes.path.";
+        assertion =
+          !lib.hasPrefix "/" cfg.daily.journalPath && !pathHasParentTraversal cfg.daily.journalPath;
+        message = "keystone.notes.daily.journalPath must stay under keystone.notes.path and must not contain '..' segments.";
       }
     ];
 

--- a/specs/REQ-009-notes.md
+++ b/specs/REQ-009-notes.md
@@ -70,3 +70,26 @@ macOS in the future).
 
 **REQ-009.15** The module MAY provide launchd plist generation for macOS
 support as a future extension.
+
+### Daily note rollover
+
+**REQ-009.16** The module MUST expose `keystone.notes.daily.enable` (bool,
+default `false`) to opt into git-tracked daily note rollover.
+
+**REQ-009.17** When `keystone.notes.daily.enable = true`, the notes sync path
+MUST ensure the configured daily entrypoint (default `daily.md`) is a relative
+symlink to a dated note under the configured journal directory (default
+`journal/YYYY-MM-DD.md`) before the final sync pass commits and pushes changes.
+
+**REQ-009.18** The module MUST create the dated target note if it does not yet
+exist, so a day rollover can be committed even before the user manually edits
+the new file.
+
+**REQ-009.19** If the daily entrypoint already exists as a regular file on the
+same day the feature is enabled, the module MUST migrate that content into the
+dated target note before replacing the entrypoint with a symlink.
+
+**REQ-009.20** On first run, when the notes repo is cloned by the sync path,
+the module MUST perform an additional sync pass after daily rollover so the
+newly-created symlink change is committed and pushed without waiting for the
+next timer tick.

--- a/specs/REQ-009-notes.md
+++ b/specs/REQ-009-notes.md
@@ -93,3 +93,12 @@ dated target note before replacing the entrypoint with a symlink.
 the module MUST perform an additional sync pass after daily rollover so the
 newly-created symlink change is committed and pushed without waiting for the
 next timer tick.
+
+**REQ-009.21** `keystone.notes.daily.symlinkPath` and
+`keystone.notes.daily.journalPath` MUST stay under `keystone.notes.path`. The
+module MUST reject absolute paths and parent-directory traversal segments such
+as `..`.
+
+**REQ-009.22** The rollover helper MUST fail fast when the configured daily
+entrypoint resolves to the same path as the derived dated target note, so it
+cannot replace a real note with a symlink.

--- a/tests/module/notes-evaluation.nix
+++ b/tests/module/notes-evaluation.nix
@@ -48,6 +48,15 @@ let
     }
   ]);
 
+  parentTraversalResult = builtins.tryEval (evalNotes [
+    {
+      keystone.notes.daily = {
+        enable = true;
+        symlinkPath = "../daily.md";
+      };
+    }
+  ]);
+
   enabledExecStart = normalizeCommand enabledConfig.systemd.user.services.keystone-notes-sync.Service.ExecStart;
   disabledExecStart = normalizeCommand disabledConfig.systemd.user.services.keystone-notes-sync.Service.ExecStart;
   execStartPost = normalizeCommand (
@@ -55,6 +64,7 @@ let
   );
   timerCalendar = enabledConfig.systemd.user.timers.keystone-notes-sync.Timer.OnCalendar;
   assertionTripped = !badConfigResult.success;
+  parentTraversalAssertionTripped = !parentTraversalResult.success;
   boolString = value: if value then "true" else "false";
 in
 pkgs.runCommand "notes-evaluation" { } ''
@@ -99,6 +109,18 @@ pkgs.runCommand "notes-evaluation" { } ''
       echo "PASS: daily-enabled sync script derives the dated journal target"
     fi
 
+    if [ -z "$rollover_helper" ] || ! grep -Fq 'if [[ "$DAILY_REAL" == "$TARGET_REAL" ]]' "$rollover_helper"; then
+      echo "FAIL: daily-enabled sync script does not guard against daily/target path aliasing" >&2
+      if [ -n "$rollover_helper" ]; then
+        cat "$rollover_helper" >&2
+      else
+        cat "$enabled_script" >&2
+      fi
+      errors=$((errors + 1))
+    else
+      echo "PASS: daily-enabled sync script guards against daily/target path aliasing"
+    fi
+
     if ! grep -Fq '/bin/repo-sync' "$enabled_script"; then
       echo "FAIL: daily-enabled sync script does not wrap repo-sync" >&2
       cat "$enabled_script" >&2
@@ -131,6 +153,9 @@ pkgs.runCommand "notes-evaluation" { } ''
 
     check "${boolString assertionTripped}" \
       "absolute daily symlink paths trip the module assertion"
+
+    check "${boolString parentTraversalAssertionTripped}" \
+      "parent traversal in daily symlink paths trips the module assertion"
 
     if [ "$errors" -gt 0 ]; then
       echo "$errors test(s) failed" >&2

--- a/tests/module/notes-evaluation.nix
+++ b/tests/module/notes-evaluation.nix
@@ -1,0 +1,141 @@
+{
+  pkgs,
+  self,
+  home-manager,
+}:
+let
+  normalizeCommand =
+    value: if builtins.isList value then builtins.concatStringsSep "\n" value else value;
+
+  evalNotes =
+    extraModules:
+    (home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      modules = [
+        self.homeModules.notes
+        {
+          nixpkgs.overlays = [ self.overlays.default ];
+          home.username = "testuser";
+          home.homeDirectory = "/home/testuser";
+          home.stateVersion = "25.05";
+
+          keystone.notes = {
+            enable = true;
+            repo = "git@example.com:test/notes.git";
+          };
+        }
+      ]
+      ++ extraModules;
+    }).config;
+
+  enabledConfig = evalNotes [
+    {
+      keystone.notes = {
+        syncInterval = "hourly";
+        daily.enable = true;
+      };
+    }
+  ];
+
+  disabledConfig = evalNotes [ ];
+
+  badConfigResult = builtins.tryEval (evalNotes [
+    {
+      keystone.notes.daily = {
+        enable = true;
+        symlinkPath = "/tmp/daily.md";
+      };
+    }
+  ]);
+
+  enabledExecStart = normalizeCommand enabledConfig.systemd.user.services.keystone-notes-sync.Service.ExecStart;
+  disabledExecStart = normalizeCommand disabledConfig.systemd.user.services.keystone-notes-sync.Service.ExecStart;
+  execStartPost = normalizeCommand (
+    enabledConfig.systemd.user.services.keystone-notes-sync.Service.ExecStartPost or ""
+  );
+  timerCalendar = enabledConfig.systemd.user.timers.keystone-notes-sync.Timer.OnCalendar;
+  assertionTripped = !badConfigResult.success;
+  boolString = value: if value then "true" else "false";
+in
+pkgs.runCommand "notes-evaluation" { } ''
+    set -euo pipefail
+    errors=0
+
+    enabled_script="${enabledExecStart}"
+    disabled_script="${disabledExecStart}"
+    exec_start_post_file="$TMPDIR/exec-start-post.sh"
+    rollover_helper="$(grep -o '/nix/store/[^[:space:]]*-keystone-notes-daily-rollover' "$enabled_script" | head -n 1 || true)"
+
+    cat >"$exec_start_post_file" <<'EOF_EXEC_START_POST'
+  ${execStartPost}
+  EOF_EXEC_START_POST
+
+    check() {
+      if [ "$1" = "true" ]; then
+        echo "PASS: $2"
+      else
+        echo "FAIL: $2" >&2
+        errors=$((errors + 1))
+      fi
+    }
+
+    if ! grep -Fq 'keystone-notes-daily-rollover' "$enabled_script"; then
+      echo "FAIL: daily-enabled sync script does not invoke rollover helper" >&2
+      cat "$enabled_script" >&2
+      errors=$((errors + 1))
+    else
+      echo "PASS: daily-enabled sync script invokes rollover helper"
+    fi
+
+    if [ -z "$rollover_helper" ] || ! grep -Fq 'TARGET_REL="$JOURNAL_REL/$TODAY_FILE_NAME"' "$rollover_helper"; then
+      echo "FAIL: daily-enabled sync script does not derive the dated journal target" >&2
+      if [ -n "$rollover_helper" ]; then
+        cat "$rollover_helper" >&2
+      else
+        cat "$enabled_script" >&2
+      fi
+      errors=$((errors + 1))
+    else
+      echo "PASS: daily-enabled sync script derives the dated journal target"
+    fi
+
+    if ! grep -Fq '/bin/repo-sync' "$enabled_script"; then
+      echo "FAIL: daily-enabled sync script does not wrap repo-sync" >&2
+      cat "$enabled_script" >&2
+      errors=$((errors + 1))
+    else
+      echo "PASS: daily-enabled sync script wraps repo-sync"
+    fi
+
+    if grep -Fq 'keystone-notes-daily-rollover' "$disabled_script"; then
+      echo "FAIL: daily-disabled sync script should not invoke rollover helper" >&2
+      cat "$disabled_script" >&2
+      errors=$((errors + 1))
+    else
+      echo "PASS: daily-disabled sync script skips rollover helper"
+    fi
+
+    if [ "${timerCalendar}" != "hourly" ]; then
+      echo "FAIL: expected timer OnCalendar=hourly, got '${timerCalendar}'" >&2
+      errors=$((errors + 1))
+    else
+      echo "PASS: timer respects custom OnCalendar"
+    fi
+
+    if ! grep -Fq 'pz export-menu-cache --write-state' "$exec_start_post_file"; then
+      echo "FAIL: ExecStartPost no longer refreshes the project menu cache" >&2
+      errors=$((errors + 1))
+    else
+      echo "PASS: ExecStartPost still refreshes the project menu cache"
+    fi
+
+    check "${boolString assertionTripped}" \
+      "absolute daily symlink paths trip the module assertion"
+
+    if [ "$errors" -gt 0 ]; then
+      echo "$errors test(s) failed" >&2
+      exit 1
+    fi
+
+    touch "$out"
+''


### PR DESCRIPTION
## Summary

- add opt-in `keystone.notes.daily.*` options so human notes repos can keep `daily.md` as a git-tracked relative symlink to `journal/YYYY-MM-DD.md`
- wrap the existing `repo-sync` path so first-run clone, daily rollover, commit, and push can happen in the same timer cycle
- add a focused `notes-evaluation` flake check and update the notes spec and docs for the new rollover behavior

## Verification

- `nix build .#checks.x86_64-linux.notes-evaluation`
- `git diff --check origin/main...HEAD`
- attempted `nix develop -c ks build`, but not claiming this as a pass because the wrapper process remained idle after its `nix eval` child exited
