### PR TITLE
fix(desktop): port v1-relevant fixes from orphaned M9 FDE branch

### DIFF
--- a/docs/milestones/M9-v1-stabilization/demo.md
+++ b/docs/milestones/M9-v1-stabilization/demo.md
@@ -1,0 +1,79 @@
+# Demo: Keystone OS FDE deployment
+
+## Goal
+
+Record a full bare-metal Keystone install that starts from the installer USB
+and ends with a bootable system using custom Secure Boot keys, durable manual
+full-disk-encryption unlock, and TPM2 automatic unlock.
+
+The demo should show the core promise before agentic workflows: Keystone can
+turn real hardware into a secure, encrypted, reproducible operating system.
+
+## Capture setup
+
+Use an HDMI capture path instead of screen recording from the target machine:
+
+- Connect the target laptop's HDMI output to an HDMI capture device.
+- Connect the capture device to the recording workstation over USB-C.
+- Record the capture feed from the workstation.
+- Keep a microphone available for narration during manual BIOS and enrollment
+  steps.
+
+This matters because the most important parts of the demo happen before the
+installed OS is available: firmware setup, installer boot, disk unlock, and
+first reboot validation.
+
+## Demo flow
+
+1. Boot the Keystone installer USB on the target hardware.
+2. Show the firmware Secure Boot state before enrollment.
+3. Install Keystone OS to encrypted storage.
+4. Reboot into the installed system.
+5. Enter firmware setup when required.
+6. Enable Secure Boot custom mode so Keystone's own keys can be enrolled.
+7. Enroll Keystone Secure Boot keys.
+8. Enroll a hardware-key or recovery-key based manual FDE unlock path.
+9. Reboot-test the manual unlock path.
+10. Enroll TPM2 automatic unlock only after manual unlock is trusted.
+11. Reboot again and show TPM2 automatic unlock under the expected Secure Boot
+    state.
+12. Run `ks hardware report` and explain the final state.
+
+## Narration points
+
+Explain the unlock methods in this order:
+
+- Hardware key: preferred manual unlock when available. It gives strong
+  physical security with better ergonomics than typing a long recovery key.
+- Recovery key: high-entropy disaster recovery. It is intentionally random,
+  hard to type, and should be stored off-host.
+- Custom LUKS password: acceptable manual fallback, but should differ from the
+  login password and should ideally be unique per host.
+- TPM2: normal day-to-day automatic unlock. It is not a backup credential and
+  should come last.
+
+Explain the boot-integrity chain:
+
+- Secure Boot custom keys protect the bootloader and initrd from tampering.
+- TPM2 unlock is only meaningful after the expected Secure Boot state is in
+  place.
+- If the boot state changes unexpectedly, TPM2 unlock should fail closed and a
+  tested manual unlock method should still recover the machine.
+
+Explain why the order matters:
+
+- Keystone should prove a durable manual unlock path before trusting automatic
+  unlock.
+- A LUKS keyslot existing is not enough; the user should reboot-test it.
+- The final state should be ergonomic for daily use while still recoverable
+  when firmware, hardware, or TPM state changes.
+
+## Final acceptance shot
+
+End the recording with:
+
+- The machine booted into the installed Keystone OS.
+- Secure Boot enabled with Keystone-controlled keys.
+- At least one tested manual FDE unlock method.
+- TPM2 automatic unlock working after manual fallback validation.
+- `ks hardware report` showing the expected Secure Boot, FDE, and TPM state.

--- a/flake.lock
+++ b/flake.lock
@@ -526,24 +526,6 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
         "systems": "systems_8"
       },
       "locked": {
@@ -563,22 +545,22 @@
     "ghostty": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "zig": "zig",
         "zon2nix": "zon2nix"
       },
       "locked": {
-        "lastModified": 1772649291,
-        "narHash": "sha256-Jfk2cmZU/H8pE5Dwb+o70w5kkfjpPddHmN/lO5DRaq8=",
+        "lastModified": 1773417630,
+        "narHash": "sha256-+ddMmUe9Jjkun4qqW8XFXVgwVZdVHsGWcQzndgIlBjQ=",
         "owner": "ghostty-org",
         "repo": "ghostty",
-        "rev": "0797b281ec0268f2df65399b1aede85eaea0d31a",
+        "rev": "332b2aefc6e72d363aa93ab6ecfc86eeeeb5ed28",
         "type": "github"
       },
       "original": {
         "owner": "ghostty-org",
+        "ref": "v1.3.1",
         "repo": "ghostty",
         "type": "github"
       }
@@ -1665,6 +1647,7 @@
       }
     },
     "systems_3": {
+      "flake": false,
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1865,7 +1848,7 @@
     },
     "yazi": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1891,21 +1874,18 @@
           "ghostty",
           "flake-compat"
         ],
-        "flake-utils": [
-          "ghostty",
-          "flake-utils"
-        ],
         "nixpkgs": [
           "ghostty",
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1763295135,
-        "narHash": "sha256-sGv/NHCmEnJivguGwB5w8LRmVqr1P72OjS+NzcJsssE=",
+        "lastModified": 1773145353,
+        "narHash": "sha256-dE8zx8WA54TRmFFQBvA48x/sXGDTP7YaDmY6nNKMAYw=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "64f8b42cfc615b2cf99144adf2b7728c7847c72a",
+        "rev": "8666155d83bf792956a7c40915508e6d4b2b8716",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,9 @@
     };
 
     # Desktop tools
-    ghostty.url = "github:ghostty-org/ghostty";
+    # Pinned to stable release tag — tracking `main` ships dev builds
+    # which have segfaulted in real use (2026-06-05 SIGSEGV killed all surfaces).
+    ghostty.url = "github:ghostty-org/ghostty?ref=v1.3.1";
     yazi = {
       url = "github:sxyazi/yazi";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/desktop/home/hyprland/appearance.nix
+++ b/modules/desktop/home/hyprland/appearance.nix
@@ -27,7 +27,6 @@ in
           enabled = false;
           range = 30;
           render_power = 3;
-          ignore_window = true;
           color = "rgba(00000045)";
         };
 

--- a/modules/desktop/home/hyprland/layout.nix
+++ b/modules/desktop/home/hyprland/layout.nix
@@ -16,7 +16,6 @@ in
       };
 
       dwindle = mkDefault {
-        pseudotile = true;
         preserve_split = true;
         force_split = 2;
       };

--- a/modules/desktop/nixos.nix
+++ b/modules/desktop/nixos.nix
@@ -95,10 +95,16 @@ in
     # sufficient — pam_systemd gives XDG_SESSION_CLASS env var highest precedence.
     # Without this, the session registers as Class=greeter on seat0, causing polkit's
     # allow_active=yes policy to deny access — breaking pcscd, YubiKey PIV, and power management.
+    # uwsm 0.26.4 (nixpkgs 26.11) gained a readability check in
+    # `check_path()`. Resolving the bare name "Hyprland" lands on
+    # `/run/wrappers/bin/Hyprland` (setuid wrapper, mode 4750), which
+    # has no read bit, so env-preloader fails before Hyprland starts.
+    # Pass the unwrapped binary path; this drops CAP_SYS_NICE but
+    # keeps the compositor launchable.
     services.greetd = {
       enable = mkDefault true;
       settings.default_session = {
-        command = mkDefault "env XDG_SESSION_CLASS=user uwsm start -F Hyprland";
+        command = mkDefault "env XDG_SESSION_CLASS=user uwsm start -F ${config.programs.hyprland.package}/bin/Hyprland";
         user = cfg.user;
       };
     };

--- a/modules/shared/password-managers.nix
+++ b/modules/shared/password-managers.nix
@@ -48,7 +48,10 @@ in
       description = "Bitwarden password manager install options.";
     };
 
-    "1password" = mkOption {
+    # Identifier-safe key (matches `bitwarden`); the display name stays
+    # "1Password". A `"1password"` key would force quoted-attribute syntax
+    # in every consumer config.
+    onepassword = mkOption {
       type = managerType "1Password" {
         cli = pkgs._1password-cli;
         cliText = "pkgs._1password-cli";
@@ -63,6 +66,6 @@ in
   config.home.packages =
     optional (terminalEnabled && pm.bitwarden.cli.enable) pm.bitwarden.cli.package
     ++ optional (desktopEnabled && pm.bitwarden.desktop.enable) pm.bitwarden.desktop.package
-    ++ optional (terminalEnabled && pm."1password".cli.enable) pm."1password".cli.package
-    ++ optional (desktopEnabled && pm."1password".desktop.enable) pm."1password".desktop.package;
+    ++ optional (terminalEnabled && pm.onepassword.cli.enable) pm.onepassword.cli.package
+    ++ optional (desktopEnabled && pm.onepassword.desktop.enable) pm.onepassword.desktop.package;
 }

--- a/modules/shared/password-managers.nix
+++ b/modules/shared/password-managers.nix
@@ -1,0 +1,68 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  pm = config.keystone.passwordManagers;
+  terminalEnabled = config.keystone.terminal.enable or false;
+  desktopEnabled = config.keystone.desktop.enable or false;
+
+  managerType =
+    name: defaults:
+    types.submodule {
+      options = {
+        cli = {
+          enable = mkEnableOption "${name} CLI";
+          package = mkOption {
+            type = types.package;
+            default = defaults.cli;
+            defaultText = literalExpression defaults.cliText;
+            description = "Package providing the ${name} CLI.";
+          };
+        };
+        desktop = {
+          enable = mkEnableOption "${name} desktop application";
+          package = mkOption {
+            type = types.package;
+            default = defaults.desktop;
+            defaultText = literalExpression defaults.desktopText;
+            description = "Package providing the ${name} desktop application.";
+          };
+        };
+      };
+    };
+in
+{
+  options.keystone.passwordManagers = {
+    bitwarden = mkOption {
+      type = managerType "Bitwarden" {
+        cli = pkgs.bitwarden-cli;
+        cliText = "pkgs.bitwarden-cli";
+        desktop = pkgs.bitwarden-desktop;
+        desktopText = "pkgs.bitwarden-desktop";
+      };
+      default = { };
+      description = "Bitwarden password manager install options.";
+    };
+
+    "1password" = mkOption {
+      type = managerType "1Password" {
+        cli = pkgs._1password-cli;
+        cliText = "pkgs._1password-cli";
+        desktop = pkgs._1password-gui;
+        desktopText = "pkgs._1password-gui";
+      };
+      default = { };
+      description = "1Password manager install options.";
+    };
+  };
+
+  config.home.packages =
+    optional (terminalEnabled && pm.bitwarden.cli.enable) pm.bitwarden.cli.package
+    ++ optional (desktopEnabled && pm.bitwarden.desktop.enable) pm.bitwarden.desktop.package
+    ++ optional (terminalEnabled && pm."1password".cli.enable) pm."1password".cli.package
+    ++ optional (desktopEnabled && pm."1password".desktop.enable) pm."1password".desktop.package;
+}

--- a/modules/terminal/default.nix
+++ b/modules/terminal/default.nix
@@ -48,6 +48,7 @@ in
     ../shared/experimental.nix
     ../shared/repos.nix
     ../shared/update.nix
+    ../shared/password-managers.nix
     ./shell.nix
     ./zide.nix
     ./editor.nix


### PR DESCRIPTION
## What

Ports the still-relevant commits off the unmerged `milestone/M9-V1-KS-OS-FDE-deployment` branch into `main`, so they land on the v1 stable line (`release/1.0` is cut from `main`). The M9 branch was a milestone working branch that diverged from main (5 ahead / 5 behind) and never had a PR; rather than make it the release base, its valuable changes are brought in through review.

## Changes

- **fix(desktop): pass unwrapped Hyprland path to uwsm** — uwsm 0.26.4's `R_OK` check breaks on the NixOS setuid wrapper (`/run/wrappers/bin/Hyprland`, mode 4750); pass the nix-store path so the compositor launches.
- **fix(desktop): drop removed Hyprland config options** — `decoration.shadow.ignore_window` and `dwindle.pseudotile` were removed upstream and surface as on-screen Error Overlays. Mirrors the v2 fix.
- **feat(modules): add `keystone.passwordManagers`** — declarative bitwarden/1password install routed by `keystone.terminal.enable` (CLI) / `keystone.desktop.enable` (GUI); replaces ad-hoc `home.packages` in consumer configs.
- **chore(deps): pin ghostty to stable `v1.3.1` tag** — tracking ghostty `main` ships dev builds; a 1.3.0-dev SIGSEGV on 2026-06-05 took down all surfaces. Only the ghostty input is relocked (other inputs left to the normal flake-bump cadence).
- **docs(milestone): add OS FDE deployment demo plan** — relocated from the M9 branch's stale `M1-V1-KS-OS-FDE-deployment/` path into the consolidated `docs/milestones/M9-v1-stabilization/demo.md`.

Skipped wholesale-porting the M9 branch's week-old 240-line `flake.lock` bump — it's stale and conflicts with the open flake-bump PR #588. Only the ghostty pin is carried, relocked fresh.

## Verification

- `keystone.passwordManagers` module evaluated in isolation: enabling bitwarden CLI + 1password desktop resolves `home.packages` to `[ bitwarden-cli, 1password ]`.
- `nix flake check --no-build` module checks (`nixosModules`, `homeModules`) pass. The `os-evaluation`/`agent-evaluation` IFD checks fail only on garbage-collected store paths locally — reproduces identically on clean `main`, so it's environmental; CI validates on a fresh store.

Part of #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)