### PR TITLE
feat(os/mail): provision CardDAV sharing ACLs alongside CalDAV

### DIFF
--- a/modules/os/mail.nix
+++ b/modules/os/mail.nix
@@ -359,6 +359,32 @@ in
                   else
                     echo "${username}: WARNING: CalDAV ACL request returned HTTP $ACL_STATUS" >&2
                   fi
+
+                  # Mirror of the CalDAV block above, for CardDAV.
+                  # DAV ACL XML is protocol-agnostic — same ACE list, different URL.
+                  echo "${username}: Setting CardDAV sharing ACLs..."
+
+                  # Trigger default address book creation by accessing the agent's CardDAV home
+                  curl -sf -u "${username}:$AGENT_PASS" \
+                    "http://127.0.0.1:8082/dav/card/${username}/" \
+                    -X PROPFIND -H "Content-Type: application/xml" -H "Depth: 1" \
+                    -d '<?xml version="1.0"?><propfind xmlns="DAV:"><prop><resourcetype/></prop></propfind>' \
+                    -o /dev/null || true
+
+                  CARD_ACL_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                    -u "${username}:$AGENT_PASS" \
+                    "http://127.0.0.1:8082/dav/card/${username}/default/" \
+                    -X ACL -H "Content-Type: application/xml" \
+                    -d '<?xml version="1.0" encoding="utf-8"?>
+                  <D:acl xmlns:D="DAV:">
+                  ${aclAces}
+                  </D:acl>')
+
+                  if [[ "$CARD_ACL_STATUS" = "200" || "$CARD_ACL_STATUS" = "204" ]]; then
+                    echo "${username}: CardDAV sharing ACLs set successfully"
+                  else
+                    echo "${username}: WARNING: CardDAV ACL request returned HTTP $CARD_ACL_STATUS" >&2
+                  fi
                 '';
             }
           ) provisionAgents


### PR DESCRIPTION
## Summary

- Mirror the existing CalDAV ACL stanza for CardDAV in the
  agent-mail provisioning systemd unit
- Every `keystone.os.users` human gets read+write on
  `/dav/card/<agent>/default/` automatically, the same way they
  already do for `/dav/cal/<agent>/default/`
- DAV ACL XML is protocol-agnostic - reuse the existing
  `${aclAces}` variable; only the URL changes
- Idempotent; safe across rebuilds

## Why

Vega's spec/stalwart-integration (downstream) discovered that the
provisioning script only handles CalDAV ACLs. The agent's address
book exists (Stalwart auto-creates it on first CardDAV PROPFIND)
but humans don't get automatic access. This patch closes that gap
for every existing agent (drago, luce, ...) on the next ocean rebuild.

## Stalwart 0.15.5 assumption check

All three assumptions confirmed via source grep at tag `v0.15.5`:

1. **Default address book URL `/dav/card/<user>/default/`** - confirmed
   in [`crates/common/src/config/groupware.rs`](https://github.com/stalwartlabs/stalwart/blob/v0.15.5/crates/common/src/config/groupware.rs#L88-L91)
   lines 88-91: `default_addressbook_name` falls back to the literal
   string `"default"` via `property_or_default("contacts.default.href-name", "default")`,
   exactly mirroring `default_calendar_name` (lines 84-87,
   `calendar.default.href-name`).
2. **ACL method honored on CardDAV collections** - confirmed in
   [`crates/dav/src/common/acl.rs`](https://github.com/stalwartlabs/stalwart/blob/v0.15.5/crates/dav/src/common/acl.rs#L84-L87)
   lines 84-87: `handle_acl_request` accepts
   `Collection::AddressBook | Collection::Calendar | Collection::FileNode`;
   `handle_acl_prop_set` (lines 197-202) repeats the same allowlist.
   AddressBook collections are treated identically to Calendar collections
   by the ACL handler.
3. **PROPFIND auto-creates default address book** - confirmed in
   [`crates/groupware/src/cache/calcard.rs`](https://github.com/stalwartlabs/stalwart/blob/v0.15.5/crates/groupware/src/cache/calcard.rs#L91-L109)
   lines 91-109: when the user's groupware cache `paths` is empty on
   first PROPFIND, the cache calls `create_default_addressbook` (or
   `create_default_calendar`) symmetrically. The implementations live
   in `crates/groupware/src/cache/mod.rs` lines 198-220 (addressbook)
   and 222-249 (calendar); both seed `name: name.clone()` where `name`
   comes from `default_addressbook_name` / `default_calendar_name`
   resolved to `"default"` by config defaults.

Net: the CardDAV side of every primitive used by the existing
CalDAV stanza is implemented by the same code paths as CalDAV.

## Test plan

- [x] `nix build .#checks.x86_64-linux.os-evaluation` clean (the
  module evaluation check that covers `modules/os/mail.nix`)
- [ ] Pre-existing unrelated failure: `check-eval` fails on
  `notesEvaluation` because a downstream ks-config flake declares
  `keystone.os.agents.drago.capabilities = ["notes"]` and the
  current upstream `keystone.os.agents` option doesn't list
  `"notes"`. Reproduced on `origin/experimental` HEAD without this
  patch - not introduced here.
- [ ] (Post-merge) Cherry-pick to upstream `keystone/main` as a
  separate PR
- [ ] (Post-deploy on ocean) `journalctl -u provision-agent-mail-agent-drago`
  shows the new "Setting CardDAV sharing ACLs..." line and a
  200/204 response
- [ ] (Post-deploy) `curl -u ncrmro:<pw> -X PROPFIND https://mail.ncrmro.com/dav/card/agent-drago/default/`
  from the ncrmro human account succeeds with the agent's contacts

## Cherry-pick path

Lands on `experimental` first so ks-dev rebuilds pick it up
immediately. Once verified live on ocean, the commit cherry-picks
cleanly into upstream `keystone/main` via a separate PR.