### PR TITLE
feat(terminal): auto-populate empty agent-asset tree on ks switch/update

### DIFF
--- a/conventions/tool.cli-coding-agents.md
+++ b/conventions/tool.cli-coding-agents.md
@@ -282,9 +282,18 @@ can review them.
     always returns the wrong value). A `KEYSTONE_CONSUMER_FLAKE` env var
     MUST be honoured as an override for testing and ad-hoc invocations.
 14. The `ks sync-agent-assets` command MUST be the only writer to the
-    consumer-flake `agents/` directory. It MUST be run manually — home-manager
-    activation MUST NOT auto-trigger it. This guarantees the user's git tree
-    is never silently rewritten during `ks switch` / `ks update --dev`.
+    consumer-flake `agents/` directory. Home-manager *activation* MUST NOT
+    auto-trigger it — activation manages symlink topology only and never
+    writes content. The user-facing `ks switch` / `ks update` wrappers MAY
+    auto-populate the tree, but ONLY when `<consumer-flake>/agents/skills/`
+    is absent or empty, and only after a deploy that activated a local host.
+    A populated tree (the user's committed git working tree) MUST NOT be
+    rewritten by the deploy wrappers — that guarantees a steady-state switch
+    never produces a spurious diff and never silently clobbers reviewed
+    content. The first-time populate exists so a fresh host does not end a
+    rebuild with empty `~/.agents/skills` / `~/.claude/skills` symlink
+    targets; manual `ks sync-agent-assets` remains the way to refresh an
+    already-populated tree.
 15. `ks sync-agent-assets` MUST unconditionally overwrite keystone-generated
     files. The user's override mechanism is git: review the diff, `git checkout`
     to restore a previous version, then commit. No in-file markers, no skip-if-exists.
@@ -342,13 +351,20 @@ per-tool dirs in the consumer flake** — every agent reads from a home-dir
 symlink resolved at activation time. First-time setup on a fresh host:
 
 ```
-ks sync-agent-assets       # writes _shared/ and skills/
+ks switch                  # activation creates home-dir symlinks AND, because
+                           # agents/skills/ is empty, auto-populates _shared/
+                           # and skills/ once via sync-agent-assets
 cd <consumer-flake>
-git status                 # _shared/ and skills/ should show as untracked
+git status                 # _shared/ and skills/ now show as untracked
 git add agents/_shared agents/skills
 git commit -m "feat: add keystone agent assets"
-ks switch                  # activation creates home-dir symlinks
 ```
+
+`ks switch` only auto-populates when the tree is empty. To refresh an
+already-populated (committed) tree — e.g. after editing `archetypes.yaml` or
+`_shared/skills.yaml` — run `ks sync-agent-assets` explicitly, then review
+and commit the diff. The deploy wrappers will not rewrite a populated tree
+for you.
 
 Migrating from the PR #539 or pre-spec PR #542 shape:
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -67,8 +67,12 @@ entire upgrade history of a single skill. Rollback is `git revert`; user
 override is just editing the file and committing — keystone's regen will
 overwrite on next run, the user's `git checkout` restores their version.
 
-The regen is **manual** (`ks sync-agent-assets`). Home-manager activation
-never silently rewrites the user's git tree.
+Home-manager activation never rewrites the user's git tree — it only manages
+symlink topology. On a fresh host, `ks switch` / `ks update` auto-populate the
+tree **once** (when `agents/skills/` is empty) so the symlinks resolve to
+content instead of nothing. Refreshing an already-populated tree stays
+**manual** (`ks sync-agent-assets`); the deploy wrappers never rewrite a
+populated, committed tree.
 
 ## L1 → L2 inheritance
 

--- a/docs/ks.md
+++ b/docs/ks.md
@@ -201,6 +201,10 @@ ks switch [--boot] [HOSTS]
 Build and deploy the current local state without pull, lock, or push steps.
 
 - `--boot`: Register the new generation for next boot without switching now.
+- After a deploy that touched a local host, if the consumer flake's
+  `agents/skills/` tree is empty, it is auto-populated once via
+  `sync-agent-assets` so agent skill symlinks resolve to content. A populated
+  (committed) tree is never rewritten — use `ks sync-agent-assets` to refresh.
 
 Examples:
 
@@ -222,6 +226,9 @@ profile manifest.
 - Rewrites generated instruction files, curated command files, and managed
   Codex skills from the live keystone checkout in development mode.
 - This is the supported no-sudo refresh path for development-mode agent assets.
+- `ks switch` / `ks update` invoke this automatically the first time, but only
+  when `<consumer-flake>/agents/skills/` is empty. Run it by hand to refresh an
+  already-populated tree (the deploy wrappers never rewrite a populated tree).
 
 Example:
 

--- a/modules/terminal/agents/assets.nix
+++ b/modules/terminal/agents/assets.nix
@@ -261,10 +261,11 @@ in
             echo "keystone-agent-asset-symlinks: $target is not readable by $USER; CLI tools running as this agent will fail to read skills/agents through $link until traversal permissions are fixed on the admin's home chain" >&2
           fi
 
-          # Empty-target hint: after this PR, ks switch no longer auto-syncs
-          # content. If the admin's target dir is empty, point them at the
-          # manual refresh path so they don't see empty skills/agents
-          # subdirs without explanation.
+          # Empty-target hint. `ks switch` / `ks update` auto-populate an empty
+          # tree once (a fresh-host convenience that never rewrites a populated,
+          # committed tree). This hint covers the activation-only path — e.g. a
+          # raw `home-manager switch` or `switch-to-configuration` that did not
+          # run through the ks wrapper — where nothing has populated the target.
           if [ "$is_agent_user" = "0" ] && [ -z "$(ls -A "$target" 2>/dev/null)" ]; then
             echo "keystone-agent-asset-symlinks: $target is empty — run 'ks sync-agent-assets' to populate keystone-curated content" >&2
           fi

--- a/packages/ks/src/cmd/switch.rs
+++ b/packages/ks/src/cmd/switch.rs
@@ -24,6 +24,15 @@ pub struct DeploySession {
     ssh: SshSessionManager,
 }
 
+impl DeploySession {
+    /// Whether this deploy session activates the current machine's profile.
+    /// `false` for a remote-only deploy, where there are no local symlinks to
+    /// populate.
+    pub fn has_local_hosts(&self) -> bool {
+        !self.local_hosts.is_empty()
+    }
+}
+
 /// Guard that keeps sudo credentials alive by refreshing every 60 seconds.
 /// Dropping the guard cancels the background refresh task.
 pub struct SudoKeepAlive {
@@ -555,7 +564,14 @@ pub async fn execute(
     let session = prepare_deploy_session(&repo_root, &hosts).await?;
     let store_paths = build_targets(&repo_root, &hosts).await?;
 
+    let deployed_local = session.has_local_hosts();
     deploy_paths_with_session(&repo_root, &session, mode, &hosts, &store_paths).await?;
+
+    // Workflow automation over the manual-only sync model: a fresh host ends a
+    // switch with a populated skill tree instead of empty symlink targets.
+    // Only fills an *empty* tree, so a committed/populated tree is never
+    // rewritten — see conventions/tool.cli-coding-agents.md rule 14.
+    crate::cmd::sync_agent_assets::populate_after_deploy(&repo_root, deployed_local);
 
     Ok(SwitchResult {
         hosts,

--- a/packages/ks/src/cmd/sync_agent_assets.rs
+++ b/packages/ks/src/cmd/sync_agent_assets.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 fn find_executable(name: &str) -> Option<PathBuf> {
@@ -16,7 +16,8 @@ fn find_executable(name: &str) -> Option<PathBuf> {
     None
 }
 
-pub fn execute() -> Result<()> {
+/// Run `keystone-sync-agent-assets`, inheriting the parent's stdio.
+fn run_sync_binary() -> Result<()> {
     let Some(program) = find_executable("keystone-sync-agent-assets") else {
         return Err(anyhow!(
             "keystone-sync-agent-assets is not available in PATH. Refresh the home-manager profile before using this command."
@@ -35,4 +36,100 @@ pub fn execute() -> Result<()> {
     }
 
     Ok(())
+}
+
+pub fn execute() -> Result<()> {
+    run_sync_binary()
+}
+
+/// Decide whether the canonical skill tree under `<consumer-flake>/agents/skills/`
+/// needs a first-time populate. Returns `true` when the directory is absent or
+/// holds no entries.
+///
+/// CRITICAL: this is the *only* condition under which a deploy is allowed to
+/// run the sync script. A populated tree is the user's committed git working
+/// tree (conventions/tool.cli-coding-agents.md rule 14); rewriting it on every
+/// switch would produce spurious diffs and silently clobber a tree the user
+/// reviews via git. We only fill an *empty* tree — the failure mode where a
+/// fresh rebuild leaves `~/.agents/skills` / `~/.claude/skills` resolving to
+/// nothing because sync was never run.
+fn skills_tree_is_empty(consumer_flake: &Path) -> bool {
+    let skills_dir = consumer_flake.join("agents").join("skills");
+    match std::fs::read_dir(&skills_dir) {
+        Ok(mut entries) => entries.next().is_none(),
+        // Missing directory (or unreadable) counts as empty — the populate path
+        // will create it. An unreadable dir is rare and the sync script surfaces
+        // its own error, so treating it as empty is safe.
+        Err(_) => true,
+    }
+}
+
+/// Auto-populate agent assets after a deploy that touched a local host, but only
+/// when the canonical skill tree is empty.
+///
+/// This is the *workflow* automation requested over the manual-only model: a
+/// fresh host (or one where the consumer flake was never synced) ends a
+/// `ks switch` / `ks update` with a populated tree instead of empty symlink
+/// targets. It deliberately stops short of an unconditional sync so the
+/// steady-state committed tree is never rewritten behind the user's back.
+///
+/// `deployed_local` gates the work to deploys that actually activated this
+/// machine's home-manager profile — a remote-only deploy writes no local
+/// symlinks, so there is nothing to populate here.
+pub fn populate_after_deploy(consumer_flake: &Path, deployed_local: bool) {
+    if !deployed_local {
+        return;
+    }
+    if !skills_tree_is_empty(consumer_flake) {
+        return;
+    }
+    eprintln!(
+        "Agent assets at {}/agents/skills are empty — populating (one-time) via sync-agent-assets...",
+        consumer_flake.display()
+    );
+    if let Err(err) = run_sync_binary() {
+        // Non-fatal: the deploy itself succeeded. Surface the reason and the
+        // manual recovery path rather than failing the whole switch.
+        eprintln!(
+            "Warning: auto-populate of agent assets failed: {err}\n  \
+             Run 'ks sync-agent-assets' manually once the profile is available."
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_when_skills_dir_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        // No agents/skills created at all.
+        assert!(skills_tree_is_empty(dir.path()));
+    }
+
+    #[test]
+    fn empty_when_skills_dir_present_but_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("agents").join("skills")).unwrap();
+        assert!(skills_tree_is_empty(dir.path()));
+    }
+
+    #[test]
+    fn not_empty_when_skills_dir_has_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills = dir.path().join("agents").join("skills");
+        std::fs::create_dir_all(&skills).unwrap();
+        std::fs::create_dir_all(skills.join("ks-system")).unwrap();
+        assert!(!skills_tree_is_empty(dir.path()));
+    }
+
+    #[test]
+    fn populate_skips_remote_only_deploy() {
+        let dir = tempfile::tempdir().unwrap();
+        // deployed_local = false must short-circuit before touching the FS or
+        // looking for the sync binary, so an empty tree stays untouched.
+        populate_after_deploy(dir.path(), false);
+        assert!(!dir.path().join("agents").join("skills").exists());
+    }
 }

--- a/packages/ks/src/cmd/update.rs
+++ b/packages/ks/src/cmd/update.rs
@@ -180,6 +180,7 @@ async fn update_locked(repo_root: &Path, mode: &str, hosts: &[String]) -> Result
     verify_all_repos_lock_ready(repo_root).await?;
 
     let deploy_session = cmd::switch::prepare_deploy_session(repo_root, hosts).await?;
+    let deployed_local = deploy_session.has_local_hosts();
     let build_result =
         cmd::build::execute(Some(&hosts.join(",")), true, None, false, Some(repo_root)).await?;
     cmd::switch::deploy_paths_with_session(
@@ -190,6 +191,13 @@ async fn update_locked(repo_root: &Path, mode: &str, hosts: &[String]) -> Result
         &build_result.store_paths,
     )
     .await?;
+
+    // First-time populate of agent assets (only when the tree is empty) so a
+    // locked fleet update leaves this host's skill symlinks resolving to
+    // content. Runs before the push so a fresh consumer flake is populated for
+    // the user to review/commit; the populate itself never commits. See
+    // conventions/tool.cli-coding-agents.md rule 14.
+    cmd::sync_agent_assets::populate_after_deploy(repo_root, deployed_local);
 
     let push_status = tokio::process::Command::new("git")
         .args(["-C"])


### PR DESCRIPTION
## Problem

After a rebuild, `~/.agents/skills` / `~/.claude/skills` resolve to an **empty** tree on any host whose consumer flake was never synced. PR #542 made content sync a deliberately **manual** step (`ks sync-agent-assets`) so that:

1. home-manager *activation* stays pure — it manages symlink topology only, never writes content; and
2. the user's committed git working tree is never silently rewritten during `ks switch` / `ks update`.

The cost of that purity is the empty-tree failure mode: nothing in the normal rebuild workflow ever populates the tree, so a fresh host ends up with skill symlinks pointing at nothing and no explanation beyond an activation hint. The reported reaction was *"shouldn't sync-agent-assets happen automatically?"*

## Approach — auto-populate **only when empty**

Rather than running a full sync on every switch (which would silently rewrite the user's committed git tree on every rebuild — exactly what rule 14 forbids), this wires a **one-time, conditional** populate into the user-facing deploy wrappers:

- After a deploy that activated a **local** host, check `<consumer-flake>/agents/skills/`.
- If it is **absent or empty**, run `sync-agent-assets` once to populate it.
- If it is **already populated** (the normal committed case), do nothing.

The logic lives in `cmd::sync_agent_assets::populate_after_deploy` and is called from:

- `cmd::switch::execute` — covers `ks switch` and `ks update --dev` (which routes through `switch::execute`);
- `update_locked` — covers `ks update --lock`, hooked in **before** the `git push` so a fresh consumer flake is populated for the user to review and commit (the populate never commits anything itself).

Scoping is via the new `DeploySession::has_local_hosts()` — a remote-only deploy writes no local symlinks, so there is nothing to populate and the step is skipped. The populate is **non-fatal**: a failure prints a warning pointing at manual recovery rather than failing the whole switch.

### Why this over the alternatives

- **Unconditional sync after switch** (the naive "wire sync into switch" reading): rejected — it would rewrite the committed `agents/skills/` tree on every rebuild, producing spurious diffs and silently clobbering reviewed content. That is precisely the behavior rule 14's rationale was written to prevent.
- **Gated `aiExtensions.autoSync` option defaulting on**: heavier, and "default on, unconditional" has the same clobber problem; "default off" doesn't fix the reported symptom out of the box.
- **systemd user service**: adds a moving part and still needs the same empty-vs-populated guard.

The empty-only guard gives the user what they asked for (the tree is never empty after a rebuild) while keeping the part of #542 that matters: a populated/committed tree is never rewritten behind the user's back.

## Relationship to #542 / activation-purity invariant

- **Activation purity is fully preserved.** The only change to `modules/terminal/agents/assets.nix` is a **comment** update — activation still manages symlink topology only and writes no content.
- **Rule 14 is updated, not reverted.** It still mandates that activation MUST NOT auto-trigger sync, and that a populated tree MUST NOT be rewritten by the deploy wrappers. It now also permits the wrappers to auto-populate an *empty* tree as a fresh-host convenience. Manual `ks sync-agent-assets` remains the way to refresh an already-populated tree.

## Files changed

- `packages/ks/src/cmd/sync_agent_assets.rs` — `populate_after_deploy` + `skills_tree_is_empty` helpers and unit tests; existing `execute` refactored to share `run_sync_binary`.
- `packages/ks/src/cmd/switch.rs` — `DeploySession::has_local_hosts()`; call populate at the end of `execute`.
- `packages/ks/src/cmd/update.rs` — call populate in `update_locked` before push.
- `modules/terminal/agents/assets.nix` — comment-only update to the empty-target hint.
- `conventions/tool.cli-coding-agents.md` — rule 14 + first-time-setup section.
- `docs/agents/README.md`, `docs/ks.md` — describe the new behavior.

## Validation

Run in the repo dev shell (`nix develop -c ...`):

- `nix-instantiate --parse modules/terminal/agents/assets.nix` → **PARSE OK**
- `bash -n modules/terminal/agents/keystone-sync-agent-assets.sh` → **OK** (script unchanged)
- `cargo build` → **Finished** (clean)
- `cargo test --lib sync_agent_assets` → **4 passed** (missing dir, empty dir, populated dir, remote-only skip)
- `cargo test --lib cmd::switch` → **7 passed** (existing switch tests unaffected)
- `cargo test --lib` → **360 passed, 0 failed, 2 ignored**
- `cargo clippy --all-targets` → **Finished**, no warnings on changed code
- `cargo fmt --check` → exit 0
- Pre-commit `nixfmt` ran on the staged `.nix` file; tree clean after commit.

`ks-legacy` (`packages/ks-legacy/ks.sh`) was intentionally **not** modified — the installed `ks` is the Rust binary (`packages/ks`, installed via `pkgs.keystone.ks`); legacy is a separate `ks-legacy` command and out of scope here.

## Risks / tradeoffs / things to confirm

- **`--lock` push ordering**: populate runs before `git push` of the nixos-config repo. The populate only touches the working tree (no commit), so the push is unaffected, but on a fresh host the working tree will be left dirty with the newly-rendered `agents/_shared` + `agents/skills` for the user to review and commit. **Confirm** this is the desired hand-off rather than, say, populating after the push.
- **Empty == needs-populate heuristic**: an unreadable `agents/skills/` is treated as empty (the sync script then surfaces its own error). This matches the activation hint's `ls -A` emptiness check.
- **Consumer-flake path**: the empty-check uses `repo_root` (from `find_repo` / the system flake pointer); the sync script independently re-resolves its destination via the same precedence. In the normal single-repo case these are identical. **Confirm** there is no multi-flake setup where they diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)