### PR TITLE
feat(notes): gate daily rollover by services singleton

### DIFF
--- a/modules/notes/default.nix
+++ b/modules/notes/default.nix
@@ -17,10 +17,22 @@
   lib,
   config,
   pkgs,
+  osConfig ? null,
   ...
 }:
 let
   cfg = config.keystone.notes;
+  currentHost =
+    if osConfig != null && lib.hasAttrByPath [ "networking" "hostName" ] osConfig then
+      osConfig.networking.hostName
+    else
+      null;
+  notesDailyHost =
+    if osConfig != null && lib.hasAttrByPath [ "keystone" "services" "notesDaily" "host" ] osConfig then
+      osConfig.keystone.services.notesDaily.host
+    else
+      null;
+  isNotesDailyHost = notesDailyHost != null && currentHost == notesDailyHost;
   pathHasParentTraversal = path: builtins.elem ".." (lib.splitString "/" path);
   sshAuthSock =
     if
@@ -189,7 +201,21 @@ in
     };
 
     daily = {
-      enable = lib.mkEnableOption "git-tracked daily note rollover";
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = isNotesDailyHost;
+        defaultText = lib.literalExpression ''
+          osConfig.keystone.services.notesDaily.host == osConfig.networking.hostName
+        '';
+        description = ''
+          Enable git-tracked daily note rollover for this user's notes repo.
+
+          When the NixOS service singleton `keystone.services.notesDaily.host`
+          is set, this defaults to true only on that host and false everywhere
+          else. Explicitly enabling daily rollover on a different host is
+          rejected to avoid multiple hosts racing to move the daily symlink.
+        '';
+      };
 
       symlinkPath = lib.mkOption {
         type = lib.types.str;
@@ -213,18 +239,29 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    assertions = lib.optionals cfg.daily.enable [
-      {
-        assertion =
-          !lib.hasPrefix "/" cfg.daily.symlinkPath && !pathHasParentTraversal cfg.daily.symlinkPath;
-        message = "keystone.notes.daily.symlinkPath must stay under keystone.notes.path and must not contain '..' segments.";
-      }
-      {
-        assertion =
-          !lib.hasPrefix "/" cfg.daily.journalPath && !pathHasParentTraversal cfg.daily.journalPath;
-        message = "keystone.notes.daily.journalPath must stay under keystone.notes.path and must not contain '..' segments.";
-      }
-    ];
+    assertions =
+      lib.optionals cfg.daily.enable [
+        {
+          assertion =
+            !lib.hasPrefix "/" cfg.daily.symlinkPath && !pathHasParentTraversal cfg.daily.symlinkPath;
+          message = "keystone.notes.daily.symlinkPath must stay under keystone.notes.path and must not contain '..' segments.";
+        }
+        {
+          assertion =
+            !lib.hasPrefix "/" cfg.daily.journalPath && !pathHasParentTraversal cfg.daily.journalPath;
+          message = "keystone.notes.daily.journalPath must stay under keystone.notes.path and must not contain '..' segments.";
+        }
+      ]
+      ++ lib.optionals (cfg.daily.enable && notesDailyHost != null && currentHost != null) [
+        {
+          assertion = currentHost == notesDailyHost;
+          message = ''
+            keystone.notes.daily.enable is true on host "${currentHost}", but
+            keystone.services.notesDaily.host selects "${notesDailyHost}".
+            Disable keystone.notes.daily.enable here or move the singleton host.
+          '';
+        }
+      ];
 
     systemd.user.services.keystone-notes-sync = lib.mkIf (cfg.sync.enable && cfg.repo != "") {
       Unit = {

--- a/modules/services.nix
+++ b/modules/services.nix
@@ -112,6 +112,18 @@ in
       description = "List of hostnames acting as GPU/ML workers.";
     };
 
+    notesDaily.host = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "ocean";
+      description = ''
+        The networking.hostName of the single host responsible for notes daily
+        rollover (daily.md -> journal/YYYY-MM-DD.md). Notes sync can still run
+        on every host; this host gate only controls the once-per-day journal
+        symlink migration to avoid multi-host rollover races.
+      '';
+    };
+
     vaultwarden.host = mkOption {
       type = types.nullOr types.str;
       default = null;
@@ -185,6 +197,7 @@ in
     ++ (validateHost "git" cfg.git.host)
     ++ (validateHost "immich" cfg.immich.host)
     ++ (concatMap (h: validateHost "immich.workers" h) cfg.immich.workers)
+    ++ (validateHost "notesDaily" cfg.notesDaily.host)
     ++ (validateHost "vaultwarden" cfg.vaultwarden.host)
     ++ (optional (cfg.vaultwarden.host != null && cfg.vaultwarden.domain == null) {
       assertion = false;

--- a/tests/module/notes-evaluation.nix
+++ b/tests/module/notes-evaluation.nix
@@ -7,10 +7,11 @@ let
   normalizeCommand =
     value: if builtins.isList value then builtins.concatStringsSep "\n" value else value;
 
-  evalNotes =
-    extraModules:
+  evalNotesWithOs =
+    osConfig: extraModules:
     (home-manager.lib.homeManagerConfiguration {
       inherit pkgs;
+      extraSpecialArgs = if osConfig == null then { } else { inherit osConfig; };
       modules = [
         self.homeModules.notes
         {
@@ -28,6 +29,13 @@ let
       ++ extraModules;
     }).config;
 
+  evalNotes = evalNotesWithOs null;
+
+  osConfigFor = hostName: notesDailyHost: {
+    networking.hostName = hostName;
+    keystone.services.notesDaily.host = notesDailyHost;
+  };
+
   enabledConfig = evalNotes [
     {
       keystone.notes = {
@@ -38,6 +46,18 @@ let
   ];
 
   disabledConfig = evalNotes [ ];
+
+  singletonHostConfig = evalNotesWithOs (osConfigFor "ocean" "ocean") [ ];
+
+  singletonClientConfig = evalNotesWithOs (osConfigFor "ncrmro-laptop" "ocean") [ ];
+
+  singletonClientExplicitResult = builtins.tryEval (
+    evalNotesWithOs (osConfigFor "ncrmro-laptop" "ocean") [
+      {
+        keystone.notes.daily.enable = true;
+      }
+    ]
+  );
 
   badConfigResult = builtins.tryEval (evalNotes [
     {
@@ -59,12 +79,15 @@ let
 
   enabledExecStart = normalizeCommand enabledConfig.systemd.user.services.keystone-notes-sync.Service.ExecStart;
   disabledExecStart = normalizeCommand disabledConfig.systemd.user.services.keystone-notes-sync.Service.ExecStart;
+  singletonHostExecStart = normalizeCommand singletonHostConfig.systemd.user.services.keystone-notes-sync.Service.ExecStart;
+  singletonClientExecStart = normalizeCommand singletonClientConfig.systemd.user.services.keystone-notes-sync.Service.ExecStart;
   execStartPost = normalizeCommand (
     enabledConfig.systemd.user.services.keystone-notes-sync.Service.ExecStartPost or ""
   );
   timerCalendar = enabledConfig.systemd.user.timers.keystone-notes-sync.Timer.OnCalendar;
   assertionTripped = !badConfigResult.success;
   parentTraversalAssertionTripped = !parentTraversalResult.success;
+  singletonClientAssertionTripped = !singletonClientExplicitResult.success;
   boolString = value: if value then "true" else "false";
 in
 pkgs.runCommand "notes-evaluation" { } ''
@@ -136,6 +159,28 @@ pkgs.runCommand "notes-evaluation" { } ''
     else
       echo "PASS: daily-disabled sync script skips rollover helper"
     fi
+
+    singleton_host_script="${singletonHostExecStart}"
+    singleton_client_script="${singletonClientExecStart}"
+
+    if ! grep -Fq 'keystone-notes-daily-rollover' "$singleton_host_script"; then
+      echo "FAIL: notesDaily singleton host should invoke rollover helper by default" >&2
+      cat "$singleton_host_script" >&2
+      errors=$((errors + 1))
+    else
+      echo "PASS: notesDaily singleton host invokes rollover helper by default"
+    fi
+
+    if grep -Fq 'keystone-notes-daily-rollover' "$singleton_client_script"; then
+      echo "FAIL: notesDaily non-host should not invoke rollover helper by default" >&2
+      cat "$singleton_client_script" >&2
+      errors=$((errors + 1))
+    else
+      echo "PASS: notesDaily non-host skips rollover helper by default"
+    fi
+
+    check "${boolString singletonClientAssertionTripped}" \
+      "notesDaily non-host explicit daily enable trips the module assertion"
 
     if [ "${timerCalendar}" != "hourly" ]; then
       echo "FAIL: expected timer OnCalendar=hourly, got '${timerCalendar}'" >&2


### PR DESCRIPTION
## Summary\n- add keystone.services.notesDaily.host as the fleet singleton for notes daily rollover\n- default keystone.notes.daily.enable to true only on the selected host via osConfig\n- reject explicit daily rollover enablement on non-selected hosts while preserving normal sync/push on every host\n\n## Verification\n- nixfmt modules/services.nix modules/notes/default.nix tests/module/notes-evaluation.nix\n- nix build .#checks.x86_64-linux.notes-evaluation --no-link\n- nix build .#checks.x86_64-linux.os-evaluation --no-link