### PR TITLE
fix(ci): build installer ISO on release/* pushes (backport #595)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,15 +38,16 @@ jobs:
           # branch head. There is no version tag to cut — releasing a fix is
           # just landing it on the release branch.
           #
-          # Always build the starter ISO so main and every release line are
-          # validated against the installer. Only `release/*` pushes publish
-          # the rolling installer ISO; `main` is validation-only.
-          force_iso_build=true
+          # Only `release/*` pushes build and publish the rolling installer
+          # ISO. `main` is validation-only here (its installer is exercised in
+          # the merge queue), so the expensive ISO build is skipped on main.
+          force_iso_build=false
           publish_iso=false
           iso_artifact_name="starter-installer-iso"
           iso_file_name="keystone-starter-installer-${GITHUB_REF_NAME//\//-}-${GITHUB_SHA::12}.iso"
 
           if [[ "${GITHUB_REF_NAME}" == release/* ]]; then
+            force_iso_build=true
             publish_iso=true
             iso_file_name="keystone-starter-installer-${GITHUB_REF_NAME//\//-}.iso"
           fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -170,8 +170,13 @@ jobs:
             echo "shellcheck=true"
           } >> "$GITHUB_OUTPUT"
 
+      # Reusable-workflow calls inherit the caller's event, so a `uses:` call
+      # from the push-triggered Release workflow surfaces here as `push`, not
+      # `workflow_call`. Match both so `inputs.force_iso_build` is actually
+      # honored (otherwise iso_build falls through to its `false` default and
+      # the installer ISO never builds on release/* pushes).
       - name: Use workflow-call policy
-        if: github.event_name == 'workflow_call'
+        if: github.event_name == 'push' || github.event_name == 'workflow_call'
         id: call-policy
         run: |
           {


### PR DESCRIPTION
Backport of #595 onto the `release/1.0` line.

Without this, `release/1.0` pushes skip `iso-build` (the reusable `validate.yml` only honored `force_iso_build` under a `workflow_call` event that `uses:` calls never surface), so the rolling `latest-iso` starter image is never published for the stable line.

Cherry-pick of b1ce5854 — workflow-only change (`validate.yml` + `release.yml`).

Part of #418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)