### PR TITLE
feat(agent): add linux task dispatcher prototype

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -548,6 +548,7 @@
           agentQueueMigration = import ./tests/module/agent-queue-migration.nix {
             inherit pkgs lib;
           };
+          linuxTaskDispatcher = ksPkgs.keystone.linux-task-dispatcher.passthru.tests.dispatcher;
         in
         {
           # Individual checks — for local debugging (nix build .#checks.x86_64-linux.<name>)
@@ -590,6 +591,7 @@
           agent-task-loop-ping-pong = agentTaskLoopPingPong;
           agent-runtime-coherence = agentRuntimeCoherence;
           agent-queue-migration = agentQueueMigration;
+          linux-task-dispatcher = linuxTaskDispatcher;
 
           # --- CI groups — parallel matrix jobs via nix-github-actions ---
 
@@ -679,6 +681,7 @@
             forgejo-cli-ex
             forgejo-project
             fetch-github-sources
+            linux-task-dispatcher
             repo-sync
             podman-agent
             ks

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -29,6 +29,7 @@ let
   forgejo-project-src = ../packages/forgejo-project;
   fetch-github-sources-src = ../packages/fetch-github-sources;
   repo-sync-src = ../packages/repo-sync;
+  linux-task-dispatcher-src = ../packages/linux-task-dispatcher;
   podman-agent-src = ../packages/podman-agent;
   cfait-src = ../packages/cfait;
   zide-src = ../packages/zide;
@@ -76,6 +77,7 @@ in
     forgejo-project = final.callPackage forgejo-project-src { };
     fetch-github-sources = final.callPackage fetch-github-sources-src { };
     repo-sync = final.callPackage repo-sync-src { };
+    linux-task-dispatcher = final.callPackage linux-task-dispatcher-src { };
     podman-agent = final.callPackage podman-agent-src { };
     agents-e2e = final.callPackage agents-e2e-src { };
     ks-legacy = final.callPackage ks-legacy-src {

--- a/packages/linux-task-dispatcher/bin/linux-task-dispatcher
+++ b/packages/linux-task-dispatcher/bin/linux-task-dispatcher
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+import argparse
+import datetime as dt
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+
+def die(message: str, code: int = 1) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_tasks(path: Path) -> dict:
+    if not path.exists():
+        die(f"tasks file does not exist: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        die("TASKS.yaml must contain a mapping at the top level")
+    tasks = data.get("tasks")
+    if not isinstance(tasks, list):
+        die("TASKS.yaml must contain a top-level tasks list")
+    return data
+
+
+def write_tasks(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
+        yaml.safe_dump(data, handle, sort_keys=False)
+        tmp_name = handle.name
+    os.replace(tmp_name, path)
+
+
+def task_name(task: dict, index: int) -> str:
+    value = task.get("name") or task.get("id") or f"task-{index}"
+    return str(value)
+
+
+def completed_names(tasks: list[dict]) -> set[str]:
+    names = set()
+    for index, task in enumerate(tasks):
+        if isinstance(task, dict) and task.get("status") == "completed":
+            names.add(task_name(task, index))
+    return names
+
+
+def is_executable(task: dict, done: set[str]) -> bool:
+    if task.get("status") != "pending":
+        return False
+    if not task.get("repo") or not task.get("branch_name"):
+        return False
+    needs = task.get("needs") or []
+    if not isinstance(needs, list):
+        return False
+    return all(str(need) in done for need in needs)
+
+
+def select_task(data: dict) -> tuple[int, dict] | tuple[None, None]:
+    tasks = data["tasks"]
+    done = completed_names(tasks)
+    for index, task in enumerate(tasks):
+        if isinstance(task, dict) and is_executable(task, done):
+            return index, task
+    return None, None
+
+
+def split_repo(repo: str) -> tuple[str, str]:
+    parts = repo.split("/")
+    if len(parts) != 2 or not all(parts):
+        die(f"repo must be OWNER/REPO: {repo}")
+    return parts[0], parts[1]
+
+
+def worktree_path(home: Path, repo: str, branch_name: str) -> Path:
+    owner, name = split_repo(repo)
+    return home / "repos" / owner / "worktree" / name / branch_name
+
+
+def main_checkout_path(home: Path, repo: str) -> Path:
+    owner, name = split_repo(repo)
+    return home / "repos" / owner / name
+
+
+def run(cmd: list[str], *, cwd: Path | None = None) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True, stdout=subprocess.DEVNULL)
+
+
+def git_branch_exists(repo_dir: Path, branch_name: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo_dir), "rev-parse", "--verify", "--quiet", branch_name],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+def ensure_worktree(home: Path, repo: str, branch_name: str) -> Path:
+    path = worktree_path(home, repo, branch_name)
+    if (path / ".git").exists() or path.joinpath(".git").is_file():
+        return path
+
+    source = main_checkout_path(home, repo)
+    if not (source / ".git").exists():
+        die(f"main checkout does not exist: {source}")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = ["git", "-C", str(source), "worktree", "add"]
+    if not git_branch_exists(source, branch_name):
+        cmd.extend(["-b", branch_name])
+    cmd.append(str(path))
+    if git_branch_exists(source, branch_name):
+        cmd.append(branch_name)
+    run(cmd)
+    return path
+
+
+def slug(value: str) -> str:
+    clean = re.sub(r"[^a-zA-Z0-9_.-]+", "-", value).strip("-")
+    return clean[:48] or "task"
+
+
+def provider_command(executor: str, task: dict) -> list[str]:
+    repo = str(task["repo"])
+    branch_name = str(task["branch_name"])
+    description = str(task.get("description") or task_name(task, 0))
+    provider = str(task.get("provider") or "claude")
+    command = [
+        executor,
+        "--repo",
+        repo,
+        "--branch",
+        branch_name,
+        "--provider",
+        provider,
+        "--task",
+        description,
+    ]
+    model = task.get("model")
+    if model:
+        command.extend(["--model", str(model)])
+    return command
+
+
+def systemd_run_command(unit: str, worktree: Path, command: list[str]) -> list[str]:
+    return [
+        "systemd-run",
+        "--user",
+        "--unit",
+        unit,
+        "--collect",
+        "--working-directory",
+        str(worktree),
+        *command,
+    ]
+
+
+def claim(args: argparse.Namespace) -> tuple[int | None, dict | None]:
+    lock_path = args.tasks_file.with_suffix(args.tasks_file.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w", encoding="utf-8") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        data = load_tasks(args.tasks_file)
+        index, task = select_task(data)
+        if index is None:
+            return None, None
+        if not args.dry_run:
+            claimed = dict(task)
+            claimed["status"] = "in_progress"
+            claimed["started_at"] = now_utc()
+            claimed["claimed_by"] = args.claimed_by
+            data["tasks"][index] = claimed
+            write_tasks(args.tasks_file, data)
+            task = claimed
+        return index, task
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Dispatch one pending executable TASKS.yaml item.")
+    parser.add_argument("--tasks-file", type=Path, default=Path("TASKS.yaml"))
+    parser.add_argument("--dry-run", action="store_true", help="select and report a task without claiming or launching")
+    parser.add_argument("--test-mode", action="store_true", help="claim and ensure worktree, but do not run systemd-run")
+    parser.add_argument("--home", type=Path, default=Path.home(), help="home directory used for repo/worktree layout")
+    parser.add_argument("--executor", default="agent.coding-agent", help="provider executor launched under systemd-run")
+    parser.add_argument("--claimed-by", default=os.environ.get("KS_AGENT_NAME") or socket.gethostname())
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    args.tasks_file = args.tasks_file.expanduser().resolve()
+    args.home = args.home.expanduser().resolve()
+
+    index, task = claim(args)
+    if task is None:
+        print(json.dumps({"status": "idle", "reason": "no pending executable task"}))
+        raise SystemExit(2)
+
+    worktree = worktree_path(args.home, str(task["repo"]), str(task["branch_name"]))
+    if not args.dry_run:
+        worktree = ensure_worktree(args.home, str(task["repo"]), str(task["branch_name"]))
+
+    command = provider_command(args.executor, task)
+    unit = f"keystone-task-{slug(task_name(task, index))}"
+    launch = systemd_run_command(unit, worktree, command)
+    result = {
+        "status": "selected",
+        "task_index": index,
+        "task": task_name(task, index),
+        "repo": task["repo"],
+        "branch_name": task["branch_name"],
+        "worktree": str(worktree),
+        "command": command,
+        "systemd_run": launch,
+    }
+    print(json.dumps(result, sort_keys=True))
+
+    if args.dry_run or args.test_mode:
+        return
+    run(launch)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/linux-task-dispatcher/default.nix
+++ b/packages/linux-task-dispatcher/default.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+  python3,
+  git,
+  systemd,
+  runCommand,
+}:
+let
+  pythonEnv = python3.withPackages (ps: [ ps.pyyaml ]);
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "linux-task-dispatcher";
+  version = "0.1.0";
+
+  src = ./.;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp bin/linux-task-dispatcher $out/bin/linux-task-dispatcher
+    substituteInPlace $out/bin/linux-task-dispatcher \
+      --replace-fail '#!/usr/bin/env python3' '#!${pythonEnv}/bin/python'
+    chmod +x $out/bin/linux-task-dispatcher
+    wrapProgram $out/bin/linux-task-dispatcher \
+      --set PYTHONPATH "${pythonEnv}/${pythonEnv.sitePackages}" \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          git
+          systemd
+        ]
+      }"
+
+    runHook postInstall
+  '';
+
+  passthru.tests.dispatcher =
+    runCommand "linux-task-dispatcher-test" { nativeBuildInputs = [ git ]; }
+      ''
+                    set -eu
+
+                    export HOME="$TMPDIR/home"
+                    mkdir -p "$HOME/repos/ncrmro/example"
+                    git -C "$HOME/repos/ncrmro/example" init
+                    git -C "$HOME/repos/ncrmro/example" config user.name "Dispatcher Test"
+                    git -C "$HOME/repos/ncrmro/example" config user.email "dispatcher-test@example.invalid"
+                    printf 'hello\n' > "$HOME/repos/ncrmro/example/README.md"
+                    git -C "$HOME/repos/ncrmro/example" add README.md
+                    git -C "$HOME/repos/ncrmro/example" commit -m initial
+
+        printf '%s\n' \
+          'tasks:' \
+          '  - name: missing-branch' \
+          '    status: pending' \
+          '    repo: ncrmro/example' \
+          '    description: Missing required branch.' \
+          '  - name: ready' \
+          '    status: pending' \
+          '    repo: ncrmro/example' \
+          '    branch_name: feat/dispatcher-test' \
+          '    provider: codex' \
+          '    model: gpt-test' \
+          '    description: Implement the dispatcher test task.' \
+          > "$TMPDIR/TASKS.yaml"
+
+                    dry_json="$(${finalAttrs.finalPackage}/bin/linux-task-dispatcher --tasks-file "$TMPDIR/TASKS.yaml" --home "$HOME" --dry-run)"
+                    printf '%s\n' "$dry_json" | ${python3}/bin/python -c 'import json,sys; data=json.load(sys.stdin); assert data["task"] == "ready"; assert data["worktree"].endswith("/repos/ncrmro/worktree/example/feat/dispatcher-test")'
+                    ${pythonEnv}/bin/python -c 'import sys,yaml; data=yaml.safe_load(open(sys.argv[1])); assert data["tasks"][1]["status"] == "pending"' "$TMPDIR/TASKS.yaml"
+
+                    test_json="$(${finalAttrs.finalPackage}/bin/linux-task-dispatcher --tasks-file "$TMPDIR/TASKS.yaml" --home "$HOME" --test-mode --claimed-by test-agent)"
+                printf '%s\n' "$test_json" | ${python3}/bin/python -c 'import json,sys; data=json.load(sys.stdin); assert data["task"] == "ready"; assert data["command"][:7] == ["agent.coding-agent", "--repo", "ncrmro/example", "--branch", "feat/dispatcher-test", "--provider", "codex"]'
+                    test -f "$HOME/repos/ncrmro/worktree/example/feat/dispatcher-test/.git"
+                    ${pythonEnv}/bin/python -c 'import sys,yaml; data=yaml.safe_load(open(sys.argv[1])); task=data["tasks"][1]; assert task["status"] == "in_progress"; assert task["claimed_by"] == "test-agent"; assert "started_at" in task' "$TMPDIR/TASKS.yaml"
+
+                    if ${finalAttrs.finalPackage}/bin/linux-task-dispatcher --tasks-file "$TMPDIR/TASKS.yaml" --home "$HOME" --dry-run > "$TMPDIR/idle.json"; then
+                      echo "expected idle dispatcher to exit non-zero" >&2
+                      exit 1
+                    fi
+                    printf '%s\n' "$(cat "$TMPDIR/idle.json")" | ${python3}/bin/python -c 'import json,sys; assert json.load(sys.stdin)["status"] == "idle"'
+
+            mkdir -p $out
+      '';
+
+  meta = with lib; {
+    description = "Minimal Linux-native TASKS.yaml dispatcher prototype";
+    license = licenses.mit;
+    mainProgram = "linux-task-dispatcher";
+  };
+})


### PR DESCRIPTION
## Summary

- Add `linux-task-dispatcher`, a small Python dispatcher for one pending executable `TASKS.yaml` task.
- Claim tasks with explicit `repo` and `branch_name`, ensure `~/repos/{owner}/worktree/{repo}/{branch}`, and construct `systemd-run --user` provider launch outside dry-run/test mode.
- Export the package through the Keystone overlay/flake and add a focused Nix check.

## Validation

- `nix develop -c python3 -m py_compile packages/linux-task-dispatcher/bin/linux-task-dispatcher`
- `nix develop -c nix build .#linux-task-dispatcher`
- `nix develop -c nix build .#checks.x86_64-linux.linux-task-dispatcher`
- `nix develop -c nix-instantiate --parse flake.nix >/dev/null`
- `nix develop -c nix-instantiate --parse overlays/default.nix >/dev/null`
- `nix develop -c nix-instantiate --parse packages/linux-task-dispatcher/default.nix >/dev/null`

## Notes

`nix develop -c nix flake check --no-build` evaluated through the new dispatcher check, then failed in existing `checks.x86_64-linux.agent-evaluation` with `path ...-keystone-conventions.drv is not valid`. DeepWork review discovery also failed locally with `Unsupported platform: codex`.
