### PR TITLE
fix(deepreview): milestone precompute self-discovers; populate dependsOnSpecs for M9/M10

### DIFF
--- a/.deepwork/review/fetch_milestone_state.sh
+++ b/.deepwork/review/fetch_milestone_state.sh
@@ -1,28 +1,24 @@
 #!/usr/bin/env bash
 # Precompute script for the milestone_github_sync .deepreview rule.
-# Detects which docs/milestones/M*/ dirs have changed files, parses each
-# README.md's YAML frontmatter, and dumps the matching GitHub milestone +
-# tracker issue + attached issue list. Output is injected as the reviewer's
-# "Precomputed Context" so a single review pass can compare local vs remote.
+# Iterates every docs/milestones/M*/ directory, parses each README.md's
+# YAML frontmatter, and dumps the matching GitHub milestone + tracker
+# issue + attached issue list. Output is injected as the reviewer's
+# "Precomputed Context" so a single review pass can compare local vs
+# remote across every milestone.
+#
+# CRITICAL: deepwork's runtime does NOT pass the matched-file list to the
+# precompute command — the script must self-discover. Don't switch back
+# to `git diff` detection; on a clean tree (post-merge or `/review --files`)
+# it produces an empty block.
 set -euo pipefail
 
 REPO="ncrmro/keystone"
 
-# Mirror deepreview's changed-file detection: committed-on-branch + staged +
-# unstaged + untracked.
-{
-  git diff --name-only --diff-filter=AMR origin/main...HEAD 2>/dev/null || true
-  git diff --name-only --diff-filter=AMR --cached 2>/dev/null || true
-  git diff --name-only --diff-filter=AMR 2>/dev/null || true
-  git ls-files --others --exclude-standard 2>/dev/null || true
-} > /tmp/.milestone_changed_files.$$
-dirs=$(grep -E '^docs/milestones/M[0-9]+-[^/]+/' /tmp/.milestone_changed_files.$$ \
-       | awk -F/ '{print $1"/"$2"/"$3}' \
-       | sort -u)
-rm -f /tmp/.milestone_changed_files.$$
+dirs=$(find docs/milestones -mindepth 1 -maxdepth 1 -type d -name 'M[0-9]*-*' 2>/dev/null \
+       | sort)
 
 if [ -z "$dirs" ]; then
-  echo "No milestone files changed."
+  echo "No docs/milestones/M*/ directories found."
   exit 0
 fi
 

--- a/docs/milestones/M10-v2-un-experimental/README.md
+++ b/docs/milestones/M10-v2-un-experimental/README.md
@@ -3,7 +3,10 @@ slug: v2-un-experimental
 trackerMilestone: 10
 trackerIssue: null
 flag: KEYSTONE_FLAG_MILESTONE_V2_UN_EXPERIMENTAL
-dependsOnSpecs: []
+dependsOnSpecs:
+  - notes
+  - conventions-grafana-mcp
+  - projects
 status: planned
 ---
 

--- a/docs/milestones/M9-v1-stabilization/README.md
+++ b/docs/milestones/M9-v1-stabilization/README.md
@@ -3,7 +3,14 @@ slug: v1-stabilization
 trackerMilestone: 9
 trackerIssue: 418
 flag: KEYSTONE_FLAG_MILESTONE_V1_STABILIZATION
-dependsOnSpecs: []
+dependsOnSpecs:
+  - keystone-os
+  - nixos-installer
+  - os-agents
+  - terminal
+  - keystone-desktop
+  - projects
+  - ks-cli
 status: in_progress
 ---
 


### PR DESCRIPTION
## Summary

Follow-ups surfaced by the DeepWork review pass on the just-merged
docs/v1-prep PR (#587).

### `fix(deepreview)` — milestone precompute script

The `milestone_github_sync` rule's precompute script used `git diff`
to decide which milestones to dump. That breaks any time the rule is
invoked on a clean tree:

- Running `/review` on `main` post-merge → empty Precomputed Context
- Running `deepwork review --files docs/milestones/...` → same

Verified in `deepwork/review/instructions.py`: the precompute command
runs via `subprocess.run` with no env vars or argv hints, so the
script must self-discover. Switched to iterating every
`docs/milestones/M*/` directory on disk. Cost is one extra `gh api`
call per inactive milestone — negligible.

### `docs(milestones)` — populate `dependsOnSpecs`

The `implementation_sync` review flagged that both milestones shipped
with `dependsOnSpecs: []` despite obvious linkable specs.

- **M9** → keystone-os, nixos-installer, os-agents, terminal,
  keystone-desktop, projects, ks-cli
- **M10** → notes, conventions-grafana-mcp, projects

Every slug verified to resolve to exactly one
`docs/specs/REQ-NNN-<slug>.md` file, so the
`milestone_github_sync` rule's resolution check passes.

## Test plan

- [ ] `bash .deepwork/review/fetch_milestone_state.sh` from project
      root on `main` produces both M9 and M10 blocks (no longer
      "No milestone files changed.")
- [ ] `deepwork review --files docs/milestones/M9-v1-stabilization/README.md`
      lists `milestone_github_sync` with non-empty Precomputed Context
- [ ] Each slug in `dependsOnSpecs:` resolves uniquely:
      `for s in keystone-os nixos-installer os-agents terminal keystone-desktop projects ks-cli notes conventions-grafana-mcp; do
        echo -n "$s "; ls docs/specs/REQ-*-${s}.md 2>/dev/null | wc -l;
      done`

## Out of scope

- The pre-existing REQ-007 ↔ implementation drift surfaced by
  `specs_review` (filed separately).
- The `tracker.md` staleness gate in the rule (the M9 tracker still
  shows #414 as `[ ]` despite being CLOSED — fixable but the rule's
  current gate only fires when tracker.md is in the changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)