### PR TITLE
feat(ks): add OS-agent task contract fields

### DIFF
--- a/docs/agents/os-agents.md
+++ b/docs/agents/os-agents.md
@@ -595,6 +595,8 @@ tasks: # REQUIRED: only top-level key
     project: "project-name" # MAY: from PROJECTS.yaml
     source: "email" # MAY: email|github-issue|github-pr|forgejo-issue|schedule|calendar|manual
     source_ref: "email-42-u@h" # MAY: unique ID for deduplication
+    repo: "ncrmro/keystone" # REQUIRED for OS-agent executable tasks; MAY be owner/name or URL
+    branch_name: "feat/task-name" # REQUIRED for OS-agent executable tasks
     profile: "fast" # MAY: semantic profile override (embedding|fast|medium|max or custom)
     provider: "gemini" # MAY: claude|gemini|codex — task execution provider override
     model: "sonnet" # MAY: provider-specific model override
@@ -613,6 +615,14 @@ tasks: # REQUIRED: only top-level key
 4. Status MUST be one of: `pending`, `in_progress`, `completed`, `blocked`
 5. Field names MUST match exactly — no `id`, `priority`, `urgency`, `depends_on`
 6. Validate after every write: `yq e '.' TASKS.yaml`
+
+**OS-agent executable task contract:**
+
+- Tasks intended for OS-agent execution MUST set `repo` and `branch_name`
+- `repo` identifies the repository the agent should work in; prefer `owner/name` for GitHub repositories and a full URL for non-GitHub remotes
+- `branch_name` is the exact branch the agent should create or reuse for the task
+- `provider`, `profile`, and `model` are optional per-task execution overrides; when omitted, the task loop uses stage and agent defaults
+- Human-only, imported, completed, or otherwise non-executable tasks MAY omit `repo` and `branch_name` for backwards compatibility
 
 **Source ref formats:**
 
@@ -683,6 +693,8 @@ tasks:
     status: pending
     source: manual
     source_ref: "manual-review-agent-provider-docs"
+    repo: ncrmro/keystone
+    branch_name: docs/review-agent-provider-docs
     profile: "medium"
     provider: claude
     model: sonnet

--- a/packages/ks/src/cli.rs
+++ b/packages/ks/src/cli.rs
@@ -218,6 +218,7 @@ pub enum Command {
     Notification(NotificationArgs),
 
     /// Manage tasks — list, add, start, complete, prioritize, prune.
+    #[command(alias = "tasks")]
     Task(TaskArgs),
 
     /// Manage projects — list, add, detect, configure provider overrides.

--- a/packages/ks/src/cmd/agent_loop.rs
+++ b/packages/ks/src/cmd/agent_loop.rs
@@ -557,7 +557,8 @@ async fn run_execute(
 
         // Resolve runtime
         let task_overrides = StageConfig {
-            provider: task.source.clone().filter(|s| !s.is_empty()),
+            provider: task.provider.clone().filter(|s| !s.is_empty()),
+            profile: task.profile.clone().filter(|s| !s.is_empty()),
             model: task.model.clone(),
             ..Default::default()
         };

--- a/packages/ks/src/cmd/tasks.rs
+++ b/packages/ks/src/cmd/tasks.rs
@@ -46,6 +46,26 @@ pub enum TaskCommand {
         /// Associated project.
         #[arg(long)]
         project: Option<String>,
+
+        /// Repository URL or owner/name slug for OS-agent execution.
+        #[arg(long)]
+        repo: Option<String>,
+
+        /// Git branch name OS agents should use for execution.
+        #[arg(long = "branch-name")]
+        branch_name: Option<String>,
+
+        /// OS-agent execution provider override (claude, gemini, codex).
+        #[arg(long)]
+        provider: Option<String>,
+
+        /// OS-agent semantic profile override.
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Provider-specific model override.
+        #[arg(long)]
+        model: Option<String>,
     },
 
     /// Mark a task as in-progress.
@@ -120,6 +140,14 @@ pub struct Task {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_ref: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workflow: Option<String>,
@@ -165,6 +193,14 @@ pub struct IngestTask {
     pub source_ref: Option<String>,
     #[serde(default)]
     pub project: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub branch_name: Option<String>,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub profile: Option<String>,
     #[serde(default)]
     pub model: Option<String>,
 }
@@ -338,6 +374,10 @@ pub fn apply_ingest(task_file: &mut TaskFile, ingest: &IngestResult) -> (usize, 
             description: it.description.clone(),
             status: "pending".to_string(),
             project: it.project.clone(),
+            repo: it.repo.clone(),
+            branch_name: it.branch_name.clone(),
+            provider: it.provider.clone(),
+            profile: it.profile.clone(),
             source: it.source.clone(),
             source_ref: it.source_ref.clone(),
             model: it.model.clone(),
@@ -369,13 +409,23 @@ pub async fn execute(args: &TaskArgs) -> Result<()> {
             source,
             source_ref,
             project,
-        }) => execute_add(
+            repo,
+            branch_name,
+            provider,
+            profile,
+            model,
+        }) => execute_add(AddTaskInput {
             description,
-            name.as_deref(),
+            name: name.as_deref(),
             source,
-            source_ref.as_deref(),
-            project.as_deref(),
-        ),
+            source_ref: source_ref.as_deref(),
+            project: project.as_deref(),
+            repo: repo.as_deref(),
+            branch_name: branch_name.as_deref(),
+            provider: provider.as_deref(),
+            profile: profile.as_deref(),
+            model: model.as_deref(),
+        }),
         Some(TaskCommand::Start { name }) => execute_start(name),
         Some(TaskCommand::Done { name }) => execute_done(name),
         Some(TaskCommand::Block { name, reason }) => execute_block(name, reason.as_deref()),
@@ -483,27 +533,39 @@ fn print_task(task: &Task) {
 
 // ── Add ───────────────────────────────────────────────────────────────
 
-fn execute_add(
-    description: &str,
-    name: Option<&str>,
-    source: &str,
-    source_ref: Option<&str>,
-    project: Option<&str>,
-) -> Result<()> {
+struct AddTaskInput<'a> {
+    description: &'a str,
+    name: Option<&'a str>,
+    source: &'a str,
+    source_ref: Option<&'a str>,
+    project: Option<&'a str>,
+    repo: Option<&'a str>,
+    branch_name: Option<&'a str>,
+    provider: Option<&'a str>,
+    profile: Option<&'a str>,
+    model: Option<&'a str>,
+}
+
+fn execute_add(input: AddTaskInput<'_>) -> Result<()> {
     let path = tasks_file_path();
     let mut task_file = load_tasks_from(&path)?;
 
-    let task_name = name
+    let task_name = input
+        .name
         .map(String::from)
-        .unwrap_or_else(|| slugify(description));
+        .unwrap_or_else(|| slugify(input.description));
     let task = Task {
         name: task_name.clone(),
-        description: description.to_string(),
+        description: input.description.to_string(),
         status: "pending".to_string(),
-        project: project.map(String::from),
-        source: Some(source.to_string()),
-        source_ref: source_ref.map(String::from),
-        model: None,
+        project: input.project.map(String::from),
+        source: Some(input.source.to_string()),
+        source_ref: input.source_ref.map(String::from),
+        repo: input.repo.map(String::from),
+        branch_name: input.branch_name.map(String::from),
+        provider: input.provider.map(String::from),
+        profile: input.profile.map(String::from),
+        model: input.model.map(String::from),
         workflow: None,
         needs: None,
         blocked_reason: None,
@@ -617,7 +679,10 @@ async fn execute_ingest(file: Option<&PathBuf>, apply: bool) -> Result<()> {
         "instructions": "Review these notifications and decide which are actionable tasks. \
             Return JSON matching the IngestResult schema: {\"tasks\": [{\"name\": \"kebab-case-name\", \
             \"description\": \"what to do\", \"source\": \"email|github|forgejo\", \
-            \"source_ref\": \"unique-ref\", \"project\": \"optional-project\"}]}. \
+            \"source_ref\": \"unique-ref\", \"project\": \"optional-project\", \
+            \"repo\": \"optional execution repo\", \"branch_name\": \"optional execution branch\", \
+            \"provider\": \"optional provider\", \"profile\": \"optional profile\", \
+            \"model\": \"optional model\"}]}. \
             Skip notifications that already have a matching source_ref in existing_refs. \
             Skip automated notifications, newsletters, and CI status. \
             Any message containing 'ping' MUST create a reply-with-pong task.",
@@ -638,6 +703,10 @@ async fn execute_ingest(file: Option<&PathBuf>, apply: bool) -> Result<()> {
                             "source": {"type": "string"},
                             "source_ref": {"type": "string"},
                             "project": {"type": "string"},
+                            "repo": {"type": "string"},
+                            "branch_name": {"type": "string"},
+                            "provider": {"type": "string"},
+                            "profile": {"type": "string"},
                             "model": {"type": "string"}
                         }
                     }
@@ -793,6 +862,10 @@ mod tests {
             project: None,
             source: None,
             source_ref: None,
+            repo: None,
+            branch_name: None,
+            provider: None,
+            profile: None,
             model: None,
             workflow: None,
             needs: None,
@@ -1061,6 +1134,10 @@ mod tests {
                 source: Some("email".to_string()),
                 source_ref: Some("email-99-user@host".to_string()),
                 project: None,
+                repo: Some("ncrmro/keystone".to_string()),
+                branch_name: Some("fix/reply-ping".to_string()),
+                provider: Some("codex".to_string()),
+                profile: Some("medium".to_string()),
                 model: Some("haiku".to_string()),
             }],
         };
@@ -1069,6 +1146,10 @@ mod tests {
         assert_eq!(added, 1);
         assert_eq!(skipped, 0);
         assert_eq!(tf.tasks[0].name, "reply-to-ping");
+        assert_eq!(tf.tasks[0].repo, Some("ncrmro/keystone".to_string()));
+        assert_eq!(tf.tasks[0].branch_name, Some("fix/reply-ping".to_string()));
+        assert_eq!(tf.tasks[0].provider, Some("codex".to_string()));
+        assert_eq!(tf.tasks[0].profile, Some("medium".to_string()));
         assert_eq!(tf.tasks[0].model, Some("haiku".to_string()));
     }
 
@@ -1085,6 +1166,10 @@ mod tests {
                     source: Some("email".to_string()),
                     source_ref: Some("email-42-user@host".to_string()),
                     project: None,
+                    repo: None,
+                    branch_name: None,
+                    provider: None,
+                    profile: None,
                     model: None,
                 },
                 IngestTask {
@@ -1093,6 +1178,10 @@ mod tests {
                     source: Some("github".to_string()),
                     source_ref: Some("https://github.com/o/r/issues/1".to_string()),
                     project: None,
+                    repo: None,
+                    branch_name: None,
+                    provider: None,
+                    profile: None,
                     model: None,
                 },
             ],

--- a/specs/REQ-007-os-agents.md
+++ b/specs/REQ-007-os-agents.md
@@ -150,6 +150,9 @@ Secrets:
   - A fast model for ingest (default: haiku)
   - A fast model for prioritize (default: haiku)
   - A capable model for execute (default: sonnet), overridable per-task via the `model` field
+- Each `TASKS.yaml` task intended for OS-agent execution MUST include `repo` and `branch_name`
+- Each `TASKS.yaml` task MAY include per-task `provider`, `profile`, and `model` overrides for OS-agent execution
+- Human-only, imported, completed, or otherwise non-executable tasks MAY omit OS-agent execution fields for backwards compatibility
 - Each task in `TASKS.yaml` MAY specify a `needs` field for dependency ordering
 - Each task in `TASKS.yaml` MAY specify a `workflow` field for DeepWork workflow dispatch
 - The task loop MUST validate `TASKS.yaml` after each write and restore from a pre-stage backup on validation failure


### PR DESCRIPTION
## Summary
- Add repo, branch_name, provider, profile, and model fields to ks task creation and ingest paths.
- Preserve backwards-compatible task parsing while documenting repo and branch_name as required for OS-agent executable tasks.
- Make agent-loop execution read provider/profile from task fields instead of source, and add a plural ks tasks alias.

## Verification
- nix develop -c cargo fmt
- nix develop -c cargo clippy -p ks -- -D warnings
- nix develop -c cargo test -p ks
- KS_TASKS_FILE=... nix develop -c cargo run -p ks --quiet -- tasks add ...