### PR TITLE
fix(ci): build installer ISO on release/* pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,15 +38,16 @@ jobs:
           # branch head. There is no version tag to cut — releasing a fix is
           # just landing it on the release branch.
           #
-          # Always build the starter ISO so main and every release line are
-          # validated against the installer. Only `release/*` pushes publish
-          # the rolling installer ISO; `main` is validation-only.
-          force_iso_build=true
+          # Only `release/*` pushes build and publish the rolling installer
+          # ISO. `main` is validation-only here (its installer is exercised in
+          # the merge queue), so the expensive ISO build is skipped on main.
+          force_iso_build=false
           publish_iso=false
           iso_artifact_name="starter-installer-iso"
           iso_file_name="keystone-starter-installer-${GITHUB_REF_NAME//\//-}-${GITHUB_SHA::12}.iso"
 
           if [[ "${GITHUB_REF_NAME}" == release/* ]]; then
+            force_iso_build=true
             publish_iso=true
             iso_file_name="keystone-starter-installer-${GITHUB_REF_NAME//\//-}.iso"
           fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -170,8 +170,13 @@ jobs:
             echo "shellcheck=true"
           } >> "$GITHUB_OUTPUT"
 
+      # Reusable-workflow calls inherit the caller's event, so a `uses:` call
+      # from the push-triggered Release workflow surfaces here as `push`, not
+      # `workflow_call`. Match both so `inputs.force_iso_build` is actually
+      # honored (otherwise iso_build falls through to its `false` default and
+      # the installer ISO never builds on release/* pushes).
       - name: Use workflow-call policy
-        if: github.event_name == 'workflow_call'
+        if: github.event_name == 'push' || github.event_name == 'workflow_call'
         id: call-policy
         run: |
           {


### PR DESCRIPTION
## Problem

The `release/1.0` Release run completed with `validate / iso-build: skipped`, so `publish-iso` never ran and the rolling `latest-iso` starter image was not published.

Root cause: `validate.yml`'s `call-policy` step — the one that sets `iso_build` from `inputs.force_iso_build` — is gated on `github.event_name == 'workflow_call'`. But a reusable workflow invoked via `uses:` inherits the **caller's** event, so a push-triggered `Release` run surfaces inside `validate.yml` as `push`. None of the three policy steps (`pull_request`/`merge_group`/`workflow_call`) match `push`, so all outputs fall through to defaults — `iso_build=false`. Pre-existing, but exposed now that `publish-iso` depends on the built ISO.

## Fix

- `validate.yml`: `call-policy` fires on `push` as well as `workflow_call`, so `force_iso_build` is honored for Release-triggered runs.
- `release.yml`: scope `force_iso_build` to `release/*` only — `main` is validation-only (its installer is exercised in the merge queue), so the expensive ISO build runs only where it's published.

## Effect

- `release/*` push → eval/ks/scripts/desktop/agents + **iso-build run** → `publish-iso` updates the rolling `latest-iso` release.
- `main` push → validation jobs run, ISO build skipped (unchanged from today's effective behavior).

Part of #418. Needs backport to `release/1.0` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)