### PR TITLE
fix(os): remove obsolete journal-remote listen option

### DIFF
--- a/modules/os/journal-remote.nix
+++ b/modules/os/journal-remote.nix
@@ -135,7 +135,6 @@ in
     (mkIf isServer {
       services.journald.remote = {
         enable = true;
-        listen = "http";
         port = cfg.server.port;
       };
     })


### PR DESCRIPTION
Closes #606

## Summary

Remove the obsolete `services.journald.remote.listen` assignment. Current nixpkgs no longer exposes that option; enabling the remote service and setting its port is sufficient.

## Validation

- `git diff --check`
- the complete `nixosConfigurations.ocean.config.system.build.toplevel` consumer build passed from `ks-config` with this Keystone worktree supplied as the input override
- `nix flake check --no-build` advanced past module evaluation, then stopped on an unrelated invalid pre-existing Nix store path