### PR TITLE
feat(ks): track stable channel via release branch, retire version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,13 @@ jobs:
       - prepare
       - validate
     if: needs.prepare.outputs.publish_iso == 'true' && needs.validate.outputs.iso_built == 'true'
+    # Serialize all publishers across release lines: every `release/*` push
+    # mutates the single shared `latest-iso` tag/release, so concurrent runs
+    # (e.g. release/1.0 and release/2.0) must not race. Keyed by a constant,
+    # independent of the workflow-level per-ref concurrency group.
+    concurrency:
+      group: publish-latest-iso
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - name: Download starter ISO artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Release version without the v prefix, for example 0.9.0"
-        required: true
-        type: string
   push:
     branches:
       - main
@@ -17,7 +11,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: release-${{ github.event_name }}-${{ inputs.version || github.ref_name }}
+  group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -25,80 +19,41 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       force_iso_build: ${{ steps.prepare.outputs.force_iso_build }}
-      publish_release: ${{ steps.prepare.outputs.publish_release }}
-      version: ${{ steps.prepare.outputs.version }}
-      release_branch: ${{ steps.prepare.outputs.release_branch }}
-      release_target: ${{ steps.prepare.outputs.release_target }}
+      publish_iso: ${{ steps.prepare.outputs.publish_iso }}
       iso_artifact_name: ${{ steps.prepare.outputs.iso_artifact_name }}
       iso_file_name: ${{ steps.prepare.outputs.iso_file_name }}
-    env:
-      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Validate release request
+      - name: Resolve release inputs
         id: prepare
         run: |
           set -euo pipefail
 
-          git fetch --prune origin --tags
-
+          # Distribution is branch-based: consumers track a `release/<M>.<m>`
+          # branch (stable) or `main` (unstable) and `ks update` follows the
+          # branch head. There is no version tag to cut — releasing a fix is
+          # just landing it on the release branch.
+          #
+          # Always build the starter ISO so main and every release line are
+          # validated against the installer. Only `release/*` pushes publish
+          # the rolling installer ISO; `main` is validation-only.
           force_iso_build=true
-          publish_release=false
-          version=""
-          release_branch=""
-          release_target="$GITHUB_SHA"
+          publish_iso=false
           iso_artifact_name="starter-installer-iso"
           iso_file_name="keystone-starter-installer-${GITHUB_REF_NAME//\//-}-${GITHUB_SHA::12}.iso"
 
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            version="${{ inputs.version }}"
-
-            if [[ "${GITHUB_REF_NAME}" != "${DEFAULT_BRANCH}" ]]; then
-              echo "The Release workflow must run from the default branch ${DEFAULT_BRANCH}"
-              exit 1
-            fi
-
-            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "Release version must match MAJOR.MINOR.PATCH"
-              exit 1
-            fi
-
-            if git rev-parse "v$version" >/dev/null 2>&1; then
-              echo "Tag v$version already exists"
-              exit 1
-            fi
-
-            publish_release=true
-            release_branch="release/${version%.*}"
-            iso_file_name="keystone-starter-installer-v${version}.iso"
-
-            # TODO: Re-enable automatic release branch creation before publishing stable releases.
-            # if git ls-remote --exit-code --heads origin "$release_branch" >/dev/null 2>&1; then
-            #   echo "Using existing release branch $release_branch for this release series"
-            # else
-            #   echo "Creating release branch $release_branch from origin/$DEFAULT_BRANCH"
-            #   git push origin "HEAD:refs/heads/$release_branch"
-            # fi
-            #
-            # TODO: Once release branch creation is active again, publish from "$release_branch"
-            # instead of the dispatch SHA so future hotfixes stabilize on that branch.
-          else
-            if [[ "${GITHUB_REF_NAME}" != "${DEFAULT_BRANCH}" && "${GITHUB_REF_NAME}" != release/* ]]; then
-              echo "Automatic release validation only runs on ${DEFAULT_BRANCH} or release/* branches"
-              exit 1
-            fi
+          if [[ "${GITHUB_REF_NAME}" == release/* ]]; then
+            publish_iso=true
+            iso_file_name="keystone-starter-installer-${GITHUB_REF_NAME//\//-}.iso"
           fi
 
           {
             echo "force_iso_build=$force_iso_build"
-            echo "publish_release=$publish_release"
-            echo "version=$version"
-            echo "release_branch=$release_branch"
-            echo "release_target=$release_target"
+            echo "publish_iso=$publish_iso"
             echo "iso_artifact_name=$iso_artifact_name"
             echo "iso_file_name=$iso_file_name"
           } >> "$GITHUB_OUTPUT"
@@ -108,7 +63,7 @@ jobs:
     uses: ./.github/workflows/validate.yml
     with:
       force_iso_build: ${{ needs.prepare.outputs.force_iso_build == 'true' }}
-      upload_iso_artifact: ${{ needs.prepare.outputs.publish_release == 'true' }}
+      upload_iso_artifact: ${{ needs.prepare.outputs.publish_iso == 'true' }}
       iso_artifact_name: ${{ needs.prepare.outputs.iso_artifact_name }}
       iso_file_name: ${{ needs.prepare.outputs.iso_file_name }}
       cache_branch_name: ${{ github.ref_name }}
@@ -125,12 +80,12 @@ jobs:
       save_nix_cache: true
     secrets: inherit
 
-  publish:
+  publish-iso:
     needs:
       - prepare
       - validate
       - warm-cache
-    if: needs.prepare.outputs.publish_release == 'true' && needs.validate.outputs.iso_built == 'true'
+    if: needs.prepare.outputs.publish_iso == 'true' && needs.validate.outputs.iso_built == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Download starter ISO artifact
@@ -156,17 +111,23 @@ jobs:
 
           echo "iso_path=$iso_path" >> "$GITHUB_OUTPUT"
 
-      - name: Create GitHub release
+      - name: Publish rolling starter ISO
         env:
           GH_TOKEN: ${{ github.token }}
           ISO_PATH: ${{ steps.iso.outputs.iso_path }}
-          RELEASE_TARGET: ${{ needs.prepare.outputs.release_target }}
-          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           set -euo pipefail
 
-          gh release create "v$VERSION" \
-            --generate-notes \
-            --title "Keystone v$VERSION" \
-            --target "$RELEASE_TARGET" \
+          # Rolling release: the `latest-iso` tag always points at the tip of
+          # the newest stabilized release line and carries that line's starter
+          # installer. This is artifact hosting for the bootstrap installer
+          # only — `ks update` never reads it. Consumers track the
+          # `release/<M>.<m>` branch directly. Recreate (not just upload) so
+          # the tag and release target advance to this commit.
+          gh release delete latest-iso --yes --cleanup-tag || true
+          gh release create latest-iso \
+            --prerelease \
+            --title "Keystone starter ISO (rolling)" \
+            --notes "Rolling starter installer ISO built from \`${GITHUB_REF_NAME}\` at \`${GITHUB_SHA::12}\`. Tracks the newest stabilized release line. \`ks update\` follows the release branch directly and does not consume this release." \
+            --target "$GITHUB_SHA" \
             "$ISO_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,10 +81,12 @@ jobs:
     secrets: inherit
 
   publish-iso:
+    # Intentionally does NOT depend on warm-cache: publishing the installer
+    # artifact needs the validated ISO, not a populated binary cache. Gating
+    # on warm-cache would let a flaky cache push block the rolling ISO.
     needs:
       - prepare
       - validate
-      - warm-cache
     if: needs.prepare.outputs.publish_iso == 'true' && needs.validate.outputs.iso_built == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/docs/milestones/M9-v1-stabilization/README.md
+++ b/docs/milestones/M9-v1-stabilization/README.md
@@ -53,6 +53,6 @@ checklist and verification matrix.
 
 ## Related docs
 
-- [`docs/releasing.md`](../../releasing.md) — branch model, tags, release workflow
+- [`docs/releasing.md`](../../releasing.md) — branch model, update channels, release workflow
 - [`docs/experimental.md`](../../experimental.md) — `keystone.experimental` gate
 - [`docs/specs/`](../../specs/) — requirement specs

--- a/docs/milestones/M9-v1-stabilization/internal-faq.md
+++ b/docs/milestones/M9-v1-stabilization/internal-faq.md
@@ -19,9 +19,12 @@ desktop, server, declarative project config, `ks` CLI, `pz` CLI.
 Set `keystone.experimental = true;` on the host. See
 [`docs/experimental.md`](../../experimental.md) for the gate semantics.
 
-## What's the release tag scheme?
+## How is v1 released?
 
-`vX.Y.Z` git tags. v1 stabilization branch is `release/1.0`. See
+Distribution is branch-based, like nixpkgs — no version tags. The v1 stable
+line is the `release/1.0` branch; the `stable` update channel tracks the
+highest `release/<M>.<m>` branch head, and `ks update` follows it. Fixes land
+on `main` and backport onto `release/1.0` by PR. See
 [`docs/releasing.md`](../../releasing.md) for the full workflow.
 
 ## What's deferred to v1.1?

--- a/docs/milestones/M9-v1-stabilization/press-release.md
+++ b/docs/milestones/M9-v1-stabilization/press-release.md
@@ -15,7 +15,7 @@ flake. Stable surface covers OS, terminal, desktop, server services, and the
 
 ## Body
 
-_Draft the customer-facing narrative here before the v1.0.0 tag is cut._
+_Draft the customer-facing narrative here before the `release/1.0` line is cut._
 
 ## Quote — operator
 
@@ -27,6 +27,6 @@ _Draft the customer-facing narrative here before the v1.0.0 tag is cut._
 
 ## Availability
 
-- Release tag: `v1.0.0`
+- Stable line: the `release/1.0` branch (no version tag — distribution is branch-based)
 - Branch model: see [`docs/releasing.md`](../../releasing.md)
-- Update channel: `stable` (default on every host)
+- Update channel: `stable` (default on every host) tracks the highest `release/<M>.<m>` line

--- a/docs/releases/AGENTS.md
+++ b/docs/releases/AGENTS.md
@@ -1,8 +1,19 @@
 # Release Context for Keystone
 
-## Versioning
+## Distribution model
 
-Keystone uses semantic versioning. The ROADMAP.md originally used `v0.0.x` for feature milestones, but this is incorrect — patch versions are for bug/security fixes only.
+Keystone distributes by **branch**, like nixpkgs — not by version tag.
+Consumers track `main` (unstable channel) or a `release/<M>.<m>` line (stable
+channel), and `ks update` follows the branch head. There is no `vX.Y.Z` tag to
+cut; shipping a fix means landing it on the line. The historical `v0.x` /
+`v1.0.0-rc.*` tags below remain as inert history and are not read by the update
+path. See [`docs/releasing.md`](../releasing.md) for the full model. The
+release-line *numbering* (`release/1.0`, `release/2.0`) still follows the semver
+intent described next.
+
+## Versioning (release-line numbering)
+
+The ROADMAP.md originally used `v0.0.x` for feature milestones, but this is incorrect — patch-level changes are for bug/security fixes only.
 
 **Correct mapping of ROADMAP milestones to semver:**
 
@@ -22,13 +33,12 @@ Keystone uses semantic versioning. The ROADMAP.md originally used `v0.0.x` for f
 
 ## Conventions
 
-- Release artifacts stored in `docs/releases/[version]/` — see `docs/releases/0.1.0/` for the established pattern
+- Historical release artifacts stored in `docs/releases/[version]/` — see `docs/releases/0.1.0/` for the established pattern
 - `CHANGELOG.md` at repo root follows Keep a Changelog format
-- Tags use `v` prefix: `v0.1.0`, `v0.2.0`, etc.
-- Pre-1.0 releases are alpha channel
+- The stable line is the `release/<M>.<m>` branch (currently `release/1.0`); the starter installer ISO is published as a rolling `latest-iso` GitHub release on each `release/*` push
 - v1 ship criteria live at [`docs/milestones/M9-v1-stabilization/`](../milestones/M9-v1-stabilization/)
 
 ## Last Updated
 
-- Date: 2026-06-06
-- From conversation about: v1 docs cleanup — `releases/` folded into `docs/releases/`
+- Date: 2026-06-13
+- From conversation about: switch distribution from version tags to branch tracking (nixpkgs model)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,58 +1,81 @@
 # Keystone releasing
 
-Keystone uses `main` as the unstable integration branch. Every merge to `main`
-is eligible for the next release train, but `main` is not the branch that
-publishes stable releases.
+Keystone distributes the way nixpkgs does: consumers track a **branch**, and
+`ks update` follows that branch's head. There is no version tag to cut —
+shipping a fix is just landing it on the right branch.
+
+- `main` is the unstable integration branch. The `unstable` channel tracks it.
+- `release/X.Y` branches are the stabilized release lines. The `stable` channel
+  tracks the highest one.
 
 ## Branch model
 
 - `main` is unstable and always open for ongoing development.
-- `release/X.Y` branches are the stabilization branches for the `X.Y` release line.
-- `hotfix/X.Y.Z` branches are optional and only used for urgent post-release fixes.
+- `release/X.Y` is the stabilization branch for the `X.Y` release line. Fixes
+  land on `main` first and are backported onto the line by pull request
+  (cherry-pick), exactly like a nixpkgs `release-*` branch.
+- Patch-level releases are commits *on* `release/X.Y`, not separate branches or
+  tags — the line advances, consumers relock, done.
 
 ## Release cadence
 
-1. A human starts the GitHub Actions `Release` workflow from `main`.
-2. The workflow takes `X.Y.Z` as the release input and derives `release/X.Y`.
-3. If `release/X.Y` does not exist, the workflow creates it from `main`.
-4. If `release/X.Y` already exists, the workflow reuses it as the stabilization branch for the next patch in that series.
-5. The workflow builds, tests, tags `vX.Y.Z`, and publishes a GitHub Release with generated notes from the `release/X.Y` branch head.
-6. Any stabilization fixes to `release/X.Y` happen through pull requests with human approval.
-7. Merge the finalized `release/X.Y` branch back into `main` after the series is stabilized.
+1. A human creates `release/X.Y` from `main` once the line is ready to
+   stabilize (`git push origin main:refs/heads/release/X.Y`, or via the GitHub
+   UI). The `release/*` ruleset is PR-only after creation, so this first push
+   is the one operator-owned step.
+2. Stabilization fixes land on `main`, then backport to `release/X.Y` through
+   pull requests with human approval.
+3. Each push to `release/X.Y` runs the `Release` workflow: it builds and
+   validates the tree and republishes the rolling starter ISO (see
+   [Publishing model](#publishing-model)).
+4. There is nothing to "tag" or "cut". A consumer on the `stable` channel picks
+   up the line's new head on its next `ks update --lock`.
 
 ## Versioning
 
-- Stable project releases are identified by git tags in the form `vX.Y.Z`.
-- The git tag is the canonical release version for Keystone.
-- `main` does not carry a stable version number. It represents the next unstable state after the latest tag.
-- Package-local versions may remain package-specific, but they do not define the Keystone release line.
+- The release line is identified by its branch name, `release/X.Y`. That branch
+  head is the canonical stable state for the line.
+- `main` represents the unstable state; the `unstable` channel exposes it as
+  `main@<short-sha>`, and `stable` exposes the line head as
+  `release/X.Y@<short-sha>`.
+- Historical `v0.x` / `v1.0.0-rc.*` tags remain in the repo as inert history.
+  Nothing in the update path reads them anymore.
+- Package-local versions may remain package-specific, but they do not define
+  the Keystone release line.
 
 ## Release notes
 
-- GitHub Releases are the canonical generated release notes for each stable release.
-- GitHub generates release notes from merged pull requests and labels using `.github/release.yml`.
-- `CHANGELOG.md` remains available as the curated historical summary for the repository.
+- The merged pull requests on a `release/X.Y` line are the change record for
+  that line; GitHub's branch compare view (`main...release/X.Y`, or between two
+  line heads) shows exactly what a relock will pick up.
+- `CHANGELOG.md` remains available as the curated historical summary.
 
 ## Publishing model
 
-- Keystone releases publish to GitHub Releases.
-- Keystone does not currently publish release binaries or packages from this workflow.
-- Consumers primarily consume Keystone through the git repository and flake input.
+- Consumers consume Keystone through the git repository and flake input — they
+  pin `keystone.url = "github:ncrmro/keystone/release/X.Y"` (stable) or
+  `.../keystone` i.e. `main` (unstable), and relocking follows the branch head.
+- The **starter installer ISO** is the one build artifact published to GitHub.
+  Each push to a `release/*` branch republishes a single rolling release tagged
+  `latest-iso`, pointing at the newest stabilized line. This is bootstrap
+  artifact hosting only — `ks update` never reads it.
+- `main` pushes are validation-only; they build the ISO to keep the installer
+  green but do not publish it.
 
 ## Update channels
 
 Hosts running the Walker update menu (`ks menu update`, wired up via
-`modules/desktop/home/services.nix`) track one of two sources. Selection is
+`modules/desktop/home/services.nix`) track one of two branches. Selection is
 declarative, through the `keystone.update.channel` option:
 
-- `stable` (default) — the Walker menu reads `/releases/latest` and only
-  treats strict `v<major>.<minor>.<patch>` tags as release-tag matches.
-  If the repository has no matching tagged release, `/releases/latest`
-  returns 404 and the menu renders `Keystone OS unavailable`.
-- `unstable` — the menu reads `GET /repos/OWNER/REPO/branches/main` —
-  this tracks the tip commit, not a tagged release. The displayed
-  `latest` row renders as `main@<short-sha>` and always reflects the
-  current head of `main`.
+- `stable` (default) — the menu resolves the highest `release/<major>.<minor>`
+  branch via the GitHub branches API and reads its tip commit. The `latest` row
+  renders as `release/X.Y@<short-sha>`. If no `release/*` branch is published
+  yet, the menu renders `Keystone OS unavailable`.
+- `unstable` — the menu reads `GET /repos/OWNER/REPO/branches/main` and tracks
+  the tip commit of `main`. The `latest` row renders as `main@<short-sha>`.
+
+Both channels track a moving branch head; neither reads release tags.
 
 To change a host's channel:
 
@@ -65,7 +88,7 @@ Then run `ks update --dev` (deploy the current checkout) to pick up the
 new value. The channel is embedded into the `ks-update.service` unit
 environment and the shell's `home.sessionVariables` at activation time,
 so interactive `ks menu update status` and background Walker dispatches
-agree on which source the host polls.
+agree on which branch the host polls.
 
 The stable channel remains the default and requires no per-host declaration.
 
@@ -104,7 +127,7 @@ module-level declarations always win.
 
 ## Branch protection
 
-Keystone now uses GitHub repository rulesets for branch protection.
+Keystone uses GitHub repository rulesets for branch protection.
 
 Configured `main` rules:
 
@@ -126,16 +149,21 @@ Configured `release/X.Y` rules:
 Notes:
 
 - The release rules are implemented as a wildcard GitHub ruleset targeting `refs/heads/release/*`.
-- No bypass actors are configured for the `release/*` ruleset, so direct updates to existing release branches are blocked for every actor.
-- The `Release` workflow is a human-owned `workflow_dispatch` action from `main`. It is the only supported path for creating new `release/*` branches.
-- GitHub repository rulesets on this repo cannot currently express "GitHub Actions may create `release/*`, but no other actor may do so." Keystone therefore treats branch creation as an operator policy enforced by process, and the ruleset enforces PR-only updates after the branch exists.
-- Agents may propose changes to `release/*` through pull requests, but they must not create release branches directly and they must not merge stabilization changes without human approval.
+- No bypass actors are configured for the `release/*` ruleset, so direct updates to existing release branches are blocked for every actor — stabilization lands by PR only.
+- Creating a new `release/X.Y` branch is a human-owned operator step (the
+  ruleset enforces PR-only updates *after* the branch exists, but cannot
+  express "only Actions may create the branch"). Agents may propose changes to
+  `release/*` through pull requests, but must not create release branches
+  directly and must not merge stabilization changes without human approval.
 - If Keystone starts using `hotfix/*` branches, add a matching GitHub ruleset for that namespace.
 
 ## Operating notes
 
-- Only run the `Release` workflow from `main`.
-- The workflow rejects duplicate tags.
-- The workflow derives `release/X.Y` from the supplied `X.Y.Z`.
-- If a release series already exists, the workflow releases from the current `release/X.Y` branch head rather than from `main`.
-- If a release needs an urgent patch after publication, branch `hotfix/X.Y.Z` from the released tag, land the fix there, rerun the release process for the next patch version, and merge the result back into `main`.
+- The `Release` workflow runs automatically on every push to `main` and
+  `release/*`. It validates the tree and, for `release/*`, republishes the
+  rolling `latest-iso` starter image. There is no manual dispatch and no
+  version input.
+- To open a new stable line, create `release/X.Y` from `main` (operator step),
+  then land fixes via backport PRs.
+- An urgent post-release fix is just another backport PR onto the existing
+  `release/X.Y` line; the line head advances and consumers relock.

--- a/packages/ks/src/cmd/update_menu.rs
+++ b/packages/ks/src/cmd/update_menu.rs
@@ -539,7 +539,9 @@ async fn highest_release_branch() -> Result<String> {
         .filter_map(|b| b.get("name").and_then(|v| v.as_str()).map(str::to_string))
         .collect();
     pick_highest_release_branch(&names).ok_or_else(|| {
-        anyhow!("no release/<major>.<minor> branch is published yet — the stable line is unavailable")
+        anyhow!(
+            "no release/<major>.<minor> branch is published yet — the stable line is unavailable"
+        )
     })
 }
 
@@ -1058,8 +1060,7 @@ fn render_entries_json(state: &MenuState) -> Result<String> {
                 // (`main`, `release/1.0`) and channel. `latest_tag` carries
                 // the branch label for both channels; naming the channel
                 // keeps a flipped host visibly distinct from the stable line.
-                let subtext =
-                    format!("Latest commit on {} ({} channel)", s.latest_tag, s.channel);
+                let subtext = format!("Latest commit on {} ({} channel)", s.latest_tag, s.channel);
                 entries.push(serde_json::json!({
                     "Text": format!("Latest: {}", s.latest_tag),
                     "Subtext": subtext,
@@ -1869,8 +1870,9 @@ mod tests {
         assert!(rendered.contains("Ref: release/1.0"));
         assert!(rendered.contains("Published: 2026-04-01T10:00:00Z"));
         assert!(rendered.contains("add Walker update menu"));
-        assert!(rendered
-            .contains("https://github.com/ncrmro/keystone/commit/bbbbbbbbccccccccddddddddeeeeeeeeffffffff"));
+        assert!(rendered.contains(
+            "https://github.com/ncrmro/keystone/commit/bbbbbbbbccccccccddddddddeeeeeeeeffffffff"
+        ));
     }
 
     #[test]

--- a/packages/ks/src/cmd/update_menu.rs
+++ b/packages/ks/src/cmd/update_menu.rs
@@ -509,12 +509,17 @@ fn pick_highest_release_branch(names: &[String]) -> Option<String> {
         .map(|(name, _)| name)
 }
 
-/// Resolve the highest `release/<M>.<m>` branch by listing the repo's
-/// branches. `per_page=100` is well above the handful of release lines
-/// Keystone will ever carry concurrently, so a single page suffices.
+/// Resolve the highest `release/<M>.<m>` branch.
+///
+/// Uses `GET /git/matching-refs/heads/release/`, which returns *only* refs
+/// under `refs/heads/release/` — so unrelated branches can never crowd a
+/// release line off a paginated `/branches` listing, and there is nothing to
+/// paginate (Keystone carries a handful of release lines at most). Returns an
+/// empty array (not 404) when no release branch exists, which maps to the
+/// fail-closed "stable line unavailable" error.
 async fn highest_release_branch() -> Result<String> {
     let url = format!(
-        "https://api.github.com/repos/{}/{}/branches?per_page=100",
+        "https://api.github.com/repos/{}/{}/git/matching-refs/heads/release/",
         RELEASE_OWNER, RELEASE_REPO
     );
     let mut req = github_client()?
@@ -534,9 +539,14 @@ async fn highest_release_branch() -> Result<String> {
         .context("GitHub response was not valid JSON")?;
     let names: Vec<String> = json
         .as_array()
-        .ok_or_else(|| anyhow!("GitHub branches response was not an array"))?
+        .ok_or_else(|| anyhow!("GitHub matching-refs response was not an array"))?
         .iter()
-        .filter_map(|b| b.get("name").and_then(|v| v.as_str()).map(str::to_string))
+        .filter_map(|r| {
+            r.get("ref")
+                .and_then(|v| v.as_str())
+                .and_then(|r| r.strip_prefix("refs/heads/"))
+                .map(str::to_string)
+        })
         .collect();
     pick_highest_release_branch(&names).ok_or_else(|| {
         anyhow!(
@@ -556,6 +566,10 @@ async fn highest_release_branch() -> Result<String> {
 ///                 "commit": { "committer": {"date": "..."},
 ///                             "message": "..." } } }
 async fn fetch_branch_tip(branch: &str) -> Result<ReleaseInfo> {
+    // The branch name is interpolated with its literal `/` (e.g.
+    // `release/1.0`). GitHub's `/branches/{branch}` endpoint matches the
+    // slashed remainder of the path greedily, so a slashed name resolves
+    // unencoded — percent-encoding the slash as `%2F` would instead 404.
     let url = format!(
         "https://api.github.com/repos/{}/{}/branches/{}",
         RELEASE_OWNER, RELEASE_REPO, branch

--- a/packages/ks/src/cmd/update_menu.rs
+++ b/packages/ks/src/cmd/update_menu.rs
@@ -48,10 +48,13 @@ pub(crate) const RELEASE_REPO: &str = "keystone";
 /// (`cmd::update`) can resolve the same target the menu surfaces.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Channel {
-    /// `/releases/latest` — latest tagged release `v<M>.<m>.<p>`.
+    /// Tip of the highest `release/<M>.<m>` branch — the stabilized release
+    /// line. Like a nixpkgs release channel, this tracks a moving branch
+    /// head (fixes are backported onto the line) rather than a tagged
+    /// release.
     Stable,
-    /// `/repos/OWNER/REPO/branches/main` — HEAD of `main`, a moving commit
-    /// SHA rather than a tagged release.
+    /// `/repos/OWNER/REPO/branches/main` — HEAD of `main`, the moving
+    /// development source.
     Unstable,
 }
 
@@ -428,11 +431,10 @@ fn github_client() -> Result<reqwest::Client> {
 }
 
 /// Normalized release metadata consumed by `load_state`. Both channels
-/// produce this shape: stable from a `/releases/latest` body, unstable from
-/// a `/branches/main` body. Keeping the extraction pure (in
-/// `parse_stable_release` and `parse_unstable_branch`) means unit tests can
-/// exercise the full unstable path — which otherwise cannot be mocked
-/// without an HTTP dep.
+/// produce this shape from a `/branches/<branch>` body — stable from the
+/// highest `release/<M>.<m>` line, unstable from `main`. Keeping the
+/// extraction pure (in `parse_branch_release`) means unit tests can
+/// exercise the full path without an HTTP dep.
 ///
 /// Crate-visible so `cmd::update` can drive the same channel-aware target
 /// resolution the menu surfaces.
@@ -448,102 +450,71 @@ pub(crate) struct ReleaseInfo {
 
 /// Fetch the release metadata for the active channel.
 ///
-/// - Stable (`/releases/latest`) returns the latest tagged release. This
-///   endpoint returns 404 when the repo has no tagged releases, which we
-///   surface to the caller as an error so the menu renders
+/// Both channels track a moving branch tip, so they share one fetch path
+/// (`fetch_branch_tip`), which reads the commit SHA inline from
+/// `GET /repos/OWNER/REPO/branches/<branch>` — no separate ref-to-sha
+/// lookup.
+///
+/// - Stable resolves the highest `release/<M>.<m>` branch (the stabilized
+///   line) via `highest_release_branch`, then reads its tip. When no
+///   `release/*` branch is published yet, this errors so the menu renders
 ///   `Keystone OS unavailable`.
-/// - Unstable (`/repos/OWNER/REPO/branches/main`) returns the tip commit
-///   of `main` — a moving SHA, not a tagged release. The `latest_rev` is
-///   inline in the response so we never need a separate ref-to-sha lookup.
+/// - Unstable reads the tip of `main` — the moving development source.
 pub(crate) async fn fetch_latest_release(channel: Channel) -> Result<ReleaseInfo> {
     match channel {
         Channel::Stable => fetch_stable_latest_release().await,
-        Channel::Unstable => fetch_unstable_latest_release().await,
+        Channel::Unstable => fetch_branch_tip("main").await,
     }
 }
 
 async fn fetch_stable_latest_release() -> Result<ReleaseInfo> {
-    let url = format!(
-        "https://api.github.com/repos/{}/{}/releases/latest",
-        RELEASE_OWNER, RELEASE_REPO
-    );
-    let mut req = github_client()?
-        .get(&url)
-        .header("Accept", "application/vnd.github+json");
-    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-        if !token.is_empty() {
-            req = req.header("Authorization", format!("Bearer {token}"));
-        }
-    }
-    let response = req.send().await.context("GitHub request failed")?;
-    let json = response
-        .error_for_status()
-        .context("GitHub returned non-success status")?
-        .json::<Value>()
-        .await
-        .context("GitHub response was not valid JSON")?;
-    let tag = parse_stable_release(&json)?;
-    let rev = fetch_release_commit_rev(&tag.latest_tag).await?;
-    Ok(ReleaseInfo {
-        latest_rev: rev,
-        ..tag
-    })
+    let branch = highest_release_branch().await?;
+    fetch_branch_tip(&branch).await
 }
 
-/// Pure extraction: map a `/releases/latest` body into `ReleaseInfo`
-/// (without the commit rev, which requires a second API call).
-fn parse_stable_release(json: &Value) -> Result<ReleaseInfo> {
-    let latest_tag = json
-        .get("tag_name")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    if latest_tag.is_empty() {
-        anyhow::bail!("GitHub did not return a latest release tag for Keystone.");
-    }
-    let latest_name = json
-        .get("name")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .unwrap_or(&latest_tag)
-        .to_string();
-    let latest_url = json
-        .get("html_url")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let latest_published = json
-        .get("published_at")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let latest_body = json
-        .get("body")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .unwrap_or("No release notes available.")
-        .to_string();
-    Ok(ReleaseInfo {
-        latest_tag,
-        latest_name,
-        latest_url,
-        latest_published,
-        latest_body,
-        latest_rev: String::new(),
-    })
+/// Sortable `release/<major>.<minor>` line key. The release line is the
+/// branch granularity (`release/1.0`), so patch is not part of the key —
+/// patch-level releases are commits *on* the line, not separate branches.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+struct ReleaseLine {
+    major: u32,
+    minor: u32,
 }
 
-async fn fetch_unstable_latest_release() -> Result<ReleaseInfo> {
-    // `GET /repos/OWNER/REPO/branches/main` returns the tip commit of
-    // `main` inline — no separate ref-to-sha lookup needed. The response
-    // has the shape:
-    //   { "name": "main",
-    //     "commit": { "sha": "...",
-    //                 "html_url": "...",
-    //                 "commit": { "committer": {"date": "..."},
-    //                             "message": "..." } } }
+/// Parse a `release/<M>.<m>` branch name into a sortable line key. Anything
+/// not matching that exact shape (extra components, pre-release/build
+/// suffixes, non-numeric parts) yields `None` and is dropped at the call
+/// site so an unrelated branch can never masquerade as a release line.
+fn parse_release_branch(name: &str) -> Option<ReleaseLine> {
+    let rest = name.strip_prefix("release/")?;
+    if rest.contains('-') || rest.contains('+') {
+        return None;
+    }
+    let mut parts = rest.split('.');
+    let major: u32 = parts.next()?.parse().ok()?;
+    let minor: u32 = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(ReleaseLine { major, minor })
+}
+
+/// Pick the highest `release/<M>.<m>` branch from a list of branch names.
+/// Returns `None` when no name matches the release-line shape.
+fn pick_highest_release_branch(names: &[String]) -> Option<String> {
+    names
+        .iter()
+        .filter_map(|name| parse_release_branch(name).map(|line| (name.clone(), line)))
+        .max_by(|a, b| a.1.cmp(&b.1))
+        .map(|(name, _)| name)
+}
+
+/// Resolve the highest `release/<M>.<m>` branch by listing the repo's
+/// branches. `per_page=100` is well above the handful of release lines
+/// Keystone will ever carry concurrently, so a single page suffices.
+async fn highest_release_branch() -> Result<String> {
     let url = format!(
-        "https://api.github.com/repos/{}/{}/branches/main",
+        "https://api.github.com/repos/{}/{}/branches?per_page=100",
         RELEASE_OWNER, RELEASE_REPO
     );
     let mut req = github_client()?
@@ -561,13 +532,56 @@ async fn fetch_unstable_latest_release() -> Result<ReleaseInfo> {
         .json()
         .await
         .context("GitHub response was not valid JSON")?;
-    parse_unstable_branch(&json)
+    let names: Vec<String> = json
+        .as_array()
+        .ok_or_else(|| anyhow!("GitHub branches response was not an array"))?
+        .iter()
+        .filter_map(|b| b.get("name").and_then(|v| v.as_str()).map(str::to_string))
+        .collect();
+    pick_highest_release_branch(&names).ok_or_else(|| {
+        anyhow!("no release/<major>.<minor> branch is published yet — the stable line is unavailable")
+    })
 }
 
-/// Pure extraction: map a `/branches/main` body into `ReleaseInfo`. Errors
-/// only when the commit SHA is missing, since without it the menu cannot
-/// compare against the locked rev.
-fn parse_unstable_branch(json: &Value) -> Result<ReleaseInfo> {
+/// Read the tip commit of `branch` from
+/// `GET /repos/OWNER/REPO/branches/<branch>`. The response carries the
+/// commit SHA inline, so no separate ref-to-sha lookup is needed. Shared by
+/// both channels: stable passes the resolved `release/<M>.<m>` branch,
+/// unstable passes `main`. The response shape:
+///   { "name": "<branch>",
+///     "commit": { "sha": "...",
+///                 "html_url": "...",
+///                 "commit": { "committer": {"date": "..."},
+///                             "message": "..." } } }
+async fn fetch_branch_tip(branch: &str) -> Result<ReleaseInfo> {
+    let url = format!(
+        "https://api.github.com/repos/{}/{}/branches/{}",
+        RELEASE_OWNER, RELEASE_REPO, branch
+    );
+    let mut req = github_client()?
+        .get(&url)
+        .header("Accept", "application/vnd.github+json");
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+        if !token.is_empty() {
+            req = req.header("Authorization", format!("Bearer {token}"));
+        }
+    }
+    let response = req.send().await.context("GitHub request failed")?;
+    let json: Value = response
+        .error_for_status()
+        .context("GitHub returned non-success status")?
+        .json()
+        .await
+        .context("GitHub response was not valid JSON")?;
+    parse_branch_release(&json, branch)
+}
+
+/// Pure extraction: map a `/branches/<branch>` body into `ReleaseInfo`. The
+/// `latest_tag`/`latest_name` carry the branch label (`main`,
+/// `release/1.0`) and its short sha — branch tracking has no tag to name.
+/// Errors only when the commit SHA is missing, since without it the menu
+/// cannot compare against the locked rev.
+fn parse_branch_release(json: &Value, branch: &str) -> Result<ReleaseInfo> {
     let commit = json
         .get("commit")
         .ok_or_else(|| anyhow!("GitHub branch response missing 'commit' object"))?;
@@ -577,7 +591,7 @@ fn parse_unstable_branch(json: &Value) -> Result<ReleaseInfo> {
         .filter(|s| !s.is_empty())
         .ok_or_else(|| anyhow!("GitHub branch response missing 'commit.sha'"))?
         .to_string();
-    // `html_url` points at the commit on GitHub; fall back to the `main`
+    // `html_url` points at the commit on GitHub; fall back to the branch
     // tree view when the field is absent so the menu always has a link.
     let latest_url = commit
         .get("html_url")
@@ -586,8 +600,8 @@ fn parse_unstable_branch(json: &Value) -> Result<ReleaseInfo> {
         .map(|s| s.to_string())
         .unwrap_or_else(|| {
             format!(
-                "https://github.com/{}/{}/tree/main",
-                RELEASE_OWNER, RELEASE_REPO
+                "https://github.com/{}/{}/tree/{}",
+                RELEASE_OWNER, RELEASE_REPO, branch
             )
         });
     let inner = commit.get("commit");
@@ -617,8 +631,8 @@ fn parse_unstable_branch(json: &Value) -> Result<ReleaseInfo> {
         latest_body
     };
     Ok(ReleaseInfo {
-        latest_tag: "main".to_string(),
-        latest_name: format!("main@{}", short(&sha)),
+        latest_tag: branch.to_string(),
+        latest_name: format!("{branch}@{}", short(&sha)),
         latest_url,
         latest_published,
         latest_body,
@@ -626,71 +640,10 @@ fn parse_unstable_branch(json: &Value) -> Result<ReleaseInfo> {
     })
 }
 
-/// Resolve a tag to its commit sha by querying the GitHub refs API.
-/// Handles both annotated and lightweight tags.
-async fn fetch_release_commit_rev(tag: &str) -> Result<String> {
-    let url = format!(
-        "https://api.github.com/repos/{}/{}/git/ref/tags/{}",
-        RELEASE_OWNER, RELEASE_REPO, tag
-    );
-    let mut req = github_client()?
-        .get(&url)
-        .header("Accept", "application/vnd.github+json");
-    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-        if !token.is_empty() {
-            req = req.header("Authorization", format!("Bearer {token}"));
-        }
-    }
-    let response = req.send().await.context("GitHub ref request failed")?;
-    let ref_json: Value = response
-        .error_for_status()
-        .context("GitHub returned non-success for ref")?
-        .json()
-        .await
-        .context("GitHub ref response was not valid JSON")?;
-
-    let obj = ref_json
-        .get("object")
-        .ok_or_else(|| anyhow!("GitHub ref missing 'object'"))?;
-    let kind = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
-    let sha = obj
-        .get("sha")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| anyhow!("GitHub ref missing sha"))?;
-
-    if kind == "commit" {
-        return Ok(sha.to_string());
-    }
-
-    // Annotated tag — follow the tag object to its target commit.
-    let tag_url = format!(
-        "https://api.github.com/repos/{}/{}/git/tags/{}",
-        RELEASE_OWNER, RELEASE_REPO, sha
-    );
-    let mut tag_req = github_client()?
-        .get(&tag_url)
-        .header("Accept", "application/vnd.github+json");
-    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-        if !token.is_empty() {
-            tag_req = tag_req.header("Authorization", format!("Bearer {token}"));
-        }
-    }
-    let tag_json: Value = tag_req
-        .send()
-        .await
-        .context("GitHub tag request failed")?
-        .error_for_status()
-        .context("GitHub returned non-success for tag")?
-        .json()
-        .await
-        .context("GitHub tag response was not valid JSON")?;
-
-    tag_json
-        .get("object")
-        .and_then(|o| o.get("sha"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-        .ok_or_else(|| anyhow!("GitHub tag object missing commit sha"))
+/// Thin wrapper retained for the unstable channel's `main` tracking and the
+/// existing parse tests. Equivalent to `parse_branch_release(json, "main")`.
+fn parse_unstable_branch(json: &Value) -> Result<ReleaseInfo> {
+    parse_branch_release(json, "main")
 }
 
 // -----------------------------------------------------------------------------
@@ -999,7 +952,7 @@ fn render_preview_release_notes(state: &MenuState) -> String {
             };
             [
                 name,
-                format!("Tag: {}", s.latest_tag),
+                format!("Ref: {}", s.latest_tag),
                 published,
                 String::new(),
                 s.latest_body.clone(),
@@ -1026,7 +979,7 @@ fn render_preview_release_notes(state: &MenuState) -> String {
                 let url = e.latest_url.clone().unwrap_or_default();
                 return [
                     name,
-                    format!("Tag: {latest_tag}"),
+                    format!("Ref: {latest_tag}"),
                     published,
                     String::new(),
                     body,
@@ -1100,17 +1053,13 @@ fn render_entries_json(state: &MenuState) -> Result<String> {
                 "PreviewType": "command",
             })];
             if url_is_shell_safe(&s.latest_url) {
-                // Branch the subtext on channel so the Walker row matches
-                // what `latest_url` actually points to: the stable channel
-                // links to a tagged release page (release notes), while the
-                // unstable channel links to the tip commit on `main`
-                // (commit message). Naming the channel in both variants
-                // keeps a flipped host visibly distinct from the stable
-                // feed so it doesn't read like the release feed drifted.
-                let subtext = match s.channel.as_str() {
-                    "unstable" => "Latest commit on main (unstable channel)".to_string(),
-                    _ => format!("GitHub release notes and changelog ({} channel)", s.channel,),
-                };
+                // Both channels track a moving branch tip, so the row links
+                // to that tip commit and the subtext names the branch
+                // (`main`, `release/1.0`) and channel. `latest_tag` carries
+                // the branch label for both channels; naming the channel
+                // keeps a flipped host visibly distinct from the stable line.
+                let subtext =
+                    format!("Latest commit on {} ({} channel)", s.latest_tag, s.channel);
                 entries.push(serde_json::json!({
                     "Text": format!("Latest: {}", s.latest_tag),
                     "Subtext": subtext,
@@ -1395,6 +1344,10 @@ fn _keep(_: &PathBuf) {}
 mod tests {
     use super::*;
 
+    // Models a stable branch-tracking state: the consumer lock sits at an
+    // older commit on the `release/1.0` line, and the latest is that line's
+    // newer tip. `current_tag` is empty because a branch-tracking lock is
+    // pinned to a commit, not a tag.
     fn ok_fixture() -> OkState {
         OkState {
             ok: true,
@@ -1402,12 +1355,14 @@ mod tests {
             repo_root: "/etc/nixos-config".into(),
             input_name: "keystone".into(),
             current_rev: "aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee".into(),
-            current_tag: "v0.7.0".into(),
-            latest_tag: "v0.8.0".into(),
-            latest_name: "v0.8.0".into(),
-            latest_url: "https://github.com/ncrmro/keystone/releases/tag/v0.8.0".into(),
+            current_tag: String::new(),
+            latest_tag: "release/1.0".into(),
+            latest_name: "release/1.0@bbbbbbb".into(),
+            latest_url:
+                "https://github.com/ncrmro/keystone/commit/bbbbbbbbccccccccddddddddeeeeeeeeffffffff"
+                    .into(),
             latest_published: "2026-04-01T10:00:00Z".into(),
-            latest_body: "## Changes\n- Added Walker update menu".into(),
+            latest_body: "feat(menu): add Walker update menu".into(),
             latest_rev: "bbbbbbbbccccccccddddddddeeeeeeeeffffffff".into(),
             host_key: "mox".into(),
             status_kind: "behind".into(),
@@ -1456,6 +1411,115 @@ mod tests {
         assert_eq!(parse_release_tag(""), None);
         assert_eq!(parse_release_tag("v"), None);
         assert_eq!(parse_release_tag("vAbC.1.2"), None);
+    }
+
+    #[test]
+    fn parse_release_branch_accepts_release_lines() {
+        assert_eq!(
+            parse_release_branch("release/1.0"),
+            Some(ReleaseLine { major: 1, minor: 0 })
+        );
+        assert_eq!(
+            parse_release_branch("release/2.11"),
+            Some(ReleaseLine {
+                major: 2,
+                minor: 11
+            })
+        );
+        assert_eq!(
+            parse_release_branch("release/10.4"),
+            Some(ReleaseLine {
+                major: 10,
+                minor: 4
+            })
+        );
+    }
+
+    #[test]
+    fn parse_release_branch_rejects_non_release_lines() {
+        // Only `release/<M>.<m>` matches. Patch-level (`release/1.0.1`),
+        // suffixed, prefix-mismatched, or non-numeric names are dropped so
+        // an unrelated branch never masquerades as a release line.
+        assert_eq!(parse_release_branch("main"), None);
+        assert_eq!(parse_release_branch("release/1"), None);
+        assert_eq!(parse_release_branch("release/1.0.1"), None);
+        assert_eq!(parse_release_branch("release/1.0-rc.1"), None);
+        assert_eq!(parse_release_branch("release/1.x"), None);
+        assert_eq!(parse_release_branch("releases/1.0"), None);
+        assert_eq!(parse_release_branch("feat/release/1.0"), None);
+        assert_eq!(parse_release_branch(""), None);
+    }
+
+    #[test]
+    fn pick_highest_release_branch_orders_numerically() {
+        // String ordering would rank "release/1.9" above "release/1.10";
+        // the numeric key must not. Non-release branches are ignored.
+        let names: Vec<String> = [
+            "main",
+            "release/1.0",
+            "release/1.9",
+            "release/1.10",
+            "release/2.0",
+            "feat/x",
+            "dependabot/nix/foo",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(
+            pick_highest_release_branch(&names),
+            Some("release/2.0".to_string())
+        );
+    }
+
+    #[test]
+    fn pick_highest_release_branch_none_when_no_release_line() {
+        let names: Vec<String> = ["main", "feat/x", "dependabot/nix/foo"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(pick_highest_release_branch(&names), None);
+    }
+
+    #[test]
+    fn parse_branch_release_labels_release_branch() {
+        // The stable channel passes a `release/<M>.<m>` branch; the parsed
+        // info must carry that branch as the ref label and `<branch>@<sha>`
+        // as the display name.
+        let sha = "ccddeeff00112233445566778899aabbccddeeff";
+        let payload = serde_json::json!({
+            "name": "release/1.0",
+            "commit": {
+                "sha": sha,
+                "html_url": format!("https://github.com/ncrmro/keystone/commit/{sha}"),
+                "commit": {
+                    "committer": { "date": "2026-06-10T09:00:00Z" },
+                    "message": "fix(desktop): backported stabilization fix",
+                }
+            }
+        });
+        let info = parse_branch_release(&payload, "release/1.0").unwrap();
+        assert_eq!(info.latest_tag, "release/1.0");
+        assert_eq!(info.latest_name, format!("release/1.0@{}", &sha[..7]));
+        assert_eq!(info.latest_rev, sha);
+    }
+
+    #[test]
+    fn parse_branch_release_tree_url_fallback_uses_branch() {
+        // A missing `commit.html_url` must fall back to the *branch* tree
+        // view, not a hardcoded `main`, so the stable line links correctly.
+        let payload = serde_json::json!({
+            "name": "release/1.0",
+            "commit": {
+                "sha": "0000000000000000000000000000000000000003",
+                "commit": { "committer": { "date": "2026-06-10T09:00:00Z" }, "message": "x" }
+            }
+        });
+        let info = parse_branch_release(&payload, "release/1.0").unwrap();
+        assert_eq!(
+            info.latest_url,
+            "https://github.com/ncrmro/keystone/tree/release/1.0"
+        );
     }
 
     #[test]
@@ -1645,16 +1709,16 @@ mod tests {
 
     #[test]
     fn entries_latest_subtext_unstable_describes_main_commit() {
-        // The unstable channel's `latest_url` points to a commit on `main`
-        // (and the preview body is a commit message), so the subtext must
-        // describe a commit — not "release notes and changelog" — to match
-        // what users actually see when they activate the row.
+        // The unstable channel's `latest_url` points to the tip commit on
+        // `main`, so the subtext describes a commit on that branch.
         let mut fixture = ok_fixture();
         fixture.channel = "unstable".into();
+        fixture.latest_tag = "main".into();
+        fixture.latest_name = format!("main@{}", short(&fixture.latest_rev));
         let rendered = render_entries_json(&MenuState::Ok(fixture)).unwrap();
         let parsed: Value = serde_json::from_str(&rendered).unwrap();
         let arr = parsed.as_array().unwrap();
-        assert_eq!(arr[1]["Text"], "Latest: v0.8.0");
+        assert_eq!(arr[1]["Text"], "Latest: main");
         assert_eq!(
             arr[1]["Subtext"],
             "Latest commit on main (unstable channel)"
@@ -1662,18 +1726,20 @@ mod tests {
     }
 
     #[test]
-    fn entries_latest_subtext_stable_describes_release_notes() {
-        // The stable channel links to a tagged release page so the subtext
-        // describes release notes. Naming the channel keeps the row
-        // visibly distinct from the unstable variant.
+    fn entries_latest_subtext_stable_describes_release_branch_commit() {
+        // The stable channel tracks the tip of the highest `release/<M>.<m>`
+        // line, so the row links to that tip commit and the subtext names
+        // the branch. Naming the channel keeps the row visibly distinct from
+        // the unstable variant.
         let fixture = ok_fixture();
         assert_eq!(fixture.channel, "stable");
         let rendered = render_entries_json(&MenuState::Ok(fixture)).unwrap();
         let parsed: Value = serde_json::from_str(&rendered).unwrap();
         let arr = parsed.as_array().unwrap();
+        assert_eq!(arr[1]["Text"], "Latest: release/1.0");
         assert_eq!(
             arr[1]["Subtext"],
-            "GitHub release notes and changelog (stable channel)"
+            "Latest commit on release/1.0 (stable channel)"
         );
     }
 
@@ -1684,8 +1750,10 @@ mod tests {
         let parsed: Value = serde_json::from_str(&rendered).unwrap();
         let arr = parsed.as_array().unwrap();
         assert_eq!(arr.len(), 3);
-        assert_eq!(arr[0]["Text"], "Current: v0.7.0");
-        assert_eq!(arr[1]["Text"], "Latest: v0.8.0");
+        // current_tag is empty under branch tracking, so the current row
+        // falls back to the short rev.
+        assert_eq!(arr[0]["Text"], "Current: aaaaaaa");
+        assert_eq!(arr[1]["Text"], "Latest: release/1.0");
         assert_eq!(arr[2]["Text"], "Update current host");
         assert_eq!(arr[2]["Value"], ACT_RUN_UPDATE);
         assert!(
@@ -1693,7 +1761,7 @@ mod tests {
                 .as_str()
                 .unwrap()
                 .starts_with(&format!("{ACT_OPEN_RELEASE}\t")),
-            "latest entry must open the release page on activation"
+            "latest entry must open the release-line commit on activation"
         );
     }
 
@@ -1742,15 +1810,15 @@ mod tests {
         // render_entries_json should drop that entry rather than risk
         // breaking Lua's single-quoted Action.
         let mut fixture = ok_fixture();
-        fixture.latest_url = "https://github.com/owner/repo/releases/tag/v0'8".into();
+        fixture.latest_url = "https://github.com/owner/repo/commit/v0'8".into();
         let state = MenuState::Ok(fixture);
         let rendered = render_entries_json(&state).unwrap();
         let parsed: Value = serde_json::from_str(&rendered).unwrap();
         let arr = parsed.as_array().unwrap();
-        // Current + Update entries remain, but the Latest (release-page)
+        // Current + Update entries remain, but the Latest (commit-link)
         // entry is filtered because the URL failed the safety check.
         assert_eq!(arr.len(), 2);
-        assert_eq!(arr[0]["Text"], "Current: v0.7.0");
+        assert_eq!(arr[0]["Text"], "Current: aaaaaaa");
         assert_eq!(arr[1]["Value"], ACT_RUN_UPDATE);
     }
 
@@ -1778,8 +1846,8 @@ mod tests {
         let rendered = render_preview_summary(&state);
         assert!(rendered.contains("Keystone OS update status"));
         assert!(rendered.contains("Consumer flake: /etc/nixos-config"));
-        assert!(rendered.contains("Current: v0.7.0 (aaaaaaa)"));
-        assert!(rendered.contains("Latest: v0.8.0 (bbbbbbb)"));
+        assert!(rendered.contains("Current: aaaaaaa (aaaaaaa)"));
+        assert!(rendered.contains("Latest: release/1.0 (bbbbbbb)"));
         assert!(rendered.contains("Update command: ks update"));
     }
 
@@ -1797,11 +1865,12 @@ mod tests {
     fn preview_release_notes_renders_body_and_url() {
         let state = MenuState::Ok(ok_fixture());
         let rendered = render_preview_release_notes(&state);
-        assert!(rendered.contains("v0.8.0"));
-        assert!(rendered.contains("Tag: v0.8.0"));
+        assert!(rendered.contains("release/1.0@bbbbbbb"));
+        assert!(rendered.contains("Ref: release/1.0"));
         assert!(rendered.contains("Published: 2026-04-01T10:00:00Z"));
-        assert!(rendered.contains("Added Walker update menu"));
-        assert!(rendered.contains("https://github.com/ncrmro/keystone/releases/tag/v0.8.0"));
+        assert!(rendered.contains("add Walker update menu"));
+        assert!(rendered
+            .contains("https://github.com/ncrmro/keystone/commit/bbbbbbbbccccccccddddddddeeeeeeeeffffffff"));
     }
 
     #[test]
@@ -1815,9 +1884,9 @@ mod tests {
             ..Default::default()
         });
         let rendered = render_preview_release_notes(&state);
-        // Partial render should surface the tag even though the overall state
+        // Partial render should surface the ref even though the overall state
         // is errored out.
-        assert!(rendered.contains("Tag: v0.8.0"));
+        assert!(rendered.contains("Ref: v0.8.0"));
         assert!(rendered.contains("Release notes body"));
         assert!(rendered.contains("https://example/release"));
     }


### PR DESCRIPTION
## What

Switches Keystone's distribution model to **branch tracking, like nixpkgs** — consumers follow a branch and `ks update` follows its head, instead of resolving `vX.Y.Z` release tags. This is what makes a `release/1.0` stable line directly consumable.

Motivation: the `stable` channel resolved GitHub `/releases/latest`, which 404s today because every published release is a prerelease. More fundamentally, a fleet OS is better served by tracking a stabilized branch (fixes backported onto the line) than by a per-update tag-cutting ceremony. See the discussion in #418.

## Changes

**`ks` (`packages/ks/src/cmd/update_menu.rs`)**
- `stable` channel now resolves the highest `release/<M>.<m>` branch (lists `/branches`, picks the numerically-highest line) and reads its tip commit; `unstable` keeps tracking `main`. Both share one branch-tip fetch (`fetch_branch_tip`).
- Removes the tag-only `parse_stable_release` + `fetch_release_commit_rev`. `parse_unstable_branch` becomes a thin wrapper over the generalized `parse_branch_release`.
- Menu/preview rows name the tracked branch for both channels (`Latest commit on release/1.0`, `Ref: release/1.0`).
- `update_approve.rs` needs no change — `resolve_target` already consumes `ReleaseInfo` channel-agnostically (prefers `latest_name`, pins `latest_rev`).
- Adds unit tests for release-branch parsing/sorting (`release/1.0` < `release/1.10` < `release/2.0`) and branch-tip extraction; updates the rendering fixtures to branch-tracking semantics.

**Release workflow (`.github/workflows/release.yml`)**
- Drops the `workflow_dispatch` version input and `vX.Y.Z` tag / GitHub-release creation. Runs on pushes to `main` and `release/*`.
- `release/*` pushes republish a single rolling `latest-iso` starter image (bootstrap artifact only — `ks update` never reads it); `main` is validation-only.

**Docs** — rewrites `docs/releasing.md` around the branch model; updates `docs/specs` (no normative change needed), the M9 milestone FAQ/press-release/README, and `docs/releases/AGENTS.md`. Historical `v0.x` / `v1.0.0-rc.*` tags stay as inert history.

## Verification

- `cargo test` (363 pass, incl. new branch-sort + branch-tip tests), `cargo clippy` clean, `cargo fmt` clean.
- Workflow YAML parses (4 jobs); rolling-ISO publish step shellchecks clean.
- `nix flake check --no-build` module checks pass locally; the `os-evaluation`/`agent-evaluation` IFD checks fail only on garbage-collected store paths that reproduce identically on clean `main` (this branch changes only Rust, a workflow YAML, and markdown — none of which those checks evaluate). CI validates on a fresh store.

Part of #418
Depends on #593 (orphaned-M9 ports) only for ordering; no code overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)