### PR TITLE
feat(agents): add dispatcher systemd units

### DIFF
--- a/docs/agents/os-agents.md
+++ b/docs/agents/os-agents.md
@@ -183,6 +183,31 @@ systemctl --user status agent-{name}-notes-sync.service
 journalctl --user -u agent-{name}-notes-sync -n 20
 ```
 
+## Experimental dispatcher units
+
+`keystone.os.agents.<name>.dispatcher` declares disabled-by-default systemd
+user units for a future dispatcher binary. This only wires Linux-native
+activation; it does not implement dispatcher logic or change the existing task
+CLI.
+
+```nix
+keystone.os.agents.drago.dispatcher = {
+  enable = true;
+  command = "/run/current-system/sw/bin/ks-dispatcher";
+  args = [ "--once" ];
+};
+```
+
+When enabled for a local agent, Keystone creates:
+
+- `agent-{name}-dispatcher.path` — watches `/home/agent-{name}/TASKS.yaml` by default
+- `agent-{name}-dispatcher.timer` — fallback trigger, defaulting to every five minutes
+- `agent-{name}-dispatcher.service` — oneshot execution in the `agent-{name}` user manager
+
+The service exports `KS_AGENT_NAME`, `KS_TASKS_FILE`, and `KS_PROJECTS_FILE`.
+All three units are guarded with `ConditionUser = "agent-{name}"` so they only
+activate in the intended agent user manager.
+
 ## What Each Agent Gets
 
 | Feature        | Service/Config                     | Details                                      |
@@ -198,6 +223,7 @@ journalctl --user -u agent-{name}-notes-sync -n 20
 | Contacts       | cardamum CLI                       | Stalwart CardDAV (auto-configured from mail) |
 | Bitwarden      | `bw` CLI                           | Configured for Vaultwarden instance          |
 | Workspace      | `clone-agent-space-{name}.service` | Clones `notes.repo` on first boot            |
+| Dispatcher     | `agent-{name}-dispatcher.*`        | Experimental opt-in path/timer/service units |
 
 ## Debugging
 

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -78,6 +78,27 @@ or validated the interaction with existing disk swap on every host.
 
 **Options**: `keystone.os.zram.enable`, `.memoryPercent`, `.swappiness`
 
+### `keystone.os.agents.<name>.dispatcher` — Agent dispatcher systemd units
+
+| | |
+|---|---|
+| **Module** | `modules/os/agents/dispatcher.nix` |
+| **Flag** | `keystone.os.agents.<name>.dispatcher.enable` (defaults to `false`) |
+| **Milestone** | [v2 — Un-experimental](https://github.com/ncrmro/keystone/milestone/10) |
+
+Declares Linux-native user units for a future dispatcher binary:
+`agent-{name}-dispatcher.path` watches `TASKS.yaml`,
+`agent-{name}-dispatcher.timer` provides a fallback trigger, and
+`agent-{name}-dispatcher.service` runs the configured command in the agent's
+user manager.
+
+**Why experimental**: The dispatcher binary and task execution contract are
+not implemented in this module yet. The units are disabled by default and
+require an explicit `dispatcher.command` when enabled.
+
+**Options**: `keystone.os.agents.<name>.dispatcher.enable`, `.command`,
+`.args`, `.tasksFile`, `.onCalendar`, `.timeout`
+
 ## For module authors
 
 To mark a module as experimental:

--- a/modules/os/agents/AGENTS.md
+++ b/modules/os/agents/AGENTS.md
@@ -19,6 +19,7 @@ agents/
   tailscale.nix      -- per-agent Tailscale (currently disabled)
   ssh.nix            -- ssh-agent + assertions
   notes.nix          -- notes-sync, task-loop, scheduler services + timers
+  dispatcher.nix     -- experimental dispatcher service + TASKS.yaml path/timer units
   home-manager.nix   -- home-manager terminal integration
   scripts/
     agent-svc.sh     -- per-agent service helper
@@ -120,6 +121,14 @@ keystone.os.agents.drago = {
     };
     scheduler.onCalendar = "*-*-* 05:00:00";
   };
+  dispatcher = {
+    enable = false;                # Experimental; requires explicit opt-in
+    command = null;                # Absolute dispatcher binary path when enabled
+    args = [];
+    tasksFile = "/home/agent-drago/TASKS.yaml";
+    onCalendar = "*:0/5";          # Timer fallback for missed path events
+    timeout = "1h";
+  };
 };
 ```
 
@@ -133,6 +142,21 @@ keystone.os.agents.drago = {
 AND the mail server's host (Stalwart provisioning). Missing either breaks auth silently.
 
 SSH keys are managed via `keystone.keys."agent-{name}"`.
+
+## Experimental dispatcher units
+
+`dispatcher.nix` only declares systemd integration for a future dispatcher
+binary. It does not implement task dispatch logic and does not depend on
+`packages/ks` task CLI code. For each local agent with
+`dispatcher.enable = true`, it creates:
+
+- `agent-{name}-dispatcher.service` — oneshot user service running the configured dispatcher command as `agent-{name}`
+- `agent-{name}-dispatcher.path` — watches `/home/agent-{name}/TASKS.yaml` by default
+- `agent-{name}-dispatcher.timer` — fallback trigger, defaulting to every five minutes
+
+All three units set `ConditionUser = "agent-{name}"` so the shared user-unit
+declarations only activate in the intended agent's user manager. Keep this
+integration disabled by default until the dispatcher binary contract is stable.
 
 ## agentctl CLI (`agentctl.nix`)
 

--- a/modules/os/agents/default.nix
+++ b/modules/os/agents/default.nix
@@ -85,6 +85,7 @@ in
     ./tailscale.nix
     ./ssh.nix
     ./notes.nix
+    ./dispatcher.nix
     ./home-manager.nix
     ./observability.nix
     ./perception.nix

--- a/modules/os/agents/dispatcher.nix
+++ b/modules/os/agents/dispatcher.nix
@@ -1,0 +1,103 @@
+# Agent dispatcher systemd integration [EXPERIMENTAL].
+#
+# Declares opt-in user service/path/timer units for a future dispatcher binary.
+# The dispatcher implementation is intentionally external to this module.
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  agentsLib = import ./lib.nix { inherit lib config pkgs; };
+  inherit (agentsLib) osCfg localAgents;
+
+  dispatcherAgents = filterAttrs (_: agentCfg: agentCfg.dispatcher.enable) localAgents;
+
+  profilePath =
+    username:
+    "/etc/profiles/per-user/${username}/bin:/run/wrappers/bin:/run/current-system/sw/bin:${lib.makeBinPath [ pkgs.nix ]}";
+in
+{
+  config = mkIf (osCfg.enable && dispatcherAgents != { }) {
+    assertions = mapAttrsToList (name: agentCfg: {
+      assertion = agentCfg.dispatcher.command != null;
+      message = "keystone.os.agents.${name}.dispatcher.command must be set when dispatcher.enable = true";
+    }) dispatcherAgents;
+
+    systemd.user.services = mkMerge (
+      mapAttrsToList (
+        name: agentCfg:
+        let
+          username = "agent-${name}";
+          dispatcher = agentCfg.dispatcher;
+          command = if dispatcher.command == null then "${pkgs.coreutils}/bin/false" else dispatcher.command;
+        in
+        {
+          "agent-${name}-dispatcher" = {
+            description = "Experimental task dispatcher for ${username}";
+            unitConfig.ConditionUser = username;
+            environment = {
+              PATH = lib.mkForce (profilePath username);
+              KS_AGENT_NAME = name;
+              KS_TASKS_FILE = dispatcher.tasksFile;
+              KS_PROJECTS_FILE = "/home/${username}/PROJECTS.yaml";
+              SSH_AUTH_SOCK = "/run/agent-${name}-ssh-agent/agent.sock";
+              GIT_SSH_COMMAND = "${pkgs.openssh}/bin/ssh -o StrictHostKeyChecking=accept-new";
+            };
+            serviceConfig = {
+              Type = "oneshot";
+              WorkingDirectory = "/home/${username}";
+              TimeoutStartSec = dispatcher.timeout;
+              SyslogIdentifier = "agent-${name}-dispatcher";
+              LogRateLimitIntervalSec = 0;
+            };
+            script = ''
+              exec ${escapeShellArg command} ${escapeShellArgs dispatcher.args}
+            '';
+          };
+        }
+      ) dispatcherAgents
+    );
+
+    systemd.user.paths = mkMerge (
+      mapAttrsToList (
+        name: agentCfg:
+        let
+          username = "agent-${name}";
+        in
+        {
+          "agent-${name}-dispatcher" = {
+            wantedBy = [ "default.target" ];
+            unitConfig.ConditionUser = username;
+            pathConfig = {
+              PathChanged = agentCfg.dispatcher.tasksFile;
+              Unit = "agent-${name}-dispatcher.service";
+            };
+          };
+        }
+      ) dispatcherAgents
+    );
+
+    systemd.user.timers = mkMerge (
+      mapAttrsToList (
+        name: agentCfg:
+        let
+          username = "agent-${name}";
+        in
+        {
+          "agent-${name}-dispatcher" = {
+            wantedBy = [ "default.target" ];
+            unitConfig.ConditionUser = username;
+            timerConfig = {
+              OnCalendar = agentCfg.dispatcher.onCalendar;
+              Persistent = true;
+              Unit = "agent-${name}-dispatcher.service";
+            };
+          };
+        }
+      ) dispatcherAgents
+    );
+  };
+}

--- a/modules/os/agents/types.nix
+++ b/modules/os/agents/types.nix
@@ -476,6 +476,64 @@ in
           };
         };
 
+        dispatcher = {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Enable experimental systemd user units for a future task dispatcher.
+              Disabled by default and independent of `keystone.experimental`
+              because the dispatcher binary is not implemented here.
+            '';
+          };
+
+          command = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = ''
+              Absolute dispatcher executable path. Required when
+              `dispatcher.enable = true`.
+            '';
+            example = "/run/current-system/sw/bin/ks-dispatcher";
+          };
+
+          args = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            description = ''
+              Extra arguments passed to the dispatcher command. The module
+              exports `KS_AGENT_NAME` and `KS_TASKS_FILE`, so arguments are
+              optional for binaries that read their environment.
+            '';
+            example = [
+              "--once"
+              "--tasks-file"
+              "/home/agent-drago/TASKS.yaml"
+            ];
+          };
+
+          tasksFile = mkOption {
+            type = types.str;
+            default = "/home/agent-${name}/TASKS.yaml";
+            description = "Task queue watched by the dispatcher path unit.";
+          };
+
+          onCalendar = mkOption {
+            type = types.str;
+            default = "*:0/5";
+            description = ''
+              Fallback systemd calendar spec for the dispatcher timer. The path
+              unit is the primary trigger; this catches missed file events.
+            '';
+          };
+
+          timeout = mkOption {
+            type = types.str;
+            default = "1h";
+            description = "Maximum runtime for one dispatcher service execution.";
+          };
+        };
+
         calendar = {
           teamEvents = mkOption {
             type = types.listOf (


### PR DESCRIPTION
## Summary

- add disabled-by-default experimental per-agent dispatcher service/path/timer units
- add dispatcher options under keystone.os.agents.<name>.dispatcher
- document the future dispatcher integration in agent and experimental docs

## Verification

- nix develop -c nixfmt --check modules/os/agents/default.nix modules/os/agents/types.nix modules/os/agents/dispatcher.nix
- nix develop -c nix-instantiate --parse modules/os/agents/default.nix modules/os/agents/types.nix modules/os/agents/dispatcher.nix
- nix develop -c nix build .#checks.x86_64-linux.agent-evaluation --no-link
- nix develop -c nix eval --impure --json --expr '<dispatcher enabled module eval>'
- nix develop -c nix eval --impure --json --expr '<dispatcher disabled module eval>'
- git diff -- packages/ks

Note: nix develop -c nix flake check --no-build was attempted. It evaluated through the agent checks, then failed in unrelated checks.x86_64-linux.polkit-keystone-approve-cache because an unbuilt /nix/store/...-approve-exec.sh.drv path was not valid under --no-build.