### PR TITLE
fix(os): make update migrations converge

### DIFF
--- a/modules/os/journal-remote.nix
+++ b/modules/os/journal-remote.nix
@@ -144,6 +144,10 @@ in
     # When nginx is proxying, bind journal-remote to localhost only.
     (mkIf (isServer && useNginxProxy) {
       systemd.sockets.systemd-journal-remote.listenStreams = mkForce [
+        # Reset systemd's upstream ListenStream=19532 before adding the
+        # localhost-only listener. Without the empty assignment, systemd keeps
+        # both sockets and the wildcard listener races the explicit IPv4 bind.
+        ""
         "127.0.0.1:${toString cfg.server.port}"
       ];
     })

--- a/modules/terminal/agents/assets.nix
+++ b/modules/terminal/agents/assets.nix
@@ -188,6 +188,16 @@ in
           ]
         }:$PATH"
 
+        asset_backup_root="$HOME/.local/state/keystone/agent-asset-symlink-backups/$(date +%Y%m%d-%H%M%S)"
+        backup_regular_file_for_symlink() {
+          link="$1"
+          rel="''${link#$HOME/}"
+          backup="$asset_backup_root/$rel"
+          mkdir -p "$(dirname "$backup")"
+          mv "$link" "$backup"
+          echo "keystone-agent-asset-symlinks: moved regular file $link to $backup before installing managed symlink" >&2
+        }
+
         # Resolve consumer-flake agents root at runtime. Prefer the runtime
         # pointer file (survives Nix evaluation, follows the active system
         # flake) so re-evaluating with a different flake doesn't strand the
@@ -319,13 +329,11 @@ in
             fi
             rm -f "$link"
           elif [ -f "$link" ]; then
-            # A regular file at the link site — possibly user-edited, possibly
-            # a leftover from a pre-symlink generation home-manager hasn't
-            # cleaned. Refuse rather than silently clobbering user content.
-            echo "keystone-agent-asset-symlinks: refusing to replace regular file $link with symlink to $target" >&2
-            echo "  Move or remove the file, then re-run home-manager activation." >&2
-            refusal_count=$((refusal_count + 1))
-            continue
+            # A regular file at these managed instruction paths is either a
+            # legacy generated file or user-edited content. Preserve it, then
+            # converge to the symlink topology required by the current agent
+            # asset layout so OS updates do not wedge on old generations.
+            backup_regular_file_for_symlink "$link"
           elif [ -e "$link" ]; then
             echo "keystone-agent-asset-symlinks: $link exists and is not a file or symlink; leaving untouched" >&2
             refusal_count=$((refusal_count + 1))
@@ -393,8 +401,8 @@ in
               ln -s "$pi_target" "$pi_link"
             fi
           elif [ -f "$pi_link" ]; then
-            echo "keystone-agent-asset-symlinks: refusing to replace regular file $pi_link with symlink to $pi_target" >&2
-            refusal_count=$((refusal_count + 1))
+            backup_regular_file_for_symlink "$pi_link"
+            ln -s "$pi_target" "$pi_link"
           elif [ -e "$pi_link" ]; then
             echo "keystone-agent-asset-symlinks: $pi_link exists and is not a file or symlink; leaving untouched" >&2
             refusal_count=$((refusal_count + 1))

--- a/tests/module/os-evaluation.nix
+++ b/tests/module/os-evaluation.nix
@@ -41,6 +41,36 @@ let
       touch $out
     '';
 
+  # Evaluate a journal-remote server and assert the generated socket binds
+  # exactly as expected. This catches systemd list-reset regressions where the
+  # upstream wildcard ListenStream remains alongside Keystone's localhost bind.
+  assertJournalRemoteSocket =
+    name: expectedListenStreams: modules:
+    let
+      result = nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          self.nixosModules.operating-system
+          {
+            system.stateVersion = "25.05";
+            boot.loader.systemd-boot.enable = true;
+          }
+        ]
+        ++ modules;
+      };
+      actualListenStreams = result.config.systemd.sockets.systemd-journal-remote.listenStreams or [ ];
+      actualJson = builtins.toJSON actualListenStreams;
+      expectedJson = builtins.toJSON expectedListenStreams;
+    in
+    pkgs.runCommand "journal-remote-socket-${name}" { } ''
+      if [ '${actualJson}' != '${expectedJson}' ]; then
+        echo "FAIL: ${name}: expected ListenStream ${expectedJson}, got ${actualJson}" >&2
+        exit 1
+      fi
+      echo "OK: ${name}: ListenStream ${actualJson}"
+      touch $out
+    '';
+
   # Evaluate a module set and assert keystone.os.adminUsername resolves
   # to `expected`. Pins the auto-derivation from the admin flag.
   assertAdminUsername =
@@ -414,36 +444,42 @@ let
         touch $out
       '';
 
-    journal-remote-server = eval "journal-remote-server" [
-      {
-        keystone = {
-          domain = "example.com";
-          hosts.ocean = {
-            hostname = "journal-server";
-            role = "server";
-            journalRemote = true;
-          };
-          os = {
-            enable = true;
-            storage = {
-              type = "zfs";
-              devices = [ "/dev/vda" ];
+    journal-remote-server =
+      assertJournalRemoteSocket "journal-remote-server"
+        [
+          ""
+          "127.0.0.1:19532"
+        ]
+        [
+          {
+            keystone = {
+              domain = "example.com";
+              hosts.ocean = {
+                hostname = "journal-server";
+                role = "server";
+                journalRemote = true;
+              };
+              os = {
+                enable = true;
+                storage = {
+                  type = "zfs";
+                  devices = [ "/dev/vda" ];
+                };
+                users.testuser = {
+                  fullName = "Test User";
+                  initialPassword = "testpass";
+                  admin = true;
+                };
+              };
             };
-            users.testuser = {
-              fullName = "Test User";
-              initialPassword = "testpass";
-              admin = true;
+            networking.hostName = "journal-server";
+            networking.hostId = "deadbeef";
+            fileSystems."/" = {
+              device = lib.mkForce "rpool/crypt/system";
+              fsType = lib.mkForce "zfs";
             };
-          };
-        };
-        networking.hostName = "journal-server";
-        networking.hostId = "deadbeef";
-        fileSystems."/" = {
-          device = lib.mkForce "rpool/crypt/system";
-          fsType = lib.mkForce "zfs";
-        };
-      }
-    ];
+          }
+        ];
 
     journal-remote-client = eval "journal-remote-client" [
       {


### PR DESCRIPTION
## Summary\n- backup legacy regular agent instruction files before replacing them with managed symlinks\n- apply the same backup-and-replace behavior to the Pi agent instruction file\n- reset systemd-journal-remote.socket ListenStream before adding the localhost-only listener\n- add an eval regression test for the journal-remote socket listener list\n\n## Verification\n- nixfmt modules/terminal/agents/assets.nix modules/os/journal-remote.nix tests/module/os-evaluation.nix\n- nix build .#checks.x86_64-linux.os-evaluation --no-link\n- nix build .#checks.x86_64-linux.notes-evaluation --no-link\n\n## Known unrelated\n- nix build .#checks.x86_64-linux.agent-evaluation --no-link currently fails on the milestone branch because agent-drago has unsupported capability "notes" in an existing fixture/config.