### PR TITLE
feat(terminal): add zide workspace helper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -522,6 +522,13 @@
               home-manager
               ;
           };
+          terminalZide = import ./tests/module/terminal-zide.nix {
+            inherit
+              pkgs
+              self
+              home-manager
+              ;
+          };
           agentTaskLoopHashRegression = import ./tests/module/agent-task-loop-hash-regression.nix {
             inherit pkgs lib;
           };
@@ -570,6 +577,7 @@
           agentctl-regression = agentctlRegression;
           binary-cache-client-merge = binaryCacheClientMerge;
           zellij-tab-prompt = zellijTabPrompt;
+          terminal-zide = terminalZide;
           agent-task-loop-hash-regression = agentTaskLoopHashRegression;
           agent-task-loop-ping-pong = agentTaskLoopPingPong;
           agent-runtime-coherence = agentRuntimeCoherence;
@@ -637,6 +645,7 @@
             ln -s ${agentQueueMigration} "$out/agent-queue-migration"
             ln -s ${binaryCacheClientMerge} "$out/binary-cache-client-merge"
             ln -s ${zellijTabPrompt} "$out/zellij-tab-prompt"
+            ln -s ${terminalZide} "$out/terminal-zide"
           '';
         };
 
@@ -666,6 +675,7 @@
             ks
             pz
             cfait
+            zide
             zellij-tab-name
             write-polkit-theme
             chrome-devtools-mcp

--- a/modules/terminal/default.nix
+++ b/modules/terminal/default.nix
@@ -49,6 +49,7 @@ in
     ../shared/repos.nix
     ../shared/update.nix
     ./shell.nix
+    ./zide.nix
     ./editor.nix
     ./conventions.nix
     ./agents

--- a/modules/terminal/zide.nix
+++ b/modules/terminal/zide.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  cfg = config.keystone.terminal;
+in
+{
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.keystone.zide ];
+
+    home.sessionVariables = {
+      ZIDE_DEFAULT_LAYOUT = mkDefault "default";
+      ZIDE_FILE_PICKER = mkDefault "yazi";
+    };
+  };
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -31,6 +31,7 @@ let
   repo-sync-src = ../packages/repo-sync;
   podman-agent-src = ../packages/podman-agent;
   cfait-src = ../packages/cfait;
+  zide-src = ../packages/zide;
   zellij-tab-name-src = ../packages/zellij-tab-name;
   hyprpolkitagent-src = ../packages/hyprpolkitagent;
   write-polkit-theme-src = ../packages/write-polkit-theme;
@@ -84,6 +85,7 @@ in
     ks = final.callPackage ks-src { };
     pz = final.callPackage pz-src { };
     cfait = final.callPackage cfait-src { };
+    zide = final.callPackage zide-src { };
     zellij-tab-name = final.callPackage zellij-tab-name-src { };
     hyprpolkitagent = final.callPackage hyprpolkitagent-src { };
     write-polkit-theme = final.callPackage write-polkit-theme-src { };

--- a/packages/zide/bin/zide
+++ b/packages/zide/bin/zide
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+ZIDE_DIR="$(cd -- "${script_dir}/.." && pwd -P)"
+export ZIDE_DIR
+
+usage() {
+  cat <<'EOF'
+Usage: zide [OPTIONS] [working_dir] [layout]
+
+Options:
+  -h, --help      Show this help text.
+  -p, --picker    File picker command to use.
+  -n, --name      Name the new Zellij session or tab.
+  -N              Name the session or tab after the working directory.
+EOF
+}
+
+picker="${ZIDE_FILE_PICKER:-}"
+name=""
+name_from_dir=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -p | --picker)
+      [[ $# -ge 2 ]] || { echo "zide: --picker requires a value" >&2; exit 2; }
+      picker="$2"
+      shift 2
+      ;;
+    -n | --name)
+      [[ $# -ge 2 ]] || { echo "zide: --name requires a value" >&2; exit 2; }
+      name="$2"
+      shift 2
+      ;;
+    -N)
+      name_from_dir=true
+      shift
+      ;;
+    -*)
+      echo "zide: unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+working_dir="${1:-$PWD}"
+layout="${2:-${ZIDE_DEFAULT_LAYOUT:-default}}"
+cwd="$(cd -- "$working_dir" && pwd -P)"
+
+if [[ -z "$name" && "${ZIDE_ALWAYS_NAME:-false}" == "true" ]]; then
+  name_from_dir=true
+fi
+
+if [[ -z "$name" && "$name_from_dir" == "true" ]]; then
+  name="$(basename -- "$cwd")"
+fi
+
+export ZIDE_FILE_PICKER="${picker:-yazi}"
+export ZIDE_ORIGINAL_EDITOR="${EDITOR:-hx}"
+export ZIDE_TAB_NAME="$name"
+export ZIDE_LAYOUT_DIR="${ZIDE_LAYOUT_DIR:-${ZIDE_DIR}/layouts}"
+
+layout_path="${layout}"
+if [[ "$layout_path" != */* ]]; then
+  layout_path="${ZIDE_LAYOUT_DIR}/${layout_path}"
+fi
+if [[ ! -f "$layout_path" && -f "${layout_path}.kdl" ]]; then
+  layout_path="${layout_path}.kdl"
+fi
+if [[ ! -f "$layout_path" ]]; then
+  echo "zide: layout not found: $layout" >&2
+  exit 1
+fi
+
+if [[ -n "${ZELLIJ:-}" ]]; then
+  args=(action new-tab --cwd "$cwd" --layout "$layout_path")
+  if [[ -n "$name" ]]; then
+    args+=(--name "$name")
+  fi
+  zellij "${args[@]}"
+else
+  cd -- "$cwd"
+  args=(--layout "$layout_path")
+  if [[ -n "$name" ]]; then
+    args=(--session "$name" "${args[@]}")
+  fi
+  exec zellij "${args[@]}"
+fi

--- a/packages/zide/bin/zide-edit
+++ b/packages/zide/bin/zide-edit
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: zide-edit [OPTIONS] <path>...
+
+Options:
+  -h, --help       Show this help text.
+  -c, --command    Editor command mode: open, hsplit, or vsplit.
+EOF
+}
+
+editor_command() {
+  local editor="$1"
+  local action="$2"
+
+  case "$(basename -- "$editor"):$action" in
+    hx:open | helix:open) printf 'open' ;;
+    hx:hsplit | helix:hsplit) printf 'hsplit' ;;
+    hx:vsplit | helix:vsplit) printf 'vsplit' ;;
+    hx:cd | helix:cd) printf 'cd' ;;
+    nvim:open | vim:open | vi:open) printf 'edit' ;;
+    nvim:hsplit | vim:hsplit | vi:hsplit) printf 'split' ;;
+    nvim:vsplit | vim:vsplit | vi:vsplit) printf 'vsplit' ;;
+    nvim:cd | vim:cd | vi:cd) printf 'cd' ;;
+    kak:open | kak:hsplit | kak:vsplit) printf 'edit' ;;
+    kak:cd) printf 'cd' ;;
+    *) printf '%s' "$action" ;;
+  esac
+}
+
+command="open"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -c | --command)
+      [[ $# -ge 2 ]] || { echo "zide-edit: --command requires a value" >&2; exit 2; }
+      command="$2"
+      shift 2
+      ;;
+    -*)
+      echo "zide-edit: unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $# -eq 0 ]]; then
+  exit 0
+fi
+
+editor="${ZIDE_ORIGINAL_EDITOR:-${EDITOR:-hx}}"
+escaped_paths=()
+for path in "$@"; do
+  escaped_paths+=("$(printf '%q' "$path")")
+done
+
+zellij action focus-next-pane
+
+if [[ $# -eq 1 && -d "$1" ]]; then
+  cd_command="$(editor_command "$editor" cd)"
+  zellij action write 27
+  zellij action write-chars ":${cd_command} ${escaped_paths[0]}"
+  zellij action write 13
+  sleep "$(printf '%s' "${#escaped_paths[0]} / 150" | bc -l)"
+fi
+
+open_command="$(editor_command "$editor" "$command")"
+zellij action write 27
+zellij action write-chars ":${open_command} ${escaped_paths[*]}"
+zellij action write 13

--- a/packages/zide/bin/zide-pick
+++ b/packages/zide/bin/zide-pick
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+ZIDE_DIR="${ZIDE_DIR:-$(cd -- "${script_dir}/.." && pwd -P)}"
+export ZIDE_DIR
+
+usage() {
+  cat <<'EOF'
+Usage: zide-pick [OPTIONS] [working_dir]
+
+Options:
+  -h, --help       Show this help text.
+  -c, --command    Editor command mode: open, hsplit, or vsplit.
+  -p, --picker     File picker command to use.
+EOF
+}
+
+picker=""
+command="open"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -c | --command)
+      [[ $# -ge 2 ]] || { echo "zide-pick: --command requires a value" >&2; exit 2; }
+      command="$2"
+      shift 2
+      ;;
+    -p | --picker)
+      [[ $# -ge 2 ]] || { echo "zide-pick: --picker requires a value" >&2; exit 2; }
+      picker="$2"
+      shift 2
+      ;;
+    -*)
+      echo "zide-pick: unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+picker="${picker:-${ZIDE_FILE_PICKER:-yazi}}"
+working_dir="${1:-$PWD}"
+
+if ! command -v "$picker" >/dev/null 2>&1; then
+  echo "zide-pick: picker is not installed or not on PATH: $picker" >&2
+  exit 1
+fi
+
+env_args=(EDITOR="zide-edit -c ${command}")
+if [[ "$picker" == "yazi" && "${ZIDE_USE_YAZI_CONFIG:-true}" != "false" ]]; then
+  env_args+=(YAZI_CONFIG_HOME="${ZIDE_USE_YAZI_CONFIG:-${ZIDE_DIR}/yazi}")
+fi
+if [[ "$picker" == "lf" && "${ZIDE_USE_LF_CONFIG:-true}" != "false" ]]; then
+  env_args+=(LF_CONFIG_HOME="${ZIDE_USE_LF_CONFIG:-${ZIDE_DIR}}")
+fi
+
+env "${env_args[@]}" "$picker" "$working_dir"

--- a/packages/zide/bin/zide-rename
+++ b/packages/zide/bin/zide-rename
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: zide-rename [name]
+
+Rename the current Zellij tab using the provided name or ZIDE_TAB_NAME.
+EOF
+}
+
+case "${1:-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+esac
+
+name="${1:-${ZIDE_TAB_NAME:-}}"
+if [[ -z "$name" || -z "${ZELLIJ:-}" ]]; then
+  exit 0
+fi
+
+zellij action rename-tab "$name"

--- a/packages/zide/default.nix
+++ b/packages/zide/default.nix
@@ -1,0 +1,73 @@
+{
+  bash,
+  bc,
+  coreutils,
+  lazygit,
+  lib,
+  makeWrapper,
+  stdenvNoCC,
+  yazi,
+  zellij,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "keystone-zide";
+  version = "0.1.0";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin" "$out/layouts" "$out/yazi" "$out/lf"
+    install -Dm755 bin/* -t "$out/bin/"
+    cp -r layouts/* "$out/layouts/"
+    cp -r yazi/* "$out/yazi/"
+    cp -r lf/* "$out/lf/"
+
+    patchShebangs "$out/bin"
+
+    for command in "$out"/bin/*; do
+      wrapProgram "$command" \
+        --prefix PATH : "${
+          lib.makeBinPath [
+            bash
+            bc
+            coreutils
+            lazygit
+            yazi
+            zellij
+          ]
+        }"
+    done
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    "$out/bin/zide" --help >/dev/null
+    "$out/bin/zide-pick" --help >/dev/null
+    "$out/bin/zide-edit" --help >/dev/null
+    "$out/bin/zide-rename" --help >/dev/null
+    test -f "$out/layouts/default.kdl"
+    grep -F 'zide-pick' "$out/layouts/default.kdl" >/dev/null
+
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    description = "Keystone Zellij IDE layout helpers";
+    license = licenses.mit;
+    mainProgram = "zide";
+    platforms = platforms.unix;
+  };
+}

--- a/packages/zide/default.nix
+++ b/packages/zide/default.nix
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation {
 
     for command in "$out"/bin/*; do
       wrapProgram "$command" \
-        --prefix PATH : "${
+        --suffix PATH : "${
           lib.makeBinPath [
             bash
             bc

--- a/packages/zide/layouts/default.kdl
+++ b/packages/zide/layouts/default.kdl
@@ -1,0 +1,58 @@
+layout {
+    tab {
+        floating_panes {
+            zide_rename
+        }
+        pane split_direction="vertical" {
+            filepicker size=40 name="picker"
+            editor
+        }
+        compact_bar size=1
+    }
+
+    swap_tiled_layout name="compact" {
+        tab exact_panes=4 {
+            pane split_direction="vertical" {
+                filepicker size=40 name="picker"
+                pane split_direction="horizontal" {
+                    editor size="75%"
+                    pane
+                }
+            }
+            compact_bar size=1
+        }
+    }
+
+    swap_tiled_layout name="wide" {
+        tab exact_panes=4 {
+            pane split_direction="vertical" {
+                filepicker size=40 name="picker"
+                editor
+                pane split_direction="horizontal" size=80 {
+                    pane
+                }
+            }
+            compact_bar size=1
+        }
+    }
+
+    pane_template name="compact_bar" {
+        borderless true
+        plugin location="compact-bar"
+    }
+
+    pane_template name="filepicker" {
+        command "zide-pick"
+    }
+
+    pane_template name="editor" {
+        command "$EDITOR"
+    }
+
+    pane_template name="zide_rename" command="zide-rename" close_on_exit=true
+
+    new_tab_template {
+        pane
+        compact_bar size=1
+    }
+}

--- a/packages/zide/layouts/default_lazygit.kdl
+++ b/packages/zide/layouts/default_lazygit.kdl
@@ -1,0 +1,37 @@
+layout {
+    tab {
+        floating_panes {
+            zide_rename
+            lazygit_pane x="5%" y="5%" width="90%" height="90%"
+        }
+        pane split_direction="vertical" {
+            filepicker size=40 name="picker"
+            editor
+        }
+        compact_bar size=1
+    }
+
+    pane_template name="compact_bar" {
+        borderless true
+        plugin location="compact-bar"
+    }
+
+    pane_template name="filepicker" {
+        command "zide-pick"
+    }
+
+    pane_template name="editor" {
+        command "$EDITOR"
+    }
+
+    pane_template name="zide_rename" command="zide-rename" close_on_exit=true
+
+    pane_template name="lazygit_pane" {
+        command "lazygit"
+    }
+
+    new_tab_template {
+        pane
+        compact_bar size=1
+    }
+}

--- a/packages/zide/layouts/stacked.kdl
+++ b/packages/zide/layouts/stacked.kdl
@@ -1,0 +1,33 @@
+layout {
+    tab {
+        floating_panes {
+            zide_rename
+        }
+        pane stacked=true {
+            filepicker name="picker"
+            editor
+            pane
+        }
+        compact_bar size=1
+    }
+
+    pane_template name="compact_bar" {
+        borderless true
+        plugin location="compact-bar"
+    }
+
+    pane_template name="filepicker" {
+        command "zide-pick"
+    }
+
+    pane_template name="editor" {
+        command "$EDITOR"
+    }
+
+    pane_template name="zide_rename" command="zide-rename" close_on_exit=true
+
+    new_tab_template {
+        pane
+        compact_bar size=1
+    }
+}

--- a/packages/zide/layouts/tall.kdl
+++ b/packages/zide/layouts/tall.kdl
@@ -1,0 +1,32 @@
+layout {
+    tab {
+        floating_panes {
+            zide_rename
+        }
+        pane split_direction="horizontal" {
+            filepicker size=18 name="picker"
+            editor
+        }
+        compact_bar size=1
+    }
+
+    pane_template name="compact_bar" {
+        borderless true
+        plugin location="compact-bar"
+    }
+
+    pane_template name="filepicker" {
+        command "zide-pick"
+    }
+
+    pane_template name="editor" {
+        command "$EDITOR"
+    }
+
+    pane_template name="zide_rename" command="zide-rename" close_on_exit=true
+
+    new_tab_template {
+        pane
+        compact_bar size=1
+    }
+}

--- a/packages/zide/lf/lfrc
+++ b/packages/zide/lf/lfrc
@@ -1,0 +1,9 @@
+cmd on-redraw %{{
+  if [ "$lf_width" -le 40 ]; then
+    lf -remote "send $id set ratios 1"
+  elif [ "$lf_width" -le 80 ]; then
+    lf -remote "send $id set ratios 1:1"
+  else
+    lf -remote "send $id set ratios 1:1:2"
+  fi
+}}

--- a/packages/zide/yazi/init.lua
+++ b/packages/zide/yazi/init.lua
@@ -1,0 +1,1 @@
+require("auto-layout")

--- a/packages/zide/yazi/plugins/auto-layout.yazi/init.lua
+++ b/packages/zide/yazi/plugins/auto-layout.yazi/init.lua
@@ -1,0 +1,23 @@
+function Tab:layout()
+  if self._area.w > 80 then
+    self._chunks = ui.Layout():direction(ui.Layout.HORIZONTAL):constraints({
+      ui.Constraint.Ratio(MANAGER.ratio.parent, MANAGER.ratio.all),
+      ui.Constraint.Ratio(MANAGER.ratio.current, MANAGER.ratio.all),
+      ui.Constraint.Ratio(MANAGER.ratio.preview, MANAGER.ratio.all),
+    }):split(self._area)
+  elseif self._area.w > 40 then
+    self._chunks = ui.Layout():direction(ui.Layout.HORIZONTAL):constraints({
+      ui.Constraint.Ratio(0, MANAGER.ratio.all),
+      ui.Constraint.Ratio(MANAGER.ratio.current + MANAGER.ratio.parent, MANAGER.ratio.all),
+      ui.Constraint.Ratio(MANAGER.ratio.preview + MANAGER.ratio.parent, MANAGER.ratio.all),
+    }):split(self._area)
+  else
+    self._chunks = ui.Layout():direction(ui.Layout.HORIZONTAL):constraints({
+      ui.Constraint.Ratio(0, MANAGER.ratio.all),
+      ui.Constraint.Ratio(MANAGER.ratio.all, MANAGER.ratio.all),
+      ui.Constraint.Ratio(0, MANAGER.ratio.all),
+    }):split(self._area)
+  end
+end
+
+return {}

--- a/packages/zide/yazi/yazi.toml
+++ b/packages/zide/yazi/yazi.toml
@@ -1,0 +1,7 @@
+[manager]
+ratio = [1, 1, 2]
+
+[opener]
+edit = [
+  { run = '$EDITOR "$@"', block = false, for = "unix" },
+]

--- a/tests/module/terminal-zide.nix
+++ b/tests/module/terminal-zide.nix
@@ -1,0 +1,54 @@
+{
+  pkgs,
+  self,
+  home-manager,
+  ...
+}:
+let
+  hmConfig = home-manager.lib.homeManagerConfiguration {
+    inherit pkgs;
+    modules = [
+      self.homeModules.notes
+      self.homeModules.terminal
+      {
+        nixpkgs.overlays = [ self.overlays.default ];
+        home.username = "testuser";
+        home.homeDirectory = "/home/testuser";
+        home.stateVersion = "25.05";
+
+        keystone.projects.enable = false;
+        keystone.terminal = {
+          enable = true;
+          sandbox.enable = false;
+          git = {
+            userName = "Test User";
+            userEmail = "testuser@example.com";
+          };
+        };
+      }
+    ];
+  };
+
+  packages = hmConfig.config.home.packages;
+  zidePackage = builtins.head (builtins.filter (pkg: (pkg.pname or "") == "keystone-zide") packages);
+in
+pkgs.runCommand "terminal-zide-check" { } ''
+  set -euo pipefail
+
+  test -x "${zidePackage}/bin/zide"
+  test -x "${zidePackage}/bin/zide-pick"
+  test -x "${zidePackage}/bin/zide-edit"
+  test -x "${zidePackage}/bin/zide-rename"
+
+  "${zidePackage}/bin/zide" --help >/dev/null
+  "${zidePackage}/bin/zide-pick" --help >/dev/null
+  "${zidePackage}/bin/zide-edit" --help >/dev/null
+  "${zidePackage}/bin/zide-rename" --help >/dev/null
+
+  grep -F 'zide-pick' "${zidePackage}/layouts/default.kdl" >/dev/null
+  grep -F 'command "$EDITOR"' "${zidePackage}/layouts/default.kdl" >/dev/null
+  grep -F 'YAZI_CONFIG_HOME' "${zidePackage}/bin/.zide-pick-wrapped" >/dev/null
+  test -f "${zidePackage}/yazi/plugins/auto-layout.yazi/init.lua"
+
+  touch "$out"
+''


### PR DESCRIPTION
## Summary
- add Keystone-owned `zide` package exported as `.#zide` and `pkgs.keystone.zide`
- install zide from the terminal Home Manager module
- add bundled Zellij layouts plus Yazi/LF picker config
- add a terminal-zide module smoke test

## Testing
- `nix build .#zide`
- `nix run .#zide -- --help`
- `nix build .#checks.x86_64-linux.terminal-zide`
- `nix build .#checks.x86_64-linux.check-agents`
- `nix develop -c shellcheck packages/zide/bin/zide packages/zide/bin/zide-edit packages/zide/bin/zide-pick packages/zide/bin/zide-rename`
- `zellij setup --dump-layout` for `default`, `default_lazygit`, `tall`, and `stacked`

No originating issue.